### PR TITLE
Remove bottom padding in hmi mode (#487)

### DIFF
--- a/app/styles/css/svg-view-page.css
+++ b/app/styles/css/svg-view-page.css
@@ -61,7 +61,7 @@
 }
 
 @media (max-width: 767px) {
-    .svg-view-page {
+    body:not(.hmi) .svg-view-page {
         padding-bottom: 5px;
     }
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.75.14-wb100) stable; urgency=medium
+
+  * Remove bottom padding in hmi mode
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 09 Nov 2023 14:58:02 +0500
+
 wb-mqtt-homeui (2.75.14) stable; urgency=medium
 
   * Add wb74 config


### PR DESCRIPTION
Backport of https://github.com/wirenboard/homeui/pull/487