### PR TITLE
build: fix 'The unauthenticated git protocol' error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ clean:
 	npm run clean
 
 build:
+	# FIXME: this replaces git:// with https:// somewhere in node modules
+	# which fixes build after Github banned unauthenticated access
+	# (https://github.blog/2021-09-01-improving-git-protocol-security-github/)
+	git config --global url."https://".insteadOf git://
+
 	npm install
 	git submodule init
 	git submodule update


### PR DESCRIPTION
It fixes build after Github banned unauthenticated access via git:// protocol which is used by one of countless Node.js modules here.

This fix should be removed in future after switching to newer dependencies versions.