### PR TITLE
fix build on bullseye

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ build:
 	# FIXME: this replaces git:// with https:// somewhere in node modules
 	# which fixes build after Github banned unauthenticated access
 	# (https://github.blog/2021-09-01-improving-git-protocol-security-github/)
-	git config --global url."https://".insteadOf git://
+	git config url."https://".insteadOf git://
+	git submodule foreach --recursive git config url."https://".insteadOf git://
 
 	npm install
 	git submodule init


### PR DESCRIPTION
sbuild резонно ругался на то, что при использовании `git config --global` записывался файл в `$HOME`, который в сборочной среде не должен использоваться, поэтому в `$HOME` было записано значение `/sbuild-nonexistent`. В старых версиях `sbuild`, видимо, эта директория всё же создавалась. В bullseye теперь её нет (и это правильное поведение: https://lists.debian.org/debian-devel/2016/02/msg00455.html).

Починил makefile так, чтобы конфиг применялся только в рамках репозитория.