### PR TITLE
Allow read binding to SVG text without nested tspan

### DIFF
--- a/app/scripts/components/svgEditor/view/svgView.controller.js
+++ b/app/scripts/components/svgEditor/view/svgView.controller.js
@@ -65,16 +65,21 @@ class SvgViewController {
     }
 
     appendRead(element, param) {
+        var elem = null;
         var tspan = element[0].querySelector('tspan');
         if (tspan !== null) {
+            elem = angular.element(tspan);
+        } else if (element[0].nodeName === 'text') {
+            elem = element;
+        }
+        if (elem !== null) {
             var val = '{{' + param.value + '}}';
-            tspan.innerHTML = val;
+            elem[0].innerHTML = val;
 
-            var $tspan = angular.element(tspan);
-            $tspan.attr('svg-view-element', '');
-            $tspan.attr('ng-cloak', '');
+            elem.attr('svg-view-element', '');
+            elem.attr('ng-cloak', '');
 
-            this.appendChannelData($tspan, param);
+            this.appendChannelData(elem, param);
         }
     }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.5.4) stable; urgency=medium
+
+ * Read bindig to SVG text node without nested tspan node is implemented.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 31 May 2021 14:00:00 +0500
+
 wb-mqtt-homeui (2.5.3) stable; urgency=medium
 
   * Widget id in json editing mode is preserved


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/homeui/pull/202