### PR TITLE
Displaying of oneOf parameters by groups editor is fixed

### DIFF
--- a/app/scripts/components/json-editor/group-editor.js
+++ b/app/scripts/components/json-editor/group-editor.js
@@ -22,13 +22,20 @@ class Editor {
         return this.schema.options && this.schema.options.hidden
     }
 
+    // Parameters with same name are organized in oneOf schema.
+    // Each element in oneOf array must have condition.
+    // Generic oneOf parameters don't have conditions
+    isConditionalOneOfEditor() {
+        return this.schema.hasOwnProperty('oneOf') && this.schema.oneOf[0].hasOwnProperty('condition')
+    }
+
     updateEditorDisplay() {
         if (!this.editor) {
             return
         }
-        if (this.schema.hasOwnProperty('oneOf')) {
+        if (this.isConditionalOneOfEditor()) {
             this.editor.switcher.style.display = 'none'
-            if (this.editor.type != this.oneOfOfIndex) {
+            if (this.editor.type != this.oneOfIndex) {
                 this.editor.switchEditor(this.oneOfIndex)
                 // 'multiple' editor doesn't respect enabled state during subeditors creation.
                 // So force enabling or disabling
@@ -101,7 +108,7 @@ class Editor {
     }
 
     shouldEnable(paramNames, paramValues) {
-        if (this.schema.hasOwnProperty('oneOf')) {
+        if (this.isConditionalOneOfEditor()) {
             var index = this.schema.oneOf.findIndex(schema => {
                 return this.checkCondition(paramNames, paramValues, schema)
             })
@@ -127,7 +134,7 @@ class Editor {
 
     setValue(val, initial) {
         if (this.editor) {
-            if (this.schema.hasOwnProperty('oneOf')) {
+            if (this.isConditionalOneOfEditor()) {
                 this.editor.editors[this.editor.type].setValue(val, initial)
             } else {
                 this.editor.setValue(val, initial)

--- a/app/scripts/services/dumbtemplate.js
+++ b/app/scripts/services/dumbtemplate.js
@@ -11,6 +11,12 @@ function dumbTemplateService() {
       return function (vars) {
 
         var expandVar = function(expr) {
+          if (expr === "true") {
+            return true
+          }
+          if (expr === "false") {
+            return false
+          }
           var t = expr.match(/^"(.*)"$/);
           if (t) {
             return t[1];

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.40.2) stable; urgency=medium
+
+  * Displaying of oneOf parameters by groups editor is fixed
+  * Support for boolean constants in expressions in json-editor's template engine is added
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 11 Jul 2022 10:22:52 +0500
+
 wb-mqtt-homeui (2.40.1) stable; urgency=medium
 
   * Add button to enter fullscreen mode


### PR DESCRIPTION
Для представления параметров, которые имеют одно имя и выбираются по условию (condition), я генерирую схему с `oneOf`, а процессе работы применяю условия и выбираю нужную схему из списка, переключаю редактор на неё и скрываю лишние элементы. Я пропустил момент, что есть обычные параметры, которые в схеме имеют `oneOf` и не имеют условий. Например, адрес или широковещательные посылки. Такие параметры стали обрабатываться криво, перестали отображаться. Добавил проверку по типу параметра, без условий обрабатываю как обычние параметры, с условиям - как описано выше.