### PR TITLE
Fix loss of focus when editing fields in the mobile version

### DIFF
--- a/app/scripts/controllers/devicesController.js
+++ b/app/scripts/controllers/devicesController.js
@@ -26,9 +26,15 @@ class DevicesCtrl {
 
     const deviceIdFromUrl = this.parseDeviceIdFromUrl($injector);
 
+    $scope.windowWidth = window.innerWidth;
     // this listener needed to redraw columns and devices on window resize.
     $(window).resize(() => {
-      this.$state.devicesIdsCount = 0;
+      // Only width changing can cause redraw
+      // Height changing can be a result of onscreen keyboard display
+      if (window.innerWidth != $scope.windowWidth) {
+        $scope.windowWidth = window.innerWidth;
+        this.$state.devicesIdsCount = 0;
+      }
     });
 
     $scope.$locale = $locale;

--- a/app/scripts/react-directives/script-editor/scriptEditor.jsx
+++ b/app/scripts/react-directives/script-editor/scriptEditor.jsx
@@ -8,14 +8,15 @@ const ScriptEditor = observer(({ text, errorLine, onChange }) => {
   const [scrolled, setScrolled] = useState(false);
   const refCallback = ref => {
     if (!scrolled && errorLine != null && ref?.view) {
-      try {
-        const line = ref.view.state.doc.line(errorLine);
-        ref.view.dispatch({
-          selection: EditorSelection.single(line.from, line.to),
-          scrollIntoView: true,
-        });
-        setScrolled(true);
-      } catch (err) {}
+      if (errorLine > ref.view.state.doc.lines) {
+        errorLine = ref.view.state.doc.lines;
+      }
+      const line = ref.view.state.doc.line(errorLine);
+      ref.view.dispatch({
+        selection: EditorSelection.single(line.from, line.to),
+        scrollIntoView: true,
+      });
+      setScrolled(true);
     }
   };
 

--- a/app/scripts/react-directives/script-editor/scriptEditor.jsx
+++ b/app/scripts/react-directives/script-editor/scriptEditor.jsx
@@ -8,12 +8,14 @@ const ScriptEditor = observer(({ text, errorLine, onChange }) => {
   const [scrolled, setScrolled] = useState(false);
   const refCallback = ref => {
     if (!scrolled && errorLine != null && ref?.view) {
-      setScrolled(true);
-      const line = ref.view.state.doc.line(errorLine);
-      ref.view.dispatch({
-        selection: EditorSelection.single(line.from, line.to),
-        scrollIntoView: true,
-      });
+      try {
+        const line = ref.view.state.doc.line(errorLine);
+        ref.view.dispatch({
+          selection: EditorSelection.single(line.from, line.to),
+          scrollIntoView: true,
+        });
+        setScrolled(true);
+      } catch (err) {}
     }
   };
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.5) stable; urgency=medium
+
+  * Fix loss of focus when editing fields in the mobile version 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 04 Aug 2023 14:42:08 +0500
+
 wb-mqtt-homeui (2.75.4) stable; urgency=medium
 
   * Fix menu overlay hiding in mobile mode


### PR DESCRIPTION
On Android devices showing of onscreen keyboard causes height change and resize event. Unexpected resizing will cause focus loss. So redraw only on width change

Видео бага тут
https://wirenboard.bitrix24.ru/company/personal/user/134/tasks/task/view/64886/