### PR TITLE
Fix wb-array items creation with sorting enabled

### DIFF
--- a/app/scripts/components/json-editor/wb-array-editor.js
+++ b/app/scripts/components/json-editor/wb-array-editor.js
@@ -201,10 +201,14 @@ function makeWbArrayEditor () {
             var v = this.getValue()
             const valueToReplace = v[this.rows.length - 1]
             const prop = this.schema.options.wb.sort_by_property
-            const index = v.findIndex(item => this._compareBySortProp(item, valueToReplace, prop) == 1)
-            v.splice(index, 0, valueToReplace)
-            v.pop()
-            this.setValue(v)
+            var index = v.findIndex(item => this._compareBySortProp(item, valueToReplace, prop) == 1)
+            if (index != -1) {
+              v.splice(index, 0, valueToReplace)
+              v.pop()
+              this.setValue(v)
+            } else {
+              index = this.rows.length - 1
+            }
             this.active_tab = this.rows[index].tab
             this.refreshTabs()
           } else {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.47.1) stable; urgency=medium
+
+  * Fix Wi-Fi AP creation in NetworkManager config editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 26 Oct 2022 15:20:24 +0500
+
 wb-mqtt-homeui (2.47.0) stable; urgency=medium
 
   * Support NetworkManager config editor


### PR DESCRIPTION
В редакторе wb-array можно указать параметр, по которому сортировать элементы. После добавления нового элемента, производится поиск позиции, в которую его переместить. Создаётся всегда в конце массива. Если перемещать никуда не надо, то неверно находился индекс вкладки, которую надо активировать.