### PR TITLE
Add support for HTML format labels in config editor

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.57.0) stable; urgency=medium
+
+  * Add support for HTML format in titles/headers and descriptions in config editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 07 Mar 2023 11:54:02 +0500
+
 wb-mqtt-homeui (2.56.2) stable; urgency=medium
 
   * Fix page freezing on spinner during initial loading

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "angularjs-dropdown-multiselect": "^2.0.0-beta.10",
     "bootstrap": "^3.3.7",
     "codemirror": "^5.25.0",
+    "dompurify": "^3.0.1",
     "i18next": "^22.0.6",
     "jquery": "^3.6.1",
     "lodash": "^4.17.21",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,8 @@ module.exports = function makeWebpackConfig() {
             jQuery: 'jquery',
             $: 'jquery',
             'window.jQuery': 'jquery',
-            'window.CodeMirror': 'codemirror/lib/codemirror'
+            'window.CodeMirror': 'codemirror/lib/codemirror',
+            'window.DOMPurify': 'dompurify',
         }),
     ];
 
@@ -151,6 +152,7 @@ module.exports = function makeWebpackConfig() {
                     'angular-ui-scroll',
                     'angular-dynamic-locale',
                     'angularjs-dropdown-multiselect',
+                    'dompurify',
                     
                     // Taken from  https://github.com/angular/angular.js/tree/master/src/ngLocale
                     './scripts/i18n/angular-locale_en.js',


### PR DESCRIPTION
Add support for HTML format in titles/headers and descriptions in json-editor generated forms

Теперь в названиях и описаниях параметров json-editor'а можно использовать HTML тэги, SVG и MathML
![image](https://user-images.githubusercontent.com/86825564/223347296-3d296b3f-2cb4-4f1c-ad29-8afca4cd8995.png)

```
Для детектирования нажатий значение должно быть в <b>5-10</b> раз меньше,<br>чем время ожидания второго нажатия. На прошивках до 1.19.0 максимально возможное время 250 мс
```