### PR TITLE
Add homepage to deb package info

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.2) stable; urgency=medium
+
+  * Add homepage to deb package info. No functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 25 Jul 2023 16:34:00 +0400
+
 wb-mqtt-homeui (2.75.1) stable; urgency=medium
 
   * Fix displaying of SVG dashboard elements with set visible condition

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 10), pkg-config, nodejs (>= 16)
+Homepage: https://github.com/wirenboard/homeui
 
 Package: wb-mqtt-homeui
 Architecture: all


### PR DESCRIPTION
`wbci-changelog` uses `Homepage` from `deb/control`:

<img width="914" alt="Näyttökuva 2023-7-25 kello 18 06 07" src="https://github.com/wirenboard/homeui/assets/688044/0655332f-cf87-4401-819f-45d8b16ee21e">
