### PR TITLE
debian: forbid nodejs>12.x as build-dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.48.5) stable; urgency=medium
+
+  * debian: forbid nodejs>12.x as build-dependency
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 16 Nov 2022 20:05:17 +0600
+
 wb-mqtt-homeui (2.48.4) stable; urgency=medium
 
   * Remove "Cancel" button from "Create connection" dialog on "Network connections" page

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), pkg-config, nodejs, npm, node-rimraf
+Build-Depends: debhelper (>= 9), pkg-config, nodejs (<< 13), npm, node-rimraf
 
 Package: wb-mqtt-homeui
 Architecture: all


### PR DESCRIPTION
homeui doesn't build with nodejs 16.x.

This fix temporarily forces nodejs to be 12.x (as in Debian bullseye upstream).