### PR TITLE
Fix displaying of conditional config parameters

### DIFF
--- a/app/scripts/components/json-editor/group-editor.js
+++ b/app/scripts/components/json-editor/group-editor.js
@@ -552,7 +552,6 @@ function makeGroupsEditor () {
         setValue(value, initial) {
             this.value = angular.extend({}, value)
             this.disableValueUpdate = true
-            this.enableEditorsAccordingToParams(value)
             Object.entries(value).forEach(([key, val]) => {
                 if (this.editors.hasOwnProperty(key)) {
                     var ed = this.editors[key]
@@ -770,15 +769,6 @@ function makeGroupsEditor () {
                     })
             paramNames = paramNames.join(',')
             return [paramNames, paramValues]
-        }
-
-        enableEditorsAccordingToParams(params) {
-            var paramValues = []
-            var paramNames = []
-            this.getParamsForConditions(params, paramNames, paramValues)
-            Object.entries(this.editors).forEach(([key, ed]) => {
-                ed.updateState(paramNames, paramValues)
-            })
         }
 
         updateEditorsState() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.48.2) stable; urgency=medium
+
+  * Fix MAI6 config editing
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Wed, 09 Nov 2022 10:29:56 +0500
+
 wb-mqtt-homeui (2.48.1) stable; urgency=medium
 
   * Fix Documentation link


### PR DESCRIPTION
При установке значения в редактор, я делал вначале один шаг определения какие параметры надо показывать. В результате последующая полная процедура останавливалась сразу на первом шаге, т.к. не было изменений в отображаемых параметрах. Убрал этот один шаг, т.к. ниже по коду делается полная процедура определения того, что надо отображать.

При редактировании MAI6 получалась такая картина, а должно было быть как внизу
![изображение](https://user-images.githubusercontent.com/86825564/200749983-92b90632-7bb4-461a-af4c-ca039e26e5fa.png)
