### PR TITLE
Control type filter in widget's properties dialog is restored

### DIFF
--- a/app/scripts/directives/widget.html
+++ b/app/scripts/directives/widget.html
@@ -67,8 +67,8 @@
       </tbody>
     </table>
       <div class="add-cell">
-      <label translate>
-        {{'widgets.labels.find'}}
+      <label>
+        {{'widgets.labels.find' | translate}}
         <select name="type-filter" ng-options="name for name in ctrl.cellTypesUsed track by name"
                 ng-model="ctrl.cellType" class="form-control"></select>
       </label>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.13.1) stable; urgency=medium
+
+  * Control type filter in widget's properties dialog is restored 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 08 Sep 2021 20:03:46 +0500
+
 wb-mqtt-homeui (2.13.0) stable; urgency=medium
 
   * Configs translation support is added


### PR DESCRIPTION
Rebase of https://github.com/wirenboard/homeui/pull/239