### PR TITLE
Bugfix/37734 date format

### DIFF
--- a/app/scripts/services/errors.js
+++ b/app/scripts/services/errors.js
@@ -5,7 +5,15 @@ function errorsService($rootScope) {
   'ngInject';
   
   function showError (message, reason) {
-    $rootScope.$broadcast("alert", message + ": " + ((reason && reason.message) || reason), true);
+    if (reason) {
+      message = message + ": "
+      if (reason.message) {
+        message = message + reason.message + (reason.data && (" " + reason.data))
+      } else {
+        message = message + reason
+      }
+    }
+    $rootScope.$broadcast("alert", message, true);
   }
 
   return {

--- a/app/scripts/services/handle-data.js
+++ b/app/scripts/services/handle-data.js
@@ -86,7 +86,7 @@ export default function handleDataService() {
         var ret = date.getFullYear()
             + "-" + this.addZeroToDate(date.getMonth() + 1)
             + "-" + this.addZeroToDate(date.getDate());
-        ret = !withTime? ret : `${ret} ${this.addZeroToDate(date.getHours())}:${this.addZeroToDate(date.getMinutes())}:00`;
+        ret = !withTime? ret : `${ret}T${this.addZeroToDate(date.getHours())}:${this.addZeroToDate(date.getMinutes())}:00`;
         return ret
     };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.5.7) stable; urgency=medium
+
+  * History chart not showing in Safari is fixed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 27 Jul 2021 13:02:29 +0500
+
 wb-mqtt-homeui (2.5.6) stable; urgency=medium
 
   * Values on History page are displayed without trailing zeros in fractional part


### PR DESCRIPTION
Safari не мог распарсить строку с датой, из-за этого не отображались графики в истории.