### PR TITLE
Feature/60274 range cell

### DIFF
--- a/app/scripts/directives/rangecell.js
+++ b/app/scripts/directives/rangecell.js
@@ -33,7 +33,6 @@ function rangeCellDirective() {
         });
       }*/
 
-
       /*relayAttr("min", DEFAULT_MIN);
       relayAttr("max", DEFAULT_MAX);
       relayAttr("step", DEFAULT_STEP);*/
@@ -50,9 +49,15 @@ function rangeCellDirective() {
         }
       };*/
 
-      $scope["min"] = !cellCtrl.cell["min"]? DEFAULT_MIN : +cellCtrl.cell["min"];
-      $scope["max"] = !cellCtrl.cell["max"]? DEFAULT_MAX : +cellCtrl.cell["max"];
-      $scope["step"] = !cellCtrl.cell["step"]? DEFAULT_STEP : +cellCtrl.cell["step"];
+      function watchAttr (name, defaultValue) {
+        $scope.$watch(() => cellCtrl.cell[name], newValue => {
+          $scope[name] = !newValue? defaultValue : +newValue;
+        });
+      }
+
+      watchAttr("max", DEFAULT_MAX);
+      watchAttr("min", DEFAULT_MIN);
+      watchAttr("step", DEFAULT_STEP);
 
       $scope.$watch(() => $scope.cell.value, value => {
         $scope._value = isNaN(value)? 0 : value;

--- a/app/scripts/services/devicedata.js
+++ b/app/scripts/services/devicedata.js
@@ -382,7 +382,7 @@ function deviceDataService(mqttClient) {
     setType (type) {
       if(type) {
         const isUnknownType = !cellTypeMap.hasOwnProperty(type)
-        
+
         if(isUnknownType) {
           const cellValue = String(this.value).trim().replace(',', '.');
           const parsedValue = parseFloat(cellValue) || parseInt(cellValue);
@@ -487,7 +487,7 @@ function deviceDataService(mqttClient) {
           this.setExplicitReadOnly(m.readonly);
           this.setType(m.type);
           this.setMin(m.min);
-          this.setMax(m.min);
+          this.setMax(m.max);
           this.setStep(m.precision);
           this.setUnits(m.units);
           this.setOrder(m.order);
@@ -594,7 +594,7 @@ function deviceDataService(mqttClient) {
         handler(payload) { cellFromTopic(topic).setUnits(payload) }
       },{
         handledTopic: cellTopicBase + '/meta/readonly',
-        handler(payload) { 
+        handler(payload) {
           if (payload === '') {
             cellFromTopic(topic).setExplicitReadOnly(null);
           } else if (payload == '1') {
@@ -630,7 +630,7 @@ function deviceDataService(mqttClient) {
 
     subscriptionHandlers.forEach(subscriptionHandler => {
       const { handledTopic, handler } = subscriptionHandler;
-        
+
       if(isTopicsAreEqual(topic, handledTopic)) {
         handler(payload);
       }
@@ -705,15 +705,15 @@ function deviceDataService(mqttClient) {
       const allDeviceTopicBases = allDevicesTopics[deviceId];
 
       // select topics that relate directly to the device sorted by length.
-      // So, first, long device topics (meta) will be deleted, 
+      // So, first, long device topics (meta) will be deleted,
       // and last - the topic of the device itself
       const deviceTopics = allDeviceTopicBases
         .filter(topic => !topic.includes('controls'))
         .sort((a, b) => b.length - a.length)
       const cellsTopics = allDeviceTopicBases
         .filter(topic => !deviceTopics.includes(topic))
-      // move the topics of the device to the end, so that the topics 
-      // of the cells are removed first, and then the device itself  
+      // move the topics of the device to the end, so that the topics
+      // of the cells are removed first, and then the device itself
       const allTopics = cellsTopics.concat(deviceTopics)
 
       allTopics.forEach(topic => {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.63.3) stable; urgency=medium
+
+  * Fix huge value of "range" controls after clearing device's meta topics
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 19 Apr 2023 17:55:12 +0500
+
 wb-mqtt-homeui (2.63.2) stable; urgency=medium
 
   * Fix typos


### PR DESCRIPTION
В rangecell не обновлялись поля ползунка. Симптомы - дефолтное значение (1e9) в поле "max" в неудачных случаях (например, выставив - убрав - выставив снова модуль ao-10-v2; или - удалив buzzer из webui и перезапустив wb-rules).