### PR TITLE
Highlighting of tabs with invalid parameters in device config

### DIFF
--- a/app/scripts/components/json-editor/select-with-hidden-items.js
+++ b/app/scripts/components/json-editor/select-with-hidden-items.js
@@ -12,6 +12,8 @@ function makeSelectWithHiddenItems () {
             const haveToUseDefaultValue = !!this.jsoneditor.options.use_default_values || typeof this.schema.default !== 'undefined'
             if (!this.enum_values.includes(sanitized)) {
                 if (this.value === sanitized) return
+                // value is not in options list
+                // select can't show correct item so force it to show empty editor
                 this.input.value = null
             } else {
                 if (initial && !this.isRequired() && !haveToUseDefaultValue) {

--- a/app/scripts/components/json-editor/select-with-hidden-items.js
+++ b/app/scripts/components/json-editor/select-with-hidden-items.js
@@ -12,7 +12,7 @@ function makeSelectWithHiddenItems () {
             const haveToUseDefaultValue = !!this.jsoneditor.options.use_default_values || typeof this.schema.default !== 'undefined'
             if (!this.enum_values.includes(sanitized)) {
                 if (this.value === sanitized) return
-                this.input.value = 'AbRaCaDaBrA'
+                this.input.value = null
             } else {
                 if (initial && !this.isRequired() && !haveToUseDefaultValue) {
                     sanitized = this.enum_values[0]

--- a/app/scripts/components/json-editor/select-with-hidden-items.js
+++ b/app/scripts/components/json-editor/select-with-hidden-items.js
@@ -5,6 +5,32 @@ import { JSONEditor } from "../../../3rdparty/jsoneditor";
 function makeSelectWithHiddenItems () {
     return class extends JSONEditor.defaults.editors["select"] {
 
+        setValue(value, initial) {
+            /* Sanitize value before setting it */
+            let sanitized = this.typecast(value)
+        
+            const haveToUseDefaultValue = !!this.jsoneditor.options.use_default_values || typeof this.schema.default !== 'undefined'
+            if (!this.enum_values.includes(sanitized)) {
+                if (this.value === sanitized) return
+                this.input.value = 'AbRaCaDaBrA'
+            } else {
+                if (initial && !this.isRequired() && !haveToUseDefaultValue) {
+                    sanitized = this.enum_values[0]
+                }
+                if (this.value === sanitized) return
+
+                if (initial) this.is_dirty = false
+                else if (this.jsoneditor.options.show_errors === 'change') this.is_dirty = true
+            
+                this.input.value = this.enum_options[this.enum_values.indexOf(sanitized)]
+            
+            }
+            this.value = sanitized
+
+            this.onChange()
+            this.change()
+        }
+
         hideFromChoices () {
             var options = this.switcher_options = this.theme.getSwitcherOptions(this.input)
             options.forEach((op, i) => {
@@ -24,6 +50,10 @@ function makeSelectWithHiddenItems () {
         onWatchedFieldChange () {
             super.onWatchedFieldChange()
             this.hideFromChoices()
+        }
+
+        showValidationErrors (errors) {
+            super.showValidationErrors(errors.filter(item => item.property !== 'oneOf'))
         }
     }
 }

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1071,3 +1071,9 @@ body.kiosk .page-header {
 .warning-notice {
   padding: 10px;
 }
+
+.nav-pills > li.has-error > a,
+.nav-pills > li.has-error > a:hover,
+.nav-pills > li.has-error > a:focus {
+  color: red;
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+wb-mqtt-homeui (2.39.2) stable; urgency=medium
+
+  * Highlighting of tabs with invalid parameters in device config is added
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 15 Jun 2022 12:34:27 +0500
+
 wb-mqtt-homeui (2.39.1) stable; urgency=medium
 
-  * do not show description in config list
+  * Do not show description in config list
 
  -- Evgeny Boger <boger@wirenboard.com>  Sat, 04 Jun 2022 13:37:47 +0300
 


### PR DESCRIPTION
При смене значения параметра другие, ранее установленные параметры на соседних вкладках могут выйти за разрешённые границы. Сделал так, чтобы такие параметры подсвечивались ошибкой. Также добавил подсветку вкладок с невалидными параметрами. Конфиг сохранять с такими ошибками теперь нельзя.

![изображение](https://user-images.githubusercontent.com/86825564/173771057-065b2703-60da-490c-8418-ab6cd04c5785.png)

![изображение](https://user-images.githubusercontent.com/86825564/173771082-64b9bb7e-025c-4b88-89e7-1cd4703f9692.png)
