### PR TITLE
Add lux, sound_level device types

### DIFF
--- a/app/scripts/services/devicedata.js
+++ b/app/scripts/services/devicedata.js
@@ -153,6 +153,18 @@ function deviceDataService(mqttClient, $window) {
       readOnly: true,
       displayType: "value"
     },
+    "lux": {
+      valueType: "number",
+      units: "lx",
+      readOnly: true,
+      displayType: "value"
+    },
+    "sound_level": {
+      valueType: "number",
+      units: "dB",
+      readOnly: true,
+      displayType: "value"
+    },
     "range": {
       valueType: "number",
       readOnly: false,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.70.1) stable; urgency=medium
+
+  * Add lux and sound_level to device data types
+
+ -- Ekaterina Volkova <wekaterina.volkova@wirenboard.ru>  Wed, 21 Jun 2023 17:18:44 +0300
+
 wb-mqtt-homeui (2.70.0) stable; urgency=medium
 
   * No functional changes


### PR DESCRIPTION
При добавлении устройства или рестарте serial получалось, что строчки с освещением и уровнем шума считались текстовыми по умолчанию, так как в схеме соответствия типа устройства и типа отображения не было ничего задано про lux и sound_level. При обновлении страницы поля меняли тип отоборажения с text на value - менялось положение чисел.
Добоавила в схему, теперь сразу все нормально
![изображение](https://github.com/wirenboard/homeui/assets/97599621/131f94f2-e6db-4013-add4-2f579e934e1d)
![изображение](https://github.com/wirenboard/homeui/assets/97599621/79aa0784-1e7c-4ffc-8bac-d21ac7546043)
