### PR TITLE
Remove bottom padding in hmi mode

### DIFF
--- a/app/styles/css/svg-view-page.css
+++ b/app/styles/css/svg-view-page.css
@@ -61,7 +61,7 @@
 }
 
 @media (max-width: 767px) {
-    .svg-view-page {
+    body:not(.hmi) .svg-view-page {
         padding-bottom: 5px;
     }
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.16) stable; urgency=medium
+
+  * Remove bottom padding in hmi mode
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 09 Nov 2023 14:58:02 +0500
+
 wb-mqtt-homeui (2.75.15) stable; urgency=medium
 
   * Add legacy current control type


### PR DESCRIPTION
Убрал лишние белые границы на низких разрешениях в hmi режиме

![image](https://github.com/wirenboard/homeui/assets/86825564/c9a67952-4853-4b28-97b9-f35185d5175a)
