### PR TITLE
Bugfix/37982 widget names in charts

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -43,6 +43,7 @@ import uiConfigService from './services/uiconfig';
 import hiliteService from './services/hilite';
 import userAgentFactory from './services/userAgent.factory';
 import rolesFactory from './services/roles.factory';
+import historyUrlService from './services/historyUrl';
 
 import handleDataService from './services/handle-data';
 
@@ -146,6 +147,7 @@ module
     .service('handleData', handleDataService)
     .service('userAgentFactory', userAgentFactory)
     .service('rolesFactory', rolesFactory)
+    .service('historyUrlService', historyUrlService)
 
 
     .run(DeviceData => {

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -435,13 +435,10 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     })
   //...........................................................................
     .state('history.sample', {
-      url: '/{device}/{control}/{start}/{end}',
+      url: '/{data}',
       templateUrl: historyTemplateUrl,
       controller: 'HistoryCtrl as $ctrl',
       resolve: {
-          /*load: ['$ocLazyLoad', function($ocLazyLoad) {
-              return $ocLazyLoad.load(['plotly','historyController'])
-          }],*/
         ctrl: ($q, $ocLazyLoad) => {
             'ngInject';
             let deferred_1 = $q.defer();

--- a/app/scripts/controllers/devicesController.js
+++ b/app/scripts/controllers/devicesController.js
@@ -1,6 +1,6 @@
 
 class DevicesCtrl {
-    constructor($scope, $state, $injector, DeviceData, handleData, rolesFactory) {
+    constructor($scope, $state, $injector, DeviceData, handleData, rolesFactory, historyUrlService) {
         'ngInject';
 
         this.haveRights = rolesFactory.checkRights(rolesFactory.ROLE_TWO);
@@ -9,6 +9,7 @@ class DevicesCtrl {
         this.$state = $state;
         this.handleData = handleData;
         this.DeviceData = DeviceData;
+        this.historyUrlService = historyUrlService;
 
         // will create object to keep devices open/close condition 
         // in localeStorage, if it's not there.
@@ -189,7 +190,7 @@ class DevicesCtrl {
 
     redirect(contr) {
         var [device,control] = contr.split('/');
-        this.$state.go('history.sample', {device, control, start: '-', end: '-'})
+        this.$state.go('history.sample', { data: this.historyUrlService.encodeControl(device, control) })
     }
 }
 

--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -149,9 +149,9 @@ class HistoryCtrl {
 
         // контролы из урла, массив объектов ControlFromUrl
         var controlsFromUrl = [];
-        if($stateParams.device && $stateParams.control) {
+        if($stateParams.device) {
             const parsedDevices = $stateParams.device.split(';');
-            const parsedControls = $stateParams.control.split(';');
+            const parsedControls = $stateParams.control ? $stateParams.control.split(';') : [""];
             // только если количество параметров сходится
             if(parsedDevices.length === parsedControls.length) {
                 for (var i = 0; i < parsedDevices.length; i++) {

--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -1,4 +1,47 @@
+class ChartTraits {
+    constructor(name) {
+        this.channelName = name;
+        this.progress = {
+            value: 0,
+            isLoaded: false
+        };
+        this.stringValues = undefined;
+        this.hasErrors = true;
+        this.isBoolean = false;
+        this.xValues = [];
+        this.yValues = [];
+        this.text = [];
+        this.maxErrors = [];
+        this.minErrors = [];
+    }
+}
 
+class ChartColors {
+    constructor() {
+        this.colors = [
+            { chartColor: 'rgb(31,119,180)',  minMaxColor: 'rgba(31,119,180,0.2)' },
+            { chartColor: 'rgb(255,127,14)',  minMaxColor: 'rgba(255,127,14,0.2)' },
+            { chartColor: 'rgb(44,160,44)',   minMaxColor: 'rgba(44,160,44,0.2)'  },
+            { chartColor: 'rgb(214,39,40)',   minMaxColor: 'rgba(214,39,40,0.2)'  },
+            { chartColor: 'rgb(148,103,189)', minMaxColor: 'rgba(148,103,189,0.2)'},
+            { chartColor: 'rgb(140,86,75)',   minMaxColor: 'rgba(140,86,75,0.2)'  },
+            { chartColor: 'rgb(227,119,194)', minMaxColor: 'rgba(227,119,194,0.2)'},
+            { chartColor: 'rgb(127,127,127)', minMaxColor: 'rgba(127,127,127,0.2)'},
+            { chartColor: 'rgb(188,189,34)',  minMaxColor: 'rgba(188,189,34,0.2)' },
+            { chartColor: 'rgb(23,190,207)',  minMaxColor: 'rgba(23,190,207,0.2)' },
+        ];
+        this.index = 0;
+    }
+
+    nextColor() {
+        var color = this.colors[this.index];
+        this.index = this.index + 1;
+        if (this.index >= this.colors.length) {
+            this.index = 0;
+        }
+        return color;
+    }
+}
 
 class HistoryCtrl {
     //...........................................................................
@@ -47,10 +90,9 @@ class HistoryCtrl {
         //     control: ...
         // } 
         this.controlsFromUrl = [];
-        this.channelShortNames = [];
-        this.channelNames = [];
-        this.stringValues = [];
-        this.progreses = [];
+        
+        // Array of ChartTraits
+        this.charts = [];
         this.progresMax = 100;
         this.layoutConfig = {
             xaxis: {
@@ -74,6 +116,8 @@ class HistoryCtrl {
             displayModeBar: true
         }
 
+        this.colors = new ChartColors();
+
         // ищу в урле контролы
         if($stateParams.device && $stateParams.control) {
             const parsedDevices = $stateParams.device.split(';');
@@ -83,8 +127,6 @@ class HistoryCtrl {
                 this.controlsFromUrl = []
                 for (var i = 0; i < parsedDevices.length; i++) {
                     this.topics.push("/devices/" + parsedDevices[i] + "/controls/" + parsedControls[i]);
-                    // инициализирую все прогрес бары
-                    this.progreses[i] = {value: 0, isLoaded: false};
                     this.controlsFromUrl[i] = {device: parsedDevices[i], control: parsedControls[i]}
                 }
             }
@@ -93,10 +135,15 @@ class HistoryCtrl {
         this.topics = this.topics.length? this.topics : [null];
         this.selectedTopics = this.topics;
 
+        // ui is ready for interaction with user, all data is loaded
         this.ready = false;
+
+        // Wait for data loading for charts
         this.loadPending = !!this.topics.length;
         this.originalUrl = this.getUrl();
-        
+
+        this.dataPointsMultiple = []
+
         // 4. Setup
         var controlsAreLoaded = $q.defer();
         uiConfig.whenReady().then((data) => {
@@ -110,12 +157,20 @@ class HistoryCtrl {
           ]).then(() => {
             vm.ready = true;
             if (vm.loadPending) {
+                vm.charts = vm.controlsFromUrl.map(control => {
+                    var chart = new ChartTraits(control.device + "/" + control.control);
+                    var cn = vm.controls.find(element => ((element.deviceControl === chart.channelName)));
+                    if (cn && (cn.valueType === "boolean")) {
+                        chart.isBoolean = true;
+                    }
+                    return chart;
+                })
                 vm.beforeLoadChunkedHistory();
             }
         });
 
         this.plotlyEvents = (graph) => {
-            // !!!!! метод обязтельно должен быть в конструкторе иначе контекст будет непонятно чей
+            // !!!!! метод обязательно должен быть в конструкторе иначе контекст будет непонятно чей
             graph.on('plotly_relayout', (event) => {
                 if(event['xaxis.range[0]']) {
                     this.timeChange();
@@ -189,12 +244,17 @@ class HistoryCtrl {
         this.timeChanged = true;
     };
 
+    getStateDescription() {
+        return {
+            device:  this.controlsFromUrl.filter(el => el).map(el => { return el.device  }).join(';'),
+            control: this.controlsFromUrl.filter(el => el).map(el => { return el.control }).join(';'),
+            start:   this.selectedStartDate ? this.selectedStartDate.getTime() + this.addHoursAndMinutes(this.selectedStartDateMinute) : "-",
+            end:     this.selectedEndDate ? this.selectedEndDate.getTime() + this.addHoursAndMinutes(this.selectedEndDateMinute) : "-"
+        }
+    }
+
     updateState() {
-        var device  = this.controlsFromUrl.map(el => { return el.device  }).join(';');
-        var control = this.controlsFromUrl.map(el => { return el.control }).join(';');
-        var st = this.selectedStartDate ? this.selectedStartDate.getTime() + this.addHoursAndMinutes(this.selectedStartDateMinute) : "-";
-        var en = this.selectedEndDate ? this.selectedEndDate.getTime() + this.addHoursAndMinutes(this.selectedEndDateMinute) : "-";
-        this.$state.go('history.sample', { device, control, start: st, end: en}, { reload: true, inherit: false, notify: true });
+        this.$state.go('history.sample', this.getStateDescription(), { reload: true, inherit: false, notify: true });
     }
 
     // смена урла
@@ -229,7 +289,9 @@ class HistoryCtrl {
         // из-за остановки и возможного возобновления загрузки графика ввожу доп проверку
         // изменился ли урл или нет
         if(this.originalUrl === url || location.href.indexOf(url)>=0) {
-            this.updateState();
+            if (!deleteOne) {
+                this.updateState();
+            }
         } else {
             this.location.path(url);
         }
@@ -246,13 +308,8 @@ class HistoryCtrl {
     }
 
     getUrl() {
-        return [
-            "/history",
-            this.controlsFromUrl.map(el => { return el.device  }).join(';'),
-            this.controlsFromUrl.map(el => { return el.control }).join(';'),
-            this.selectedStartDate ? this.selectedStartDate.getTime() + this.addHoursAndMinutes(this.selectedStartDateMinute) : "-",
-            this.selectedEndDate ? this.selectedEndDate.getTime() + this.addHoursAndMinutes(this.selectedEndDateMinute) : "-"
-        ].join("/")
+        const st = this.getStateDescription();
+        return ["/history", st.device, st.control, st.start, st.end].join("/");
     }
 
     resetTime() {
@@ -365,17 +422,10 @@ class HistoryCtrl {
     } // parseTopic
 
     beforeLoadChunkedHistory(indexOfControl=0) {
-        if (!this.ready) {
-            this.loadPending = true;
-            return
-        }
-        this.loadPending = false;
         if (!this.topics[indexOfControl]) {
-            // если это последний контрол + 1 то надо
-            // и посчитать таблицу данных внизу страницы
-            if (this.topics[indexOfControl-1]) {
-                this.calculateTable();
-            } else  return
+            this.loadPending = false;
+            this.calculateTable();
+            return
         }
         var chunks = this.handleData.splitDate(this.startDate,this.endDate,this.CHUNK_INTERVAL+1);
         this.chunksN = chunks.length - 1;
@@ -385,8 +435,8 @@ class HistoryCtrl {
     calculateTable() {
         //TODO: use merge sort as we have here n^2 complexity
         var objX = {},graph = [];
-        this.chartConfig.forEach((ctrl,i) => {
-            ctrl.x.forEach(x=> {
+        this.charts.forEach((ctrl,i) => {
+            ctrl.xValues.forEach(x=> {
                 objX[x] = null
             })
         });
@@ -396,17 +446,17 @@ class HistoryCtrl {
         _arrX.forEach(date=> {
             graph.push({
                 date,
-                value: Array(this.chartConfig.length).fill(null)
+                value: Array(this.charts.length).fill(null)
             });
             // ищу совпадения в каждом канале
-            this.chartConfig.forEach((ctrl,iCtrl)=> {
-                for (var i = 0; i < ctrl.x.length; i++) {
+            this.charts.forEach((ctrl,iCtrl)=> {
+                for (var i = 0; i < ctrl.xValues.length; i++) {
                     // если не нахожу то останется null
-                    if(date === ctrl.x[i]) {
-                        if (this.stringValues[iCtrl]) {
+                    if(date === ctrl.xValues[i]) {
+                        if (this.charts[iCtrl].stringValues) {
                             graph[graph.length-1].value[iCtrl] = ctrl.text[i];
                         } else {
-                            graph[graph.length-1].value[iCtrl] = ctrl.y[i];
+                            graph[graph.length-1].value[iCtrl] = ctrl.yValues[i];
                         }
                         break
                     }
@@ -459,123 +509,96 @@ class HistoryCtrl {
         return ar.values.some(item => item.v != parseFloat(item.v))
     }
 
+    createMainChart(chart, lineColor) {
+        return {
+            name: chart.channelName,
+            x: chart.xValues,
+            y: chart.yValues,
+            text: chart.text,
+            type: 'scatter',
+            mode: 'lines',
+            line: {
+                shape: (chart.stringValues || chart.isBoolean ? 'hv' : 'linear'),
+                color: lineColor
+            },
+            hovertemplate: '%{text}<extra></extra>'
+        };
+    }
+
+    createErrorChart(chart, fillColor) {
+        return {//https://plotly.com/javascript/continuous-error-bars/
+            name: "min/max "+ chart.channelName,
+            x: [...chart.xValues, ...[...chart.xValues].reverse()],
+            y: [...chart.maxErrors, ...[...chart.minErrors].reverse()],
+            type: "scatter",
+            fill: "toself", 
+            fillcolor: fillColor, 
+            line: {color: "transparent"},
+            hoverinfo: "none"
+        };
+    }
+
+    processDbRecord(record, chart) {
+        var ts = new Date();
+        ts.setTime(record.t * 1000);
+        chart.xValues.push(this.dateFilter(ts, "yyyy-MM-dd HH:mm:ss"));
+        if (chart.stringValues) {
+            chart.text.push(record.v);
+            if (!chart.stringValues.has(record.v)) {
+                chart.stringValues.set(record.v, chart.stringValues.size + 1)
+            }
+            chart.yValues.push(chart.stringValues.get(record.v));
+        } else {
+            if (record.min) {
+                chart.text.push(record.v + " [" + record.min + ", " + record.max + "]");
+            } else {
+                chart.text.push(record.v);
+            }
+            chart.yValues.push(record.v);
+            chart.maxErrors.push(record.max ? record.max : record.v);
+            chart.minErrors.push(record.min ? record.min : record.v);
+        }
+    }
+
+    processChunk(chunk, indexOfControl, indexOfChunk, chunks) {
+        var chart = this.charts[indexOfControl];
+        chart.progress.value = indexOfChunk + 1;
+
+        if (chunk.has_more) this.errors.showError("Warning", "maximum number of points exceeded. Please select start date.");
+
+        if (indexOfChunk==0 && this.hasStringValues(chunk)) {
+            chart.stringValues = new Map();
+            chart.hasErrors = false;
+        }
+
+        chunk.values.forEach(item => this.processDbRecord(item, chart));
+
+        // если еще есть части интервала
+        if (indexOfChunk + 2 < chunks.length) {
+            this.loadChunkedHistory(indexOfControl,indexOfChunk + 1,chunks);
+        // запрашиваю следущий контол если есть
+        } else {
+            if (chart.xValues.length) {
+                var colors = this.colors.nextColor();
+                this.chartConfig.push(this.createMainChart(chart, colors.chartColor));
+                if (chart.hasErrors) {
+                    this.chartConfig.push(this.createErrorChart(chart, colors.minMaxColor));
+                }
+            }
+            chart.progress.isLoaded = true;
+            this.beforeLoadChunkedHistory(indexOfControl + 1);
+        }
+    }
+
     loadHistory(params,indexOfControl,indexOfChunk,chunks) {
-        if(this.stopLoadData) return;
-        this.channelShortNames[indexOfControl] = params.channels[0][1];
-        this.channelNames[indexOfControl] = params.channels[0][0] + ' / ' + params.channels[0][1];
-        this.pend = true;
-
-        this.HistoryProxy.get_values(params).then(result => {
-
-            this.progreses[indexOfControl].value = indexOfChunk + 1;
-            if(indexOfChunk === chunks.length - 2) {
-                this.$timeout( () => {this.progreses[indexOfControl].isLoaded = true}, 500)
-            }
-            
-            this.pend = false;
-
-            if (result.has_more) this.errors.showError("Warning", "maximum number of points exceeded. Please select start date.");
-
-            this.xValues = result.values.map(item => {
-                var ts = new Date();
-                ts.setTime(item.t * 1000);
-                return this.dateFilter(ts, "yyyy-MM-dd HH:mm:ss");
-            });
-
-            if(indexOfChunk==0 && this.hasStringValues(result)) {
-                this.stringValues[indexOfControl] = new Map();
-            }
-
-            this.text = []
-            var minValuesErr = []
-            var maxValuesErr = []
-            if (this.stringValues[indexOfControl]) {
-                this.yValues = result.values.map((item) => {
-                    this.text.push(item.v);
-                    if (!this.stringValues[indexOfControl].has(item.v)) {
-                        this.stringValues[indexOfControl].set(item.v, this.stringValues[indexOfControl].size + 1)
-                    }
-                    return this.stringValues[indexOfControl].get(item.v);
-                });
-            } else {
-                this.yValues = result.values.map(item => item.v);
-                // изза особенности графика типа "ОШИБКИ" отображать экстремумы надо
-                // высчитывая отклонение от основных значений
-                minValuesErr = result.values.map(item => item.min && item.v? (item.v-item.min).toFixed(6) : null);
-                maxValuesErr = result.values.map(item => item.max && item.v? (item.max-item.v).toFixed(6) : null);
-            }
-
-            // если это первый чанк то создаю график
-            if(indexOfChunk==0) {
-                var nameCn = params.channels[0][0] + '/' + params.channels[0][1];
-                var cn = this.controls.find(element => ((element.deviceControl === nameCn) && (element.valueType === "boolean")));
-                var shapeMode = 'linear';
-                if (cn != undefined || this.stringValues[indexOfControl]) {
-                    shapeMode = 'hv';
-                }
-                this.chartConfig[indexOfControl] = {//https://plot.ly/javascript/error-bars/
-                    name: nameCn,
-                    x: this.xValues,
-                    y: this.yValues,
-                    text: this.text,
-                    error_y: {//построит график  типа "ОШИБКИ"(error-bars)
-                        type: 'data',
-                        symmetric: false,
-                        array: maxValuesErr,
-                        arrayminus: minValuesErr,
-                        // styling error-bars https://plot.ly/javascript/error-bars/#colored-and-styled-error-bars
-                        thickness: 0.5,
-                        width: 0,
-                        value: 0.1,
-                        opacity: 0.5
-                    },
-                    type: 'scatter',
-                    mode: 'lines',
-                    line: {shape: shapeMode}
-                }
-                if (!this.stringValues[indexOfControl]) {
-                    this.chartConfig[indexOfControl].hovertemplate = '%{y:} ∆ +%{error_y.array:}/-%{error_y.arrayminus:}<extra></extra>'
-                } else {
-                    this.chartConfig[indexOfControl].hovertemplate = '%{text}<extra></extra>'
-                }
-            } else {
-                // если последущие то просто добавляю дату
-                this.chartConfig[indexOfControl].x = this.chartConfig[indexOfControl].x.concat(this.xValues);
-                this.chartConfig[indexOfControl].y = this.chartConfig[indexOfControl].y.concat(this.yValues);
-                this.chartConfig[indexOfControl].text = this.chartConfig[indexOfControl].text.concat(this.text);
-                this.chartConfig[indexOfControl].error_y.array = this.chartConfig[indexOfControl].error_y.array.concat(maxValuesErr);
-                this.chartConfig[indexOfControl].error_y.arrayminus = this.chartConfig[indexOfControl].error_y.arrayminus.concat(minValuesErr);
-            }
-
-            if(indexOfControl==0) {
-                this.firstChunkIsLoaded = true;
-            }
-
-            if(this.topics.length === 1) {
-                // проверить есть ли точки в контроллах
-                // ниже point.y == 0 специально выставлено не жесткое сравнение / не менять!!!
-                this.hasPoints = this.chartConfig[indexOfControl].y.some(y => {
-                  return  !!y || y == 0
-                } )
-                
-            } else {
-                this.dataPointsArr = [];
-                this.chartConfig.forEach((ctrl,i) => {
-                    this.dataPointsArr[i] = ctrl.y.some(point =>  !!point);
-                });
-                this.hasPoints = this.dataPointsArr.some(boolin => boolin);
-            }
-
-
-            // если еще есть части интервала
-            if(indexOfChunk + 2 < chunks.length) {
-                this.loadChunkedHistory(indexOfControl,indexOfChunk + 1,chunks);
-            // запрашиваю следущий контол если есть
-            } else if(indexOfControl < this.selectedTopics.length){
-                 this.beforeLoadChunkedHistory(indexOfControl + 1);
-            }
-        }).catch(this.errors.catch("Error getting history"));
-    } // loadHistory
+        if(this.stopLoadData) {
+            this.loadPending = false;
+            return;
+        }
+        this.HistoryProxy.get_values(params)
+                         .then(result => this.processChunk(result, indexOfControl, indexOfChunk, chunks))
+                         .catch(this.errors.catch("Error getting history"));
+    }
 
     downloadHistoryTable() {
       const rows = document.querySelectorAll("#history-table tr");

--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -301,7 +301,7 @@ class HistoryCtrl {
         this.selectedControls.push(null)
     }
 
-    deleteTopic(i) {
+    deleteTopic(index) {
         this.selectedControls.splice(index, 1)
     }
 

--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -213,22 +213,26 @@ class HistoryCtrl {
     //...........................................................................
     updateControls(widgets, DeviceData) {
         this.controls = this.orderByFilter(
-            widgets.map(widget =>
-                widget.cells.map(item => {
-                    const cell = DeviceData.cell(item.id);
-                    const device = DeviceData.devices[cell.deviceId];
-                    return new ChartsControl(cell, "Каналы из виджетов: ", device.name, widget.name);
-                })
-            ),
-            "name");
-        this.controls.push(...Object.keys(DeviceData.devices).sort().map(deviceId => {
+            Array.prototype.concat.apply(
+                [], 
+                widgets.map(widget =>
+                    widget.cells.map(item => {
+                        const cell = DeviceData.cell(item.id);
+                        const device = DeviceData.devices[cell.deviceId];
+                        return new ChartsControl(cell, "Каналы из виджетов: ", device.name, widget.name);
+                    })
+                ),
+            "name"));
+        this.controls.push(...Array.prototype.concat.apply(
+            [],
+            Object.keys(DeviceData.devices).sort().map(deviceId => {
                 const device = DeviceData.devices[deviceId];
                 return device.cellIds.map(cellId => {
                     const cell = DeviceData.cell(cellId);
                     return new ChartsControl(cell, "Все каналы: ", device.name);
                 });
             })
-        );
+        ));
     }
 
     setSelectedControlsAndStartLoading(controlsFromUrl) {

--- a/app/scripts/controllers/widgetsController.js
+++ b/app/scripts/controllers/widgetsController.js
@@ -1,5 +1,5 @@
 class WidgetsCtrl {
-  constructor($scope, uiConfig, DeviceData, handleData, rolesFactory) {
+  constructor($scope, $state, uiConfig, DeviceData, handleData, rolesFactory, historyUrlService) {
     'ngInject';
 
     
@@ -23,8 +23,11 @@ class WidgetsCtrl {
     }
     
     $scope.roles = rolesFactory;
-    $scope.historyStartTS = () => this.handleData.historyStartTS();
     $scope.rows = [];
+    $scope.goToHistory = (cell) => {
+      const data = historyUrlService.encodeControl(cell.device, cell.control, handleData.historyStartTS());
+      $state.go('history.sample', { data })
+    }
     $scope.$watch(uiConfig.version, () => {
       var dashboardMap = Object.create(null);
       var dashboards = uiConfig.data.dashboards;

--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -4,7 +4,7 @@ function displayCellDirective(displayCellConfig, $compile) {
   'ngInject';
 
   class DisplayCellController {
-    constructor ($scope, $state, $element, $attrs, handleData) {
+    constructor ($scope, $state, $element, $attrs, handleData, historyUrlService) {
       'ngInject';
       //this.$scope = $scope;
       this.cell = $scope.cell;
@@ -13,6 +13,7 @@ function displayCellDirective(displayCellConfig, $compile) {
       //console.log("+++++++++this.cell",this.cell);
 
       this.handleData = handleData;
+      this.historyUrlService = historyUrlService;
     }
 
     /*copy() {
@@ -35,7 +36,7 @@ function displayCellDirective(displayCellConfig, $compile) {
 
     redirect(contr) {
       var [device,control] = contr.split('/');
-      this.$state.go('history.sample', {device, control, start: '-', end: '-'})
+      this.$state.go('history.sample', { data: this.historyUrlService.encodeControl(device, control) })
     }
   }
 

--- a/app/scripts/services/historyUrl.js
+++ b/app/scripts/services/historyUrl.js
@@ -1,0 +1,54 @@
+import LZString from "lz-string"
+
+function historyUrlService() {
+
+    //   controls = [
+    //     {
+    //       d: deviceId
+    //       c: controlId
+    //       w: widgetId
+    //     },
+    //     ...
+    //   ]
+    this.encodeControls = function (controls, startDate, endDate) {
+      const data = {
+        c: controls,
+        s: startDate,
+        e: endDate
+      };
+      return LZString.compressToEncodedURIComponent(JSON.stringify(data))
+    };
+
+    this.encodeControl = function (deviceId, controlId, startDate, endDate) {
+      return this.encodeControls([{d: deviceId, c: controlId}], startDate, endDate);
+    };
+
+    // Returns
+    // {
+    //   c: [
+    //     {
+    //       d: deviceId
+    //       c: controlId
+    //       w: widgetId
+    //     },
+    //     ...
+    //   ],
+    //   s: Date // Start date
+    //   e: Date // End date
+    // }
+    this.decode = function (data) {
+      try {
+        var res = JSON.parse(LZString.decompressFromEncodedURIComponent(data));
+        if (res.s) {
+          res.s = new Date(res.s);
+        }
+        if (res.e) {
+          res.e = new Date(res.e);
+        }
+        return res;
+      } catch (reason) {}
+      return {};
+    };
+}
+
+export default historyUrlService;

--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -121,7 +121,7 @@ div[uib-datepicker-popup-wrap] {
     margin-top: 7px;
 }
 
-@media (max-width: 996px){
+@media (max-width: 991px){
     .history-page .progress {
         height: 4px;
         margin-bottom: 1px;

--- a/app/views/history.html
+++ b/app/views/history.html
@@ -4,34 +4,33 @@
         History
     </h1>
 
-    <div class="row" ng-repeat="sel in $ctrl.selectedTopics track by $index">
+    <div class="row" ng-repeat="sel in $ctrl.selectedControls track by $index">
         <div class="col-xs-8 col-md-5">
             <select id="control-select"
                     class="form-control"
                     ng-disabled="$ctrl.loadPending || !$ctrl.ready"
-                    ng-change="$ctrl.updateUrl($index)"
-                    ng-model="$ctrl.selectedTopics[$index]"
-                    ng-options="control.topic as control.name group by control.group for control in $ctrl.controls">
+                    ng-model="$ctrl.selectedControls[$index]"
+                    ng-options="control as control.name group by control.group for control in $ctrl.controls track by control.name">
                 <option value="">- Please Choose -</option>
             </select>
         </div>
-        <div class="col-xs-4 col-md-3">
+        <div class="col-xs-4 col-md-2">
             <div>
-                <div ng-hide="($index==0 && $ctrl.selectedTopics.length==1) || !$ctrl.selectedTopics[1]"
+                <div ng-hide="($index==0 && $ctrl.selectedControls.length==1) || !$ctrl.selectedControls[1]"
                      ng-disabled="$ctrl.loadPending || !$ctrl.ready"
                      class="btn btn-danger" ng-click="$ctrl.deleteTopic($index)">delete
                 </div>
             </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-4" ng-if="$ctrl.chunksN>1">
-            <uib-progressbar ng-if="$ctrl.selectedTopics[$index] && !$ctrl.charts[$index].progress.isLoaded && $ctrl.loadPending"
+        <div class="col-xs-12 col-md-5" ng-if="$ctrl.chunksN>1">
+            <uib-progressbar ng-if="$ctrl.selectedControls[$index] && !$ctrl.charts[$index].progress.isLoaded && $ctrl.loadPending"
                              value="$ctrl.charts[$index].progress.value"
                              min="0" max="::$ctrl.chunksN">
                 <div>{{$ctrl.charts[$index].progress.value}}/{{::$ctrl.chunksN}}</div>
             </uib-progressbar>
         </div>
     </div>
-    <div ng-hide="$ctrl.selectedTopics.length==1 && !$ctrl.selectedTopics[$ctrl.selectedTopics.length-1]">
+    <div ng-hide="$ctrl.selectedControls.length==1 && !$ctrl.selectedControls[$ctrl.selectedControls.length-1]">
         <br>
         <button class="btn btn-success" ng-click="$ctrl.addTopic()" ng-disabled="$ctrl.loadPending || !$ctrl.ready">
             Add channel
@@ -41,7 +40,7 @@
 
     <div class="row">
         <div class="col-md-6 col-lg-5">
-            <div class="row" ng-show="$ctrl.topics.length">
+            <div class="row">
                 <div class="col-xs-1 col-md-1 history-time-col-l">
                     <label for="history-start">Start</label>
                 </div>
@@ -78,7 +77,7 @@
         </div>
 
         <div class="col-md-6 col-lg-5">
-            <div class="row" ng-show="$ctrl.topics.length">
+            <div class="row">
                 <div class="col-xs-1 col-md-1 history-time-col-l">
                     <label for="history-end">End</label>
                 </div>
@@ -116,12 +115,12 @@
     </div>
 
     <button class="btn btn-success"
-            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0] || $ctrl.loadPending || !$ctrl.ready"
+            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedControls[0] || $ctrl.loadPending || !$ctrl.ready"
             ng-click="$ctrl.updateDateRange()">
         Load data
     </button>
     <button class="btn btn-success"
-            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0] || $ctrl.loadPending || !$ctrl.ready"
+            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedControls[0] || $ctrl.loadPending || !$ctrl.ready"
             ng-click="$ctrl.readDatesFromUrl()">
         Reset
     </button>
@@ -166,7 +165,7 @@
             <thead>
             <tr>
                 <th>Date and time</th>
-                <th ng-repeat="channel in $ctrl.charts">{{channel.channelName}}</th>
+                <th ng-repeat="channel in $ctrl.charts">{{channel.name}}</th>
             </tr>
             </thead>
             <tbody>

--- a/app/views/history.html
+++ b/app/views/history.html
@@ -165,7 +165,7 @@
             <thead>
             <tr>
                 <th>Date and time</th>
-                <th ng-repeat="channel in $ctrl.charts">{{channel.name}}</th>
+                <th ng-repeat="channel in $ctrl.charts">{{channel.channelName}}</th>
             </tr>
             </thead>
             <tbody>

--- a/app/views/history.html
+++ b/app/views/history.html
@@ -8,7 +8,7 @@
         <div class="col-xs-8 col-md-5">
             <select id="control-select"
                     class="form-control"
-                    ng-disabled="$ctrl.pend"
+                    ng-disabled="$ctrl.loadPending || !$ctrl.ready"
                     ng-change="$ctrl.updateUrl($index)"
                     ng-model="$ctrl.selectedTopics[$index]"
                     ng-options="control.topic as control.name group by control.group for control in $ctrl.controls">
@@ -18,21 +18,22 @@
         <div class="col-xs-4 col-md-3">
             <div>
                 <div ng-hide="($index==0 && $ctrl.selectedTopics.length==1) || !$ctrl.selectedTopics[1]"
+                     ng-disabled="$ctrl.loadPending || !$ctrl.ready"
                      class="btn btn-danger" ng-click="$ctrl.deleteTopic($index)">delete
                 </div>
             </div>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-4" ng-if="$ctrl.chunksN>1">
-            <uib-progressbar ng-if="$ctrl.selectedTopics[$index] && !$ctrl.progreses[$index].isLoaded"
-                             value="$ctrl.progreses[$index].value"
+            <uib-progressbar ng-if="$ctrl.selectedTopics[$index] && !$ctrl.charts[$index].progress.isLoaded && $ctrl.loadPending"
+                             value="$ctrl.charts[$index].progress.value"
                              min="0" max="::$ctrl.chunksN">
-                <div>{{$ctrl.progreses[$index].value}}/{{::$ctrl.chunksN}}</div>
+                <div>{{$ctrl.charts[$index].progress.value}}/{{::$ctrl.chunksN}}</div>
             </uib-progressbar>
         </div>
     </div>
     <div ng-hide="$ctrl.selectedTopics.length==1 && !$ctrl.selectedTopics[$ctrl.selectedTopics.length-1]">
         <br>
-        <button class="btn btn-success" ng-click="$ctrl.addTopic()">
+        <button class="btn btn-success" ng-click="$ctrl.addTopic()" ng-disabled="$ctrl.loadPending || !$ctrl.ready">
             Add channel
         </button>
         <br>
@@ -52,11 +53,16 @@
                                uib-datepicker-popup="{{format}}"
                                ng-change="$ctrl.timeChange('start')"
                                ng-model="$ctrl.selectedStartDate"
+                               ng-disabled="$ctrl.loadPending || !$ctrl.ready"
                                is-open="$ctrl.popups.start"
                                close-text="Close"/>
                           <span class="input-group-btn">
-                            <button type="button" class="btn btn-default" ng-click="$ctrl.popups.start = true"><i
-                                    class="glyphicon glyphicon-calendar"></i></button>
+                            <button type="button"
+                                    class="btn btn-default"
+                                    ng-click="$ctrl.popups.start = true"
+                                    ng-disabled="$ctrl.loadPending || !$ctrl.ready">
+                                <i class="glyphicon glyphicon-calendar"></i>
+                            </button>
                           </span>
                     </div>
                 </div>
@@ -64,6 +70,7 @@
                     <div uib-timepicker
                          ng-model="$ctrl.selectedStartDateMinute"
                          ng-change="$ctrl.timeChange('start')"
+                         ng-disabled="$ctrl.loadPending || !$ctrl.ready"
                          minute-step="5" hour-step="1"
                          show-meridian="false"></div>
                 </div>
@@ -83,11 +90,16 @@
                                uib-datepicker-popup="{{format}}"
                                ng-change="$ctrl.timeChange('end')"
                                ng-model="$ctrl.selectedEndDate"
+                               ng-disabled="$ctrl.loadPending || !$ctrl.ready"
                                is-open="$ctrl.popups.end"
                                close-text="Close"/>
                           <span class="input-group-btn">
-                            <button type="button" class="btn btn-default" ng-click="$ctrl.popups.end = true"><i
-                                    class="glyphicon glyphicon-calendar"></i></button>
+                            <button type="button"
+                                    class="btn btn-default"
+                                    ng-click="$ctrl.popups.end = true"
+                                    ng-disabled="$ctrl.loadPending || !$ctrl.ready">
+                                <i class="glyphicon glyphicon-calendar"></i>
+                            </button>
                           </span>
                     </div>
                 </div>
@@ -96,44 +108,45 @@
                          ng-model="$ctrl.selectedEndDateMinute"
                          ng-change="$ctrl.timeChange('end')"
                          minute-step="5" hour-step="1"
-                         show-meridian="false"></div>
+                         show-meridian="false"
+                         ng-disabled="$ctrl.loadPending || !$ctrl.ready"></div>
                 </div>
             </div>
         </div>
     </div>
 
     <button class="btn btn-success"
-            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0]"
+            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0] || $ctrl.loadPending || !$ctrl.ready"
             ng-click="$ctrl.updateDateRange()">
         Load data
     </button>
     <button class="btn btn-success"
-            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0]"
+            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0] || $ctrl.loadPending || !$ctrl.ready"
             ng-click="$ctrl.readDatesFromUrl()">
         Reset
     </button>
     <button class="btn btn-success"
-            ng-disabled="!$ctrl.pend"
+            ng-disabled="!$ctrl.loadPending || !$ctrl.ready"
             ng-click="$ctrl.stopLoadingData()">
         Stop loading
     </button>
     <br><br>
 
     <div class="col-sm-12 spinner" ng-cloak ng-if="!$ctrl.stopLoadData"
-         ng-show="$ctrl.pend || (!$ctrl.firstChunkIsLoaded && !$ctrl.selectedTopics.length)">
+         ng-show="$ctrl.loadPending || !$ctrl.ready">
         <span class="spinner-loader">Loading...</span>
     </div>
 
     <div>
-        <div class="col-sm-12" ng-if="$ctrl.firstChunkIsLoaded">
+        <div class="col-sm-12">
             <plotly plotly-events="$ctrl.plotlyEvents"
                     plotly-data="$ctrl.chartConfig"
                     plotly-layout="$ctrl.layoutConfig"
                     plotly-options="$ctrl.options"
-                    ng-hide="!$ctrl.hasPoints"></plotly>
+                    ng-hide = "$ctrl.loadPending || !$ctrl.chartConfig.length"></plotly>
             <br>
             <div class="history-empty"
-                 ng-show="this.chartConfig[0].x.length || !$ctrl.hasPoints">
+                 ng-show="!$ctrl.chartConfig.length && !$ctrl.loadPending">
                 No data points to display.
             </div>
         </div>
@@ -148,12 +161,12 @@
     </button>
     <br><br>
 
-    <div class="col-xs-12" ng-if="$ctrl.dataPointsMultiple.length && $ctrl.hasPoints">
+    <div class="col-xs-12" ng-if="$ctrl.dataPointsMultiple.length">
         <table id="history-table" class="table">
             <thead>
             <tr>
                 <th>Date and time</th>
-                <th ng-repeat="name in $ctrl.channelNames">{{name}}</th>
+                <th ng-repeat="channel in $ctrl.charts">{{channel.channelName}}</th>
             </tr>
             </thead>
             <tbody>

--- a/app/views/widgets.html
+++ b/app/views/widgets.html
@@ -34,9 +34,9 @@
             <display-cell compact="true"></display-cell>
         </td>
         <td ng-if="!row.preview" class="cell-history-col">
-            <a title="History" class="cell-history"
-               ui-sref="history.sample({device: row.cell.device, control: row.cell.control, start: historyStartTS(), end: '-'})"><i
-                    class="glyphicon glyphicon-stats"></i></a>
+            <a title="History" class="cell-history" ng-click="goToHistory(row.cell)">
+                <i class="glyphicon glyphicon-stats"></i>
+            </a>
         </td>
         <td ng-if="!!row.widget" class="description-col" rowspan="{{ row.rowSpan }}">{{ row.widget.description }}</td>
         <td ng-if="!!row.widget" class="dashboards-col" rowspan="{{ row.rowSpan }}" >

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.7.0) stable; urgency=medium
+
+  * Minimum and maximum values in charts on History page are shown as bands not as lines
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 03 Aug 2021 09:40:20 +0500
+
 wb-mqtt-homeui (2.6.0) stable; urgency=medium
 
   * Displaying of string values in chart on History page is implemented

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.8.0) stable; urgency=medium
+
+  * Widget names are preserved in charts legend on History page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 03 Aug 2021 18:56:20 +0500
+
 wb-mqtt-homeui (2.7.0) stable; urgency=medium
 
   * Minimum and maximum values in charts on History page are shown as bands not as lines

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "codemirror": "^5.25.0",
     "d3": "^4.7.4",
     "jquery": "^3.2.1 <3.5.0",
+    "lz-string": "^1.4.4",
     "ng-file-upload": "^12.2.13",
     "ng-toast": "^2.0.0",
     "ngbootbox": "^0.2.0",


### PR DESCRIPTION
Сделано на базе https://github.com/wirenboard/homeui/pull/214 так что надо смотреть только второй коммит.

Проблема в том, что при загрузке графика, если были выбраны контролы из виджетов, их названия подменяются на названия контролов.
Список контролов для отображения у нас передаётся в url.  Идёт список устройств через точку запятую, потом слэш и список каналов снова через точку запятую.
Для виджетов в список устройств пишу название виджета, в список каналов пустую строку.