### PR TITLE
"Deprecated template" message is added to names of deprecated device tempates

### DIFF
--- a/app/scripts/components/json-editor/collapsible-multiple-editor.js
+++ b/app/scripts/components/json-editor/collapsible-multiple-editor.js
@@ -10,6 +10,7 @@ import { JSONEditor } from "../../../3rdparty/jsoneditor";
 // Title and header controls of a selected type editor are hidden
 // Has additional expandEditor and collapseEditor functions
 function makeCollapsibleMultipleEditor () {
+    JSONEditor.defaults.languages.en.deprecated_template = 'deprecated template'
     return class extends JSONEditor.defaults.editors["multiple"] {
 
         build () {
@@ -170,6 +171,35 @@ function makeCollapsibleMultipleEditor () {
             this.container.style.paddingBottom = 0
             this.switcher.disabled = false
         }
+
+        onChildEditorChange (editor) {
+            super.onChildEditorChange(editor)
+            this.onWatchedFieldChange()
+        }
+
+        getDisplayText (arr) {
+            const disp = []
+            const inc = {}
+
+            arr.forEach(el => {
+                var title = 'Item'
+                if (el.title) {
+                    title = this.translateProperty(el.title)
+                    if (el.options && el.options.wb && el.options.wb.hide_from_selection) {
+                        title = title + ' (' + this.translate('deprecated_template') + ')'
+                    }
+                }
+                if (inc[title]) {
+                    title = `${title} ${inc[title]}`
+                    inc[title]++
+                } else {
+                    inc[title] = 2
+                }
+                disp.push(title)
+            })
+
+            return disp
+          }
 
         _adjustControls(editor)
         {

--- a/app/scripts/components/json-editor/json-editor-ru.js
+++ b/app/scripts/components/json-editor/json-editor-ru.js
@@ -328,7 +328,10 @@ const JsonEditorRussianTranslation = {
 
     unknown_device_warning: 'Шаблон для устройства отсутствует или содержит ошибки',
 
-    channel: "Канал"
+    channel: 'Канал',
+
+    deprecated_template: 'устаревший шаблон'
+
 };
 
 export default JsonEditorRussianTranslation;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.36.0) stable; urgency=medium
+
+  * "Deprecated template" message is added to names of deprecated device templates
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 25 May 2022 12:02:46 +0500
+
 wb-mqtt-homeui (2.35.0) stable; urgency=medium
 
   * Support for device parameters specified as array is added


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/86825564/170202171-9f848f42-6a34-473b-b989-135967510e65.png)
В скобочках то, что добавилось. Остальное из названия шаблона, сейчас там руками прописано "- устаревший шаблон". После этого PR, удалю такие названия из wb-mqtt-serial