### PR TITLE
Fit SVG to page height in dashboard editor

### DIFF
--- a/app/styles/css/svg-edit-page.css
+++ b/app/styles/css/svg-edit-page.css
@@ -31,6 +31,12 @@
     align-items: center;
 }
 
+@media (min-width: 992px) {
+    .svg-edit-page .svg-edit-left-panel {
+        height: calc(100vh - 150px);
+    }
+}
+
 .svg-edit-page .svg-edit-left-panel button{
     margin-top: 10px;
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.72.1) stable; urgency=medium
+
+  * Fit SVG to page height in dashboard editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 30 Jun 2023 10:59:54 +0500
+
 wb-mqtt-homeui (2.72.0) stable; urgency=medium
 
   * Format source code. No functional changes


### PR DESCRIPTION
Было
![image](https://github.com/wirenboard/homeui/assets/86825564/1c8903d0-f999-4ac9-bad2-101f9409dfb5)


Стало
![image](https://github.com/wirenboard/homeui/assets/86825564/f2aa5812-7eee-41d1-bd42-3cb980cbc9c5)
