### PR TITLE
Fix BAC-6000 error messages display

### DIFF
--- a/app/scripts/components/json-editor/collapsible-multiple-editor.js
+++ b/app/scripts/components/json-editor/collapsible-multiple-editor.js
@@ -425,7 +425,10 @@ function makeCollapsibleMultipleEditor () {
             /* oneOf error paths need to remove the oneOf[i] part before passing to child editors */
             this.editors.forEach((editor, i) => {
                 if (!editor) return
-                const originalIndex = this.types[i].originalIndex || i
+                var originalIndex = this.types[i].originalIndex
+                if (originalIndex === undefined) {
+                    originalIndex = i
+                }
                 const check = `${this.path}.oneOf[${originalIndex}]`
                 const filterError = (newErrors, error) => {
                     if (error.path.startsWith(check) || error.path === check.substr(0, error.path.length)) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.44.4) stable; urgency=medium
+
+  * Fix BAC-6000 error messages display
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 27 Jul 2022 16:27:23 +0500
+
 wb-mqtt-homeui (2.44.3) stable; urgency=medium
 
   * Fix overlapping of wb-watch-update's status in fwupdate progress bar


### PR DESCRIPTION
Было
![изображение](https://user-images.githubusercontent.com/86825564/181236405-01d70741-5dad-41be-8fe8-c2045567079f.png)

Стало
![изображение](https://user-images.githubusercontent.com/86825564/181236465-7506720a-1d33-4b7c-8d06-45edfcbed20c.png)

Всё из-за неявного преобразования 0 в false