### PR TITLE
Support preffered languages settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ See into [conventions](https://github.com/wirenboard/conventions/blob/main/READM
 
 Run `npm run build` for building and `npm start` for preview.
 
-## Testing
-
-Running `npm run test` will run the unit tests with karma.
-
 ## Default SVG-Dashboards
 
 In default svg-dashboards, the text is converted to curves. If you need to add something - add new text and select the Ubuntu font.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ See into [conventions](https://github.com/wirenboard/conventions/blob/main/READM
 
 ## Build & development
 
-Run `grunt` for building and `grunt serve` for preview.
+Run `npm run build` for building and `npm start` for preview.
 
 ## Testing
 
-Running `grunt test` will run the unit tests with karma.
+Running `npm run test` will run the unit tests with karma.
 
 ## Default SVG-Dashboards
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -382,9 +382,10 @@ const realApp = angular.module('realHomeuiApp', [module.name, mqttServiceModule,
             prefix: $window.localStorage['prefix']
         };
 
-        var language =  $window.localStorage['language'];
-        if (!language) {
-            language = window.navigator.language.startsWith('ru') ? 'ru' : 'en';
+        var language = $window.localStorage['language'];
+        if (!language || i18n.languages.indexOf(language) === -1) {
+            var preferredLanguages = window.navigator.languages;
+            language = preferredLanguages.filter(lang => i18n.languages.indexOf(lang.split('-')[0]) !== -1)[0] || 'en';
             $window.localStorage.setItem('language', language);
         }
         $translate.use(language);

--- a/app/scripts/controllers/webUiController.js
+++ b/app/scripts/controllers/webUiController.js
@@ -6,7 +6,11 @@ export default class WebUICtrl {
 
         this.rolesFactory = rolesFactory;
         this.uiConfig = uiConfig;
-        this.language =  $window.localStorage['language'] || 'en';
+        this.language = $window.localStorage['language'];
+        if (!this.language || i18n.languages.indexOf(this.language) === -1) {
+            let preferredLanguages = window.navigator.languages;
+            this.language = preferredLanguages.filter(lang => i18n.languages.indexOf(lang.split('-')[0]) !== -1)[0] || 'en';
+        }
 
         uiConfig.whenReady()
             .then((data) => {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.51.1) stable; urgency=medium
+
+  * Support preffered languages settings
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 23 Jan 2023 09:17:00 +0400
+
 wb-mqtt-homeui (2.51.0) stable; urgency=medium
 
   * json-editor: array tabs highlighting support (used in network connections

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-homeui (2.51.1) stable; urgency=medium
 
-  * Support preffered languages settings
+  * Choose default language based on browser's preffered languages
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 23 Jan 2023 09:17:00 +0400
 


### PR DESCRIPTION
Как воспроизвести:
1. Очистить localStorage для UI
2. Настроить в браузере Preffered Languages, где первым в списке будет любой язык кроме ru и en, вторым ru
3. Обновить, UI отобразится на английском, хотя учитывая список языков, по приоритету должен быть выбран второй (русский)