### PR TITLE
Added ability to use SSL for MQTT connections on port 443

### DIFF
--- a/app/scripts/services/mqttService.js
+++ b/app/scripts/services/mqttService.js
@@ -173,7 +173,11 @@ function mqttClient($window, $timeout, $q, topicMatches, mqttConnectTimeout,
       get: () => MAX_QUEUED_MESSAGES - client.inFlightMessages.length,
     });
 
-    client.connect(angular.copy(connectOptions));
+    try {
+      client.connect(angular.copy(connectOptions));
+    } catch (e) {
+      console.error(e);   
+    }
   };
 
   //...........................................................................

--- a/app/scripts/services/mqttService.js
+++ b/app/scripts/services/mqttService.js
@@ -134,7 +134,7 @@ function mqttClient($window, $timeout, $q, topicMatches, mqttConnectTimeout,
       connectOptions.password = password;
     }
       
-    if(parseInt(port) === 443) {
+    if(parseInt(port) === 443 || location.protocol === 'https:') {
       connectOptions.useSSL = true
     }
 

--- a/app/scripts/services/mqttService.js
+++ b/app/scripts/services/mqttService.js
@@ -133,6 +133,10 @@ function mqttClient($window, $timeout, $q, topicMatches, mqttConnectTimeout,
       connectOptions.userName = user;
       connectOptions.password = password;
     }
+      
+    if(parseInt(port) === 443) {
+      connectOptions.useSSL = true
+    }
 
     id = clientid;
 


### PR DESCRIPTION
Hello, currently, if you try to use reverse proxy with SSL, you will face the issue that HomeUI will still try to use a WS connection over the HTTPS-served page to establish MQTT connection. Such behavior will cause the following error.

```
Mixed Content: The page at 'https://your-domain.com/' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://your-domain:443/mqtt'. This request has been blocked; this endpoint must be available over WSS.
v._doConnect @ main.640d40dd027f9102c521.js:2
```

After examining the code base, I found that the MQTT library supports WSS connection. We need to pass `useSSL` option as `true`.
https://github.com/wirenboard/homeui/blob/f84679fc1a7a4475b7c284a4ac429ec34492accf/app/lib/mqttws31.js#L971

This PR adds the check if the current port is 443 and sets `useSSL` to `true`