### PR TITLE
Fix state display for newly created connections

### DIFF
--- a/app/scripts/react-directives/network-connections/network-connections.js
+++ b/app/scripts/react-directives/network-connections/network-connections.js
@@ -14,9 +14,15 @@ function networkConnectionsDirective(mqttClient, whenMqttReady, ConfigEditorProx
       path: '=',
     },
     link: function (scope, element) {
-      scope.onSave = data => {
-        return ConfigEditorProxy.Save({ path: scope.path, content: data });
+      scope.onSave = async (data, needReload) => {
+        await ConfigEditorProxy.Save({ path: scope.path, content: data });
+        if (needReload) {
+          const res = await ConfigEditorProxy.Load({ path: scope.path });
+          return res.content.ui.connections;
+        }
+        return null;
       };
+
       scope.toggleConnectionState = uuid => {
         mqttClient.send(`/devices/system__networks__${uuid}/controls/UpDown/on`, '1', false);
       };

--- a/app/scripts/react-directives/network-connections/pageStore.js
+++ b/app/scripts/react-directives/network-connections/pageStore.js
@@ -143,10 +143,14 @@ class NetworkConnectionsPageStore {
       },
     };
     try {
-      await this.onSave(jsonToSave);
+      const needToReload = jsonToSave.ui.connections.some(cn => !cn.connection_uuid);
+      const res = await this.onSave(jsonToSave, needToReload);
       this.connections.submit();
       this.switcher.submit();
       this.setLoading(false);
+      if (needToReload) {
+        this.connections.updateUuids(res);
+      }
     } catch (err) {
       this.setError(err.message);
       this.setLoading(false);
@@ -181,23 +185,23 @@ class NetworkConnectionsPageStore {
   }
 
   setConnectionState(connectionUuid, state) {
-    this.connections.findConnection(connectionUuid)?.setState(state);
+    this.connections.setConnectionState(connectionUuid, state);
   }
 
   setConnectionConnectivity(connectionUuid, state) {
-    this.connections.findConnection(connectionUuid)?.setConnectivity(state);
+    this.connections.setConnectionConnectivity(connectionUuid, state);
   }
 
   setConnectionOperator(connectionUuid, state) {
-    this.connections.findConnection(connectionUuid)?.setOperator(state);
+    this.connections.setConnectionOperator(connectionUuid, state);
   }
 
   setConnectionSignalQuality(connectionUuid, state) {
-    this.connections.findConnection(connectionUuid)?.setSignalQuality(state);
+    this.connections.setConnectionSignalQuality(connectionUuid, state);
   }
 
   setConnectionAccessTechnologies(connectionUuid, state) {
-    this.connections.findConnection(connectionUuid)?.setAccessTechnologies(state);
+    this.connections.setConnectionAccessTechnologies(connectionUuid, state);
   }
 
   setError(msg) {

--- a/app/scripts/react-directives/network-connections/singleConnectionStore.js
+++ b/app/scripts/react-directives/network-connections/singleConnectionStore.js
@@ -180,6 +180,10 @@ export class SingleConnection {
     this.isDirty = !isEqual(this.editedData, this.data);
   }
 
+  setUuid(uuid) {
+    this.data.connection_uuid = uuid;
+  }
+
   submit() {
     this.data = cloneDeep(this.editedData);
     this.updateName();

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.69.1) stable; urgency=medium
+
+  * Fix state display for newly created connections
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 21 Jun 2023 11:33:20 +0500
+
 wb-mqtt-homeui (2.69.0) stable; urgency=medium
 
   * Support swipe and long touch/click on SVG dashboards


### PR DESCRIPTION
Для новых соединений нет uuid, т.к. он назначается NetwrokManager'ом. Изменение состояния соединения привязано к uuid. Из-за этого у новых соединений не отображались изменения состояния. Для получения uuid сделал запрос списка соединений после добавления нового.