### PR TITLE
Dates tooltips on charts hover

### DIFF
--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -466,7 +466,7 @@ class HistoryCtrl {
             fill: "toself", 
             fillcolor: fillColor, 
             line: {color: "transparent"},
-            hoverinfo: "none",
+            hoverinfo: "skip",
             yaxis: axisName
         };
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.10.1) stable; urgency=medium
+
+  * Display of  date labels when hovering points on history charts is restored. 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 25 Aug 2021 11:32:22 +0500
+
 wb-mqtt-homeui (2.10.0) stable; urgency=medium
 
   * An interface for querying device's logs is added.


### PR DESCRIPTION
Исчезли надписи снизу с датой и временем, когда наводишь на точку в графике. Исправил