### PR TITLE
Control's meta topic handling error is fixed

### DIFF
--- a/app/scripts/services/devicedata.js
+++ b/app/scripts/services/devicedata.js
@@ -463,7 +463,7 @@ function deviceDataService(mqttClient) {
       ensureDevice(this.deviceId).cellIds.sort(compareCellIds);
     }
 
-    // meta must be a string with JSON
+    // meta must be a string with JSON or empty string or undefined
     // {
     //   title: {
     //    en: ...,
@@ -478,14 +478,26 @@ function deviceDataService(mqttClient) {
     //  units: ...
     // }
     setMeta(meta) {
-      const m = JSON.parse(meta);
-      this._nameTranslations = m.title || {};
-      this.setExplicitReadOnly(m.readonly);
-      this.setType(m.type);
-      this.setMin(m.min);
-      this.setMax(m.min);
-      this.setStep(m.precision);
-      this.setUnits(m.units)
+      if (meta) {
+        try {
+          const m = JSON.parse(meta);
+          this._nameTranslations = m.title || {};
+          this.setExplicitReadOnly(m.readonly);
+          this.setType(m.type);
+          this.setMin(m.min);
+          this.setMax(m.min);
+          this.setStep(m.precision);
+          this.setUnits(m.units)
+        } catch (e) {}
+      } else {
+        this._nameTranslations = {};
+        this.setExplicitReadOnly(null);
+        this.setType("");
+        this.setMin("");
+        this.setMax("");
+        this.setStep("");
+        this.setUnits("")
+      }
     }
 
     getName(lang) {
@@ -534,7 +546,7 @@ function deviceDataService(mqttClient) {
       {
         handledTopic: deviceTopicBase + '/meta',
         handler() {
-          if (payload === "") {
+          if (!payload) {
             if (devices.hasOwnProperty(deviceId)) {
               devices[deviceId].explicit = false;
               maybeRemoveDevice(deviceId);
@@ -548,7 +560,7 @@ function deviceDataService(mqttClient) {
       },{
         handledTopic: deviceTopicBase + '/meta/name',
         handler() {
-          if (payload === "") {
+          if (!payload) {
             if (devices.hasOwnProperty(deviceId)) {
               devices[deviceId].name = deviceId;
               devices[deviceId].explicit = false;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.24.2) stable; urgency=medium
+
+  * A disconnection from MQTT broker after receiving null in control's meta topic is fixed.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 08 Dec 2021 13:37:05 +0500
+
 wb-mqtt-homeui (2.24.1) stable; urgency=medium
 
   * Fixed typo in Ru translation about default panel at homepage


### PR DESCRIPTION
A disconnection from MQTT broker after receiving null in control's meta topic is fixed.