### PR TITLE
Fix can connection saving

### DIFF
--- a/app/scripts/react-directives/network-connections/connectionsStore.js
+++ b/app/scripts/react-directives/network-connections/connectionsStore.js
@@ -136,6 +136,9 @@ class Connections {
 
   updateUuids(connectionsFromJson) {
     connectionsFromJson.forEach(cn => {
+      if (cn.connection_uuid === undefined) {
+        return;
+      }
       let res = this.findConnection(cn.connection_uuid);
       if (!res) {
         res = this.connections.find(

--- a/app/scripts/react-directives/network-connections/connectionsStore.js
+++ b/app/scripts/react-directives/network-connections/connectionsStore.js
@@ -136,9 +136,6 @@ class Connections {
 
   updateUuids(connectionsFromJson) {
     connectionsFromJson.forEach(cn => {
-      if (cn.connection_uuid === undefined) {
-        return;
-      }
       let res = this.findConnection(cn.connection_uuid);
       if (!res) {
         res = this.connections.find(

--- a/app/scripts/react-directives/network-connections/singleConnectionStore.js
+++ b/app/scripts/react-directives/network-connections/singleConnectionStore.js
@@ -181,7 +181,9 @@ export class SingleConnection {
   }
 
   setUuid(uuid) {
-    this.data.connection_uuid = uuid;
+    if (this.managedByNM) {
+      this.data.connection_uuid = uuid;
+    }
   }
 
   submit() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.11) stable; urgency=medium
+
+  * Fix can connection saving
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 18 Sep 2023 13:20:00 +0400
+
 wb-mqtt-homeui (2.75.10) stable; urgency=medium
 
   * Fix editor for not required parameters in devices configs


### PR DESCRIPTION
1. Изменить can соединение
2. Сохранить => появляется connection_uuid поле
3. Перейти к другому соединению => получим "Есть несохранённые изменения"

<img width="1190" alt="Näyttökuva 2023-9-18 kello 13 35 56" src="https://github.com/wirenboard/homeui/assets/688044/b3ddee2d-33d4-4948-b118-02ce3e36003f">
