### PR TITLE
Move help page content to translations

### DIFF
--- a/app/scripts/i18n/help/en.json
+++ b/app/scripts/i18n/help/en.json
@@ -1,12 +1,6 @@
 {
     "help": {
         "title": "Help",
-        "list": {
-            "forum": "Technical support",
-            "docs": "Documentation"
-        },
-        "url": {
-            "docs": "https://wirenboard.com/wiki/Documentation/en"
-        }
+        "content": "<ul><li><a href=\"https://wirenboard.com/wiki/Documentation/en\" target=\"_blank\" translate>Documentation</a></li><li><a href=\"https://support.wirenboard.com\" target=\"_blank\" translate=\"\">Technical support</a></li></ul>"
     }
 }

--- a/app/scripts/i18n/help/ru.json
+++ b/app/scripts/i18n/help/ru.json
@@ -1,12 +1,6 @@
 {
     "help": {
         "title": "Помощь",
-        "list": {
-            "forum": "Портал техподдержки",
-            "docs": "Документация"
-        },
-        "url": {
-            "docs": "https://wirenboard.com/wiki/Documentation/ru"
-        }
+        "content": "<ul><li><a href=\"https://wirenboard.com/wiki/Documentation/ru\" target=\"_blank\" translate>Документация</a></li><li><a href=\"https://support.wirenboard.com\" target=\"_blank\" translate=\"\">Портал техподдержки</a></li></ul>"
     }
 }

--- a/app/views/help.html
+++ b/app/views/help.html
@@ -1,12 +1,3 @@
 
 <h1 class="page-header" translate>{{'help.title'}}</h1>
-<div class="scripts">
-    <ul>
-        <li>
-            <a href="{{'help.url.docs' | translate}}" target="_blank" translate>{{'help.list.docs'}}</a>
-        </li>
-        <li>
-            <a href="https://support.wirenboard.com" target="_blank" translate="">{{'help.list.forum'}}</a>
-        </li>
-    </ul>
-</div>
+<div class="scripts" translate>{{'help.content'}}</div>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.6) stable; urgency=medium
+
+  * Move help page content to translations
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 04 Aug 2023 17:00:00 +0400
+
 wb-mqtt-homeui (2.75.5) stable; urgency=medium
 
   * Edited Wiren Board 7 SVG Dashboard


### PR DESCRIPTION
В кастомных сборках нам надо иметь возможность поменять информацию на help страничке без пересборки homeui. Сейчас это все находится в скомпиленом `main.*.js` и в переводах, и подменить help таким образом не просто. С этим же изменением достаточно будет заменить `help.content` в json файле c переводами.