### PR TITLE
Error during dicts merge is fixed

### DIFF
--- a/convert_config_v1v2.py
+++ b/convert_config_v1v2.py
@@ -21,6 +21,10 @@ def _generate_dict(path, value):
 def _merge_dicts(d1, d2):
     if d1 == d2:
         return d1
+    if d1 == 'undefined':
+        return d2
+    if d2 == 'undefined':
+        return d1
     d1_keys = set(d1.keys())
     d2_keys = set(d2.keys())
     is_same_keys = d2_keys.issubset(d1)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.0.1) stable; urgency=medium
+
+  * Error in config conversion from v1.x is fixed.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 11 Jan 2021 12:20:10 +0300
+
 wb-mqtt-homeui (2.0.0) stable; urgency=medium
 
   * mark as stable


### PR DESCRIPTION
Some widget descriptions in dashboard can contain 'undefined' in topic name. Script will take topic name from root widget description.