### PR TITLE
Remove "Cancel" button from create item dialog in wb-array

### DIFF
--- a/app/scripts/components/json-editor/wb-array-editor.js
+++ b/app/scripts/components/json-editor/wb-array-editor.js
@@ -92,22 +92,27 @@ function makeWbArrayEditor () {
             this._addRowByType(this.addrow_options[this.addrow_select.selectedOptions[0].index].default)
             this._hideAddRowDialog()
           })
-          this.addrow_cancel = this.getButton('button_cancel', 'cancel', 'button_cancel')
-          this.addrow_cancel.classList.add('pull-right')
-          this.addrow_cancel.classList.add('json-editor-btntype-cancel')
-          this.addrow_cancel.addEventListener('click', (e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            this._hideAddRowDialog()
-          })
           this.addrow_dialog_controls.appendChild(this.addrow_save)
-          this.addrow_dialog_controls.appendChild(this.addrow_cancel)
           this.addrow_holder.appendChild(this.addrow_dialog_controls)
           column.appendChild(this.addrow_dialog_controls)
           row.appendChild(column)
           this.addrow_holder.appendChild(row)
 
           this.controls.insertBefore(this.addrow_holder, this.controls.childNodes[0])
+
+          /* Close modal if clicked outside modal */
+          this.onOutsideModalClickListener = this.onOutsideModalClick.bind(this)
+          document.addEventListener('click', this.onOutsideModalClickListener, true)
+          this.adding_row = false
+        }
+
+        onOutsideModalClick (e) {
+          const path = e.path || (e.composedPath && e.composedPath())
+          if (this.addrow_holder && !this.addrow_holder.contains(path[0]) && this.adding_row) {
+            e.preventDefault()
+            e.stopPropagation()
+            this._hideAddRowDialog()
+          }
         }
 
         build () {
@@ -120,6 +125,7 @@ function makeWbArrayEditor () {
         _hideAddRowDialog () {
           this.addrow_holder.style.display = 'none'
           this.enable()
+          this.adding_row = false
         }
 
         _showAddRowDialog () {
@@ -127,6 +133,7 @@ function makeWbArrayEditor () {
           this.addrow_holder.style.top = `${this.add_row_button.offsetTop + this.add_row_button.offsetHeight}px`
           this.addrow_holder.style.display = ''
           this.disable()
+          this.adding_row = true
         }
 
         _createAddRowButton () {
@@ -282,6 +289,11 @@ function makeWbArrayEditor () {
               }
             })
           }
+        }
+
+        destroy () {
+          document.removeEventListener('click', this.onOutsideModalClickListener, true)
+          super.destroy()
         }
     }
 }

--- a/app/scripts/components/json-editor/wb-array-editor.js
+++ b/app/scripts/components/json-editor/wb-array-editor.js
@@ -82,7 +82,6 @@ function makeWbArrayEditor () {
           row = this.theme.getGridRow()
           column = this.theme.getGridColumn()
           this.theme.setGridColumnSize(column, 12)
-          this.addrow_dialog_controls = this.theme.getFormButtonHolder('right')
           this.addrow_save = this.getButton('button_add', 'add', 'button_add')
           this.addrow_save.classList.add('pull-right')
           this.addrow_save.classList.add('json-editor-btntype-save')
@@ -92,9 +91,7 @@ function makeWbArrayEditor () {
             this._addRowByType(this.addrow_options[this.addrow_select.selectedOptions[0].index].default)
             this._hideAddRowDialog()
           })
-          this.addrow_dialog_controls.appendChild(this.addrow_save)
-          this.addrow_holder.appendChild(this.addrow_dialog_controls)
-          column.appendChild(this.addrow_dialog_controls)
+          column.appendChild(this.addrow_save)
           row.appendChild(column)
           this.addrow_holder.appendChild(row)
 

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1097,6 +1097,7 @@ body.kiosk .page-header {
 
 .je-modal {
   padding: 9px 19px 9px 19px;
+  width: max-content
 }
 
 .je-modal label {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.48.4) stable; urgency=medium
+
+  * Remove "Cancel" button from "Create connection" dialog on "Network connections" page
+  * "Create connection" dialog can be canceled by clicking outside of the dialog
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 14 Nov 2022 08:48:43 +0500
+
 wb-mqtt-homeui (2.48.3) stable; urgency=medium
 
   * Fix MAI6 config editing


### PR DESCRIPTION
The dialog can be canceled by clicking outside of it

![изображение](https://user-images.githubusercontent.com/86825564/201572731-4af6b9b4-caf2-43ed-ab19-7d373be8adf0.png)
