### PR TITLE
Fix parameter values after activation in configs editor

### DIFF
--- a/app/scripts/components/json-editor/select-with-hidden-items.js
+++ b/app/scripts/components/json-editor/select-with-hidden-items.js
@@ -5,6 +5,15 @@ import { JSONEditor } from "../../../3rdparty/jsoneditor";
 function makeSelectWithHiddenItems () {
     return class extends JSONEditor.defaults.editors["select"] {
 
+        enable() {
+            if (!this.isEnabled() && !this.enum_values.includes(this.value)) {
+                super.enable()
+                this.setValue(this.getDefault())
+            } else {
+                super.enable()
+            }
+        }
+
         setValue(value, initial) {
             /* Sanitize value before setting it */
             let sanitized = this.typecast(value)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.44.2) stable; urgency=medium
+
+  * Fix parameter values after activation in configs editor.
+    Deactivation and reactivation of a parameter will set it to default value.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 26 Jul 2022 15:10:47 +0500
+
 wb-mqtt-homeui (2.44.1) stable; urgency=medium
 
   * Fix interface slowdown when editing wbio-ai-dv-12 config


### PR DESCRIPTION
Стоит посмотреть видео из задачи https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/50274/

Выбрали режим работы диммера, выбрали значение одного из параметров. Потом параметр убрали (сняли галочку). Переключили режим. Теперь ранее выбранное значение у отключенного параметра не применимо. Снова выбрали параметр. Ожидаем, что появится значение по умолчанию. А оно внутри пытается применить старое значение и ругается ошибкой.

Перегрузил для редактора функцию, которая вызывается при активации. Если текущее значение в редакторе - не одно из возможных, то выставляю значение по умолчанию.