### PR TITLE
Fix interface slowdown

### DIFF
--- a/app/scripts/components/json-editor/group-editor.js
+++ b/app/scripts/components/json-editor/group-editor.js
@@ -348,20 +348,22 @@ function makeGroupsEditor () {
             this.groups.set(undefined, new Group(undefined)) // root group
             if (this.schema.options && this.schema.options.wb && this.schema.options.wb.groups) {
                 this.schema.options.wb.groups.forEach(groupSchema => {
-                    var group = this.groups.get(groupSchema.id)
-                    if (group) {
-                        group.schema = groupSchema
-                    } else {
-                        group = new Group(groupSchema)
-                        this.groups.set(groupSchema.id, group)
+                    if (typeof groupSchema === 'object' && !Array.isArray && groupSchema !== null) {
+                        var group = this.groups.get(groupSchema.id)
+                        if (group) {
+                            group.schema = groupSchema
+                        } else {
+                            group = new Group(groupSchema)
+                            this.groups.set(groupSchema.id, group)
+                        }
+                        var parentGroup = this.groups.get(groupSchema.group)
+                        if (!parentGroup) {
+                            parentGroup = new Group()
+                            this.groups.set(groupSchema.group, parentGroup)
+                        }
+                        parentGroup.addSubgroup(group)
+                        group.parentGroup = parentGroup
                     }
-                    var parentGroup = this.groups.get(groupSchema.group)
-                    if (!parentGroup) {
-                        parentGroup = new Group()
-                        this.groups.set(groupSchema.group, parentGroup)
-                    }
-                    parentGroup.addSubgroup(group)
-                    group.parentGroup = parentGroup
                 })
             }
         }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.44.1) stable; urgency=medium
+
+  * Fix interface slowdown when editing wbio-ai-dv-12 config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 26 Jul 2022 10:18:25 +0500
+
 wb-mqtt-homeui (2.44.0) stable; urgency=medium
 
   * Slave id is preserved after device type switching


### PR DESCRIPTION
wb-multiple editor has item groups for select. They are defined as an array of strings in options.wb.groups. Device config editor has also groups defined in options.wb.groups. They are used for tabs and panels and defined as array of objects. json-editor merges these options if groups editor is used in oneOf array in wb-multiple. So groups editor can receive groups of wb-multiple. Ignore them.

Баг проявляется, если выбрать wbio-ai-dv-12 в настройках wb-mqtt-serial. Веб-интерфейс зависнет.