### PR TITLE
Fix font assets file names

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.55.2) stable; urgency=medium
+
+  * Fix font assets file names
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 21 Feb 2023 14:44:00 +0400
+
 wb-mqtt-homeui (2.55.1) stable; urgency=medium
 
   * Code refactoring, no functional changes

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,7 +102,7 @@ module.exports = function makeWebpackConfig() {
                 test: /\.(svg|woff|woff2|ttf|eot)$/,
                 type: 'asset/resource',
                 generator: {
-                    filename: '[name].[ext]'
+                    filename: '[name][ext]'
                 }
             },
             {


### PR DESCRIPTION
Сейчас:
```sh
$ find /var/www -name "*..*"
/var/www/fontawesome-webfont..svg
/var/www/fa-solid-900..ttf
/var/www/fontawesome-webfont..woff
/var/www/fa-solid-900..woff
/var/www/glyphicons-halflings-regular..svg
/var/www/fa-solid-900..woff2
/var/www/fontawesome-webfont..ttf
/var/www/fa-solid-900..svg
/var/www/glyphicons-halflings-regular..woff
/var/www/glyphicons-halflings-regular..ttf
```