### PR TITLE
Fix docs url

### DIFF
--- a/app/views/help.html
+++ b/app/views/help.html
@@ -3,7 +3,7 @@
 <div class="scripts">
     <ul>
         <li>
-            <a href="{{'help.url.docs'}}" target="_blank" translate>{{'help.list.docs'}}</a>
+            <a href="{{'help.url.docs' | translate}}" target="_blank" translate>{{'help.list.docs'}}</a>
         </li>
         <li>
             <a href="https://support.wirenboard.com" target="_blank" translate="">{{'help.list.forum'}}</a>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-homeui (2.48.2) stable; urgency=medium
 
-  * Fix Documentation link
+  * Fix broken translation (help view)
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 10 Nov 2022 06:28:31 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.48.2) stable; urgency=medium
+
+  * Fix Documentation link
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 10 Nov 2022 06:28:31 +0400
+
 wb-mqtt-homeui (2.48.1) stable; urgency=medium
 
   * Fix Documentation link


### PR DESCRIPTION
В #360 упущен `| translate`, без него оказывается не работает.