### PR TITLE
Fix uploading fit-image

### DIFF
--- a/app/scripts/controllers/backupController.js
+++ b/app/scripts/controllers/backupController.js
@@ -2,11 +2,9 @@ class BackupCtrl {
   constructor($scope) {
     'ngInject';
 
-    $scope.btnVisible = true;
     $scope.btnEnabled = true;
 
     var downloadRootfs = function () {
-      window.location.href = 'fwupdate/download/rootfs';
       $scope.btnEnabled = false;
     };
 

--- a/app/scripts/controllers/diagnosticController.js
+++ b/app/scripts/controllers/diagnosticController.js
@@ -8,6 +8,7 @@ class DiagnosticCtrl {
     $scope.collecting = false;
     $scope.pathMessage = false;
     $scope.text = '';
+    $scope.href = '';
 
     $scope.path = undefined;
     $scope.basename = undefined;
@@ -29,7 +30,7 @@ class DiagnosticCtrl {
       if (contentType == 'application/zip') {
         $scope.btnEnabled = true;
         changeBtnText('collector.buttons.download');
-        $scope.btnMethod = downloadDiag;
+        $scope.href = 'diag/' + $scope.basename;
       } else {
         $scope.btnVisible = false;
         $scope.pathMessage = true;
@@ -80,11 +81,6 @@ class DiagnosticCtrl {
           changeBtnText('collector.errors.timeout');
         }
       );
-    };
-
-    var downloadDiag = function () {
-      var filename = $scope.basename;
-      window.location.href = 'diag/' + filename;
     };
 
     $scope.btnMethod = diag;

--- a/app/views/system.html
+++ b/app/views/system.html
@@ -15,8 +15,7 @@
             <li>{{'backup.rootfs_warning2' | translate}}</li>
             <li>{{'backup.rootfs_warning3' | translate}}</li>
         </ul>
-        <a type="button" class="btn btn-success btn-lg pull-left" ng-click="btnMethod()" ng-disabled="!btnEnabled"
-            ng-show="btnVisible">
+        <a type="button" class="btn btn-success btn-lg pull-left" ng-href="fwupdate/download/rootfs" ng-disabled="!btnEnabled" download>
             <i class="glyphicon glyphicon-save"></i> <span>{{'backup.download_rootfs_button' | translate}}</span>
         </a>
 
@@ -36,9 +35,15 @@
         </div>
 
         <button type="button" class="btn btn-success btn-lg pull-left" ng-click="btnMethod()" ng-disabled="!btnEnabled"
-            ng-show="btnVisible" translate>
+            ng-if="!href" ng-show="btnVisible" translate>
             {{ text }}
         </button>
+
+        <a type="button" class="btn btn-success btn-lg pull-left" ng-href="{{href}}" ng-disabled="!btnEnabled"
+            ng-if="href" ng-show="btnVisible" download>
+            {{ text }}
+        </a>
+
         <div class="col-xs-1" ng-show="collecting">
             <span class="spinner-loader"></span>
         </div>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.12) stable; urgency=medium
+
+  * Fix downloading diagnostic archive simultaneously with uploading fit-image
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 03 Oct 2023 10:03:47 +0500
+
 wb-mqtt-homeui (2.75.11) stable; urgency=medium
 
   * Fix can connection saving


### PR DESCRIPTION
Fix downloading diagnostic archive simultaneously with uploading fit-image

Если загружать fit в контроллер и в тот же самый момент скачать диагностический архив или rootfs, загрузка fit'а прервётся. Проблема была в том, что все загрузки делались через смену location, а это приводило к полной перезагрузке страницы