### PR TITLE
SVG resizing in dashboard editor is fixed

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -932,3 +932,8 @@ table.table-bordered {
 ul.col-md-2.nav.nav-pills.nav-stacked {
     margin-bottom: 9px;
 }
+
+.svg-edit-result > svg {
+    width: 100%;
+    height: 100%;
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.4.4) stable; urgency=medium
+
+ * SVG resizing in dashboard editor is fixed.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 31 May 2021 11:58:00 +0500
+
 wb-mqtt-homeui (2.4.3) stable; urgency=medium
 
  * Do not show empty options in selects for optional parameters in config editor (json-editor updated to 2.5.3-wb2).


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/homeui/pull/193