### PR TITLE
Fix editor for not required parameters

### DIFF
--- a/app/scripts/json-editor/group-editor.js
+++ b/app/scripts/json-editor/group-editor.js
@@ -711,7 +711,11 @@ function makeGroupsEditor() {
           ret.build();
           ret.postBuild();
           ret.setOptInCheckbox(ret.header);
-          if (this.checkRequired(key, ed) || this.checkDefault(key)) {
+          if (
+            this.checkRequired(key, ed) ||
+            this.checkDefault(key) ||
+            ed.schema?.options?.show_opt_in
+          ) {
             ret.activate();
             ed.show();
           } else {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.10) stable; urgency=medium
+
+  * Fix editor for not required parameters in devices configs
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 13 Sep 2023 11:06:02 +0500
+
 wb-mqtt-homeui (2.75.9) stable; urgency=medium
 
   * Fix fractional value parsing


### PR DESCRIPTION
Для параметров из шаблонов устройств, у которых не стоял признак, что они обязательные, не рисовался редактор.

Теперь рисуется
![Screenshot_20230913_114429](https://github.com/wirenboard/homeui/assets/86825564/97cd1670-0c93-43a2-a499-7d57ebb261e7)
