### PR TITLE
Add ability to set disabled optional parameter text

### DIFF
--- a/app/scripts/components/json-editor/disabled-editor-wrapper.js
+++ b/app/scripts/components/json-editor/disabled-editor-wrapper.js
@@ -7,7 +7,11 @@ function makeDisabledEditorWrapper (Base) {
             this.disabledEditor = this.theme.getFormInputField(this.input_type)
             this.disabledEditor.style.display = 'none'
             this.disabledEditor.disabled = true
-            this.disabledEditor.value = this.translate('unknown')
+            if (this.schema.options && this.schema.options.inputAttributes && this.schema.options.inputAttributes.placeholder) {
+                this.disabledEditor.value = this.translateProperty(this.schema.options.inputAttributes.placeholder)
+            } else {
+                this.disabledEditor.value = this.translate('unknown')
+            }
             this.control.insertBefore(this.disabledEditor, this.description)
         }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-homeui (2.46.2) stable; urgency=medium
 
-  * Use options.inputAttributes.placeholder for disabled text of optional parameters
+  * Add ability to set disabled optional parameter text
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 04 Oct 2022 14:42:25 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.46.2) stable; urgency=medium
+
+  * Use options.inputAttributes.placeholder for disabled text of optional parameters
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 04 Oct 2022 14:42:25 +0500
+
 wb-mqtt-homeui (2.46.1) stable; urgency=medium
 
   * Fix parameter values after activation in configs editor.


### PR DESCRIPTION
Use options.inputAttributes.placeholder for disabled text of optional parameters

Раньше было захардкожено так
![изображение](https://user-images.githubusercontent.com/86825564/193809329-7f642253-01e2-4a9b-be2b-66862c47f0b6.png)

Сейчас можно в схеме задать текст
![изображение](https://user-images.githubusercontent.com/86825564/193809410-80040459-527c-445b-8bc2-2d6bd0eb8c78.png)
