### PR TITLE
Widget names are preserved in charts legend

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -43,6 +43,7 @@ import uiConfigService from './services/uiconfig';
 import hiliteService from './services/hilite';
 import userAgentFactory from './services/userAgent.factory';
 import rolesFactory from './services/roles.factory';
+import historyUrlService from './services/historyUrl';
 
 import handleDataService from './services/handle-data';
 
@@ -146,6 +147,7 @@ module
     .service('handleData', handleDataService)
     .service('userAgentFactory', userAgentFactory)
     .service('rolesFactory', rolesFactory)
+    .service('historyUrlService', historyUrlService)
 
 
     .run(DeviceData => {

--- a/app/scripts/app.routes.js
+++ b/app/scripts/app.routes.js
@@ -435,13 +435,10 @@ function routing($stateProvider,  $locationProvider, $urlRouterProvider) {
     })
   //...........................................................................
     .state('history.sample', {
-      url: '/{device}/{control}/{start}/{end}',
+      url: '/{data}',
       templateUrl: historyTemplateUrl,
       controller: 'HistoryCtrl as $ctrl',
       resolve: {
-          /*load: ['$ocLazyLoad', function($ocLazyLoad) {
-              return $ocLazyLoad.load(['plotly','historyController'])
-          }],*/
         ctrl: ($q, $ocLazyLoad) => {
             'ngInject';
             let deferred_1 = $q.defer();

--- a/app/scripts/controllers/devicesController.js
+++ b/app/scripts/controllers/devicesController.js
@@ -1,6 +1,6 @@
 
 class DevicesCtrl {
-    constructor($scope, $state, $injector, DeviceData, handleData, rolesFactory) {
+    constructor($scope, $state, $injector, DeviceData, handleData, rolesFactory, historyUrlService) {
         'ngInject';
 
         this.haveRights = rolesFactory.checkRights(rolesFactory.ROLE_TWO);
@@ -9,6 +9,7 @@ class DevicesCtrl {
         this.$state = $state;
         this.handleData = handleData;
         this.DeviceData = DeviceData;
+        this.historyUrlService = historyUrlService;
 
         // will create object to keep devices open/close condition 
         // in localeStorage, if it's not there.
@@ -189,7 +190,7 @@ class DevicesCtrl {
 
     redirect(contr) {
         var [device,control] = contr.split('/');
-        this.$state.go('history.sample', {device, control, start: '-', end: '-'})
+        this.$state.go('history.sample', { data: this.historyUrlService.encodeControl(device, control) })
     }
 }
 

--- a/app/scripts/controllers/widgetsController.js
+++ b/app/scripts/controllers/widgetsController.js
@@ -1,5 +1,5 @@
 class WidgetsCtrl {
-  constructor($scope, uiConfig, DeviceData, handleData, rolesFactory) {
+  constructor($scope, $state, uiConfig, DeviceData, handleData, rolesFactory, historyUrlService) {
     'ngInject';
 
     
@@ -23,8 +23,11 @@ class WidgetsCtrl {
     }
     
     $scope.roles = rolesFactory;
-    $scope.historyStartTS = () => this.handleData.historyStartTS();
     $scope.rows = [];
+    $scope.goToHistory = (cell) => {
+      const data = historyUrlService.encodeControl(cell.device, cell.control, handleData.historyStartTS());
+      $state.go('history.sample', { data })
+    }
     $scope.$watch(uiConfig.version, () => {
       var dashboardMap = Object.create(null);
       var dashboards = uiConfig.data.dashboards;

--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -4,7 +4,7 @@ function displayCellDirective(displayCellConfig, $compile) {
   'ngInject';
 
   class DisplayCellController {
-    constructor ($scope, $state, $element, $attrs, handleData) {
+    constructor ($scope, $state, $element, $attrs, handleData, historyUrlService) {
       'ngInject';
       //this.$scope = $scope;
       this.cell = $scope.cell;
@@ -13,6 +13,7 @@ function displayCellDirective(displayCellConfig, $compile) {
       //console.log("+++++++++this.cell",this.cell);
 
       this.handleData = handleData;
+      this.historyUrlService = historyUrlService;
     }
 
     /*copy() {
@@ -35,7 +36,7 @@ function displayCellDirective(displayCellConfig, $compile) {
 
     redirect(contr) {
       var [device,control] = contr.split('/');
-      this.$state.go('history.sample', {device, control, start: '-', end: '-'})
+      this.$state.go('history.sample', { data: this.historyUrlService.encodeControl(device, control) })
     }
   }
 

--- a/app/scripts/services/historyUrl.js
+++ b/app/scripts/services/historyUrl.js
@@ -1,0 +1,54 @@
+import LZString from "lz-string"
+
+function historyUrlService() {
+
+    //   controls = [
+    //     {
+    //       d: deviceId
+    //       c: controlId
+    //       w: widgetId
+    //     },
+    //     ...
+    //   ]
+    this.encodeControls = function (controls, startDate, endDate) {
+      const data = {
+        c: controls,
+        s: startDate,
+        e: endDate
+      };
+      return LZString.compressToEncodedURIComponent(JSON.stringify(data))
+    };
+
+    this.encodeControl = function (deviceId, controlId, startDate, endDate) {
+      return this.encodeControls([{d: deviceId, c: controlId}], startDate, endDate);
+    };
+
+    // Returns
+    // {
+    //   c: [
+    //     {
+    //       d: deviceId
+    //       c: controlId
+    //       w: widgetId
+    //     },
+    //     ...
+    //   ],
+    //   s: Date // Start date
+    //   e: Date // End date
+    // }
+    this.decode = function (data) {
+      try {
+        var res = JSON.parse(LZString.decompressFromEncodedURIComponent(data));
+        if (res.s) {
+          res.s = new Date(res.s);
+        }
+        if (res.e) {
+          res.e = new Date(res.e);
+        }
+        return res;
+      } catch (reason) {}
+      return {};
+    };
+}
+
+export default historyUrlService;

--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -121,7 +121,7 @@ div[uib-datepicker-popup-wrap] {
     margin-top: 7px;
 }
 
-@media (max-width: 996px){
+@media (max-width: 991px){
     .history-page .progress {
         height: 4px;
         margin-bottom: 1px;

--- a/app/views/history.html
+++ b/app/views/history.html
@@ -4,34 +4,33 @@
         History
     </h1>
 
-    <div class="row" ng-repeat="sel in $ctrl.selectedTopics track by $index">
+    <div class="row" ng-repeat="sel in $ctrl.selectedControls track by $index">
         <div class="col-xs-8 col-md-5">
             <select id="control-select"
                     class="form-control"
                     ng-disabled="$ctrl.disableUi"
-                    ng-change="$ctrl.updateUrl($index)"
-                    ng-model="$ctrl.selectedTopics[$index]"
-                    ng-options="control.topic as control.name group by control.group for control in $ctrl.controls">
+                    ng-model="$ctrl.selectedControls[$index]"
+                    ng-options="control as control.name group by control.group for control in $ctrl.controls track by control.name">
                 <option value="">- Please Choose -</option>
             </select>
         </div>
-        <div class="col-xs-4 col-md-3">
+        <div class="col-xs-4 col-md-2">
             <div>
-                <div ng-hide="($index==0 && $ctrl.selectedTopics.length==1) || !$ctrl.selectedTopics[1]"
+                <div ng-hide="($index==0 && $ctrl.selectedControls.length==1) || !$ctrl.selectedControls[1]"
                      ng-disabled="$ctrl.disableUi"
                      class="btn btn-danger" ng-click="$ctrl.deleteTopic($index)">delete
                 </div>
             </div>
         </div>
-        <div class="col-xs-12 col-sm-12 col-md-4" ng-if="$ctrl.chunksN>1">
-            <uib-progressbar ng-if="$ctrl.selectedTopics[$index] && !$ctrl.charts[$index].progress.isLoaded && $ctrl.loadPending"
+        <div class="col-xs-12 col-md-5" ng-if="$ctrl.chunksN>1">
+            <uib-progressbar ng-if="$ctrl.selectedControls[$index] && !$ctrl.charts[$index].progress.isLoaded && $ctrl.loadPending"
                              value="$ctrl.charts[$index].progress.value"
                              min="0" max="::$ctrl.chunksN">
                 <div>{{$ctrl.charts[$index].progress.value}}/{{::$ctrl.chunksN}}</div>
             </uib-progressbar>
         </div>
     </div>
-    <div ng-hide="$ctrl.selectedTopics.length==1 && !$ctrl.selectedTopics[$ctrl.selectedTopics.length-1]">
+    <div ng-hide="$ctrl.selectedControls.length==1 && !$ctrl.selectedControls[$ctrl.selectedControls.length-1]">
         <br>
         <button class="btn btn-success" ng-click="$ctrl.addTopic()" ng-disabled="$ctrl.disableUi">
             Add channel
@@ -41,7 +40,7 @@
 
     <div class="row">
         <div class="col-md-6 col-lg-5">
-            <div class="row" ng-show="$ctrl.topics.length">
+            <div class="row">
                 <div class="col-xs-1 col-md-1 history-time-col-l">
                     <label for="history-start">Start</label>
                 </div>
@@ -78,7 +77,7 @@
         </div>
 
         <div class="col-md-6 col-lg-5">
-            <div class="row" ng-show="$ctrl.topics.length">
+            <div class="row">
                 <div class="col-xs-1 col-md-1 history-time-col-l">
                     <label for="history-end">End</label>
                 </div>
@@ -116,17 +115,17 @@
     </div>
 
     <button class="btn btn-success"
-            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0] || $ctrl.disableUi"
+            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedControls[0] || $ctrl.disableUi"
             ng-click="$ctrl.updateDateRange()">
         Load data
     </button>
     <button class="btn btn-success"
-            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedTopics[0] || $ctrl.disableUi"
+            ng-disabled="!$ctrl.timeChanged || !$ctrl.selectedControls[0] || $ctrl.disableUi"
             ng-click="$ctrl.readDatesFromUrl()">
         Reset
     </button>
     <button class="btn btn-success"
-            ng-disabled="$ctrl.disableUi"
+            ng-disabled="!$ctrl.loadPending"
             ng-click="$ctrl.stopLoadingData()">
         Stop loading
     </button>

--- a/app/views/widgets.html
+++ b/app/views/widgets.html
@@ -34,9 +34,9 @@
             <display-cell compact="true"></display-cell>
         </td>
         <td ng-if="!row.preview" class="cell-history-col">
-            <a title="History" class="cell-history"
-               ui-sref="history.sample({device: row.cell.device, control: row.cell.control, start: historyStartTS(), end: '-'})"><i
-                    class="glyphicon glyphicon-stats"></i></a>
+            <a title="History" class="cell-history" ng-click="goToHistory(row.cell)">
+                <i class="glyphicon glyphicon-stats"></i>
+            </a>
         </td>
         <td ng-if="!!row.widget" class="description-col" rowspan="{{ row.rowSpan }}">{{ row.widget.description }}</td>
         <td ng-if="!!row.widget" class="dashboards-col" rowspan="{{ row.rowSpan }}" >

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.8.0) stable; urgency=medium
+
+  * Widget names are preserved in charts legend on History page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 03 Aug 2021 18:56:20 +0500
+
 wb-mqtt-homeui (2.7.0) stable; urgency=medium
 
   * Minimum and maximum values in charts on History page are shown as bands not as lines

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "codemirror": "^5.25.0",
     "d3": "^4.7.4",
     "jquery": "^3.2.1 <3.5.0",
+    "lz-string": "^1.4.4",
     "ng-file-upload": "^12.2.13",
     "ng-toast": "^2.0.0",
     "ngbootbox": "^0.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,8 @@ module.exports = function makeWebpackConfig() {
             'angular-translate',
             'angular-translate-loader-partial',
             'angular-spinkit',
-            'ngbootbox'
+            'ngbootbox',
+            'lz-string'
         ]
     };
     /**


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/homeui/pull/215

* Widget ids are now stored in url for transfering between page reloads. So it is possible to correctly show widget names in chart's legend and control's comboboxes.
* History params are stored in JSON and are packed using LZString. Resulting string is appended to url.