### PR TITLE
css: fix widget's description resize & bounds

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -686,6 +686,10 @@ button.show-console span {
   max-width: 100%;
 }
 
+.widget .editable-elastic-textarea textarea {
+  resize: none;
+}
+
 .widget.compact .display-cell.cell-type-range {
   margin-top: 4px;
 }
@@ -720,6 +724,7 @@ button.show-console span {
 .widgets-table .description-col {
   min-width: 200px;
   max-width: 300px;
+  overflow-wrap: break-word;
 }
 
 .widgets-table ul {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.41.1) stable; urgency=medium
+
+  * css: fix widget's description resizing and bounds
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 12 Jul 2022 18:11:39 +0500
+
 wb-mqtt-homeui (2.41.0) stable; urgency=medium
 
   * Support for groups in device type select in wb-mqtt-serial config editor is added


### PR DESCRIPTION
описание виджетов странно ресайзилось и вылезало за границы
### было:

![2022-07-12_18-17-22](https://user-images.githubusercontent.com/25829054/178525252-c235e7c3-7bcc-436b-b5df-bf6b6dcad3be.png)
![2022-07-12_18-17-15](https://user-images.githubusercontent.com/25829054/178525266-7aad8198-bbe6-4275-85b8-d7207b2df0a8.png)


### стало:
![2022-07-12_18-15-04](https://user-images.githubusercontent.com/25829054/178525328-108b7ec8-ebbb-4248-a44c-72ba5fe9653c.png)
![2022-07-12_18-14-44](https://user-images.githubusercontent.com/25829054/178525329-9911a933-2666-4db0-a72e-44a8592f2d6d.png)
