### PR TITLE
Fix SVG bindings parameters editor

### DIFF
--- a/app/scripts/react-directives/edit-svg-dashboard/editSvgDashboardPage.jsx
+++ b/app/scripts/react-directives/edit-svg-dashboard/editSvgDashboardPage.jsx
@@ -117,8 +117,8 @@ export const SwipeParametersForm = observer(({ store }) => {
       <FormCheckbox key={store.params.enable.id} store={store.params.enable} />
       {store.params.enable.value && (
         <>
-          <FormSelect store={store.params.left} />
-          <FormSelect store={store.params.right} />
+          <FormSelect store={store.params.left} isClearable={true} />
+          <FormSelect store={store.params.right} isClearable={true} />
         </>
       )}
     </div>

--- a/app/scripts/react-directives/edit-svg-dashboard/visualBindingsEditor.jsx
+++ b/app/scripts/react-directives/edit-svg-dashboard/visualBindingsEditor.jsx
@@ -41,10 +41,10 @@ export const VisibleBindingForm = observer(({ store }) => {
         <>
           <FormSelect store={store.params.channel} />
           <BootstrapRow>
-            <div className="col-xs-6 col-sm-3 col-md-2 col-lg-2">
+            <div className="col-xs-6 col-sm-3 col-md-4 col-lg-3">
               <FormSelect store={store.params.condition} />
             </div>
-            <div className="col-sx-6 col-sm-9 col-md-10 col-lg-10">
+            <div className="col-sx-6 col-sm-9 col-md-8 col-lg-9">
               <FormStringEdit store={store.params.value} />
             </div>
           </BootstrapRow>

--- a/app/scripts/react-directives/forms/forms.jsx
+++ b/app/scripts/react-directives/forms/forms.jsx
@@ -63,7 +63,7 @@ export const FormCheckbox = observer(({ store }) => {
   );
 });
 
-export const FormSelect = observer(({ store }) => {
+export const FormSelect = observer(({ store, isClearable }) => {
   const withGroups = store.options.some(el => 'options' in el);
   const borderColor = store.hasErrors ? '#b94a48' : '#ccc';
   const customStyles = {
@@ -125,7 +125,7 @@ export const FormSelect = observer(({ store }) => {
       <Select
         options={store.options}
         isSearchable={true}
-        isClearable={true}
+        isClearable={isClearable}
         value={store.selectedOption}
         styles={customStyles}
         placeholder={store.placeholder}

--- a/app/scripts/react-directives/forms/optionsStore.js
+++ b/app/scripts/react-directives/forms/optionsStore.js
@@ -41,6 +41,8 @@ export class OptionsStore {
     });
     if (this.strict) {
       this.hasErrors = !this.selectedOption;
+    } else {
+      this.hasErrors = false;
     }
   }
 
@@ -50,8 +52,7 @@ export class OptionsStore {
   }
 
   setSelectedOption(option) {
-    this.setValue(option ? option.value : null);
     this.selectedOption = option;
-    this.hasErrors = false;
+    this.setValue(option ? option.value : null);
   }
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.75.20) stable; urgency=medium
+
+  * Fix SVG bindings parameters editor layout on medium screens
+  * Remove clear button from option selects in SVG bindings parameters editor 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 10 Nov 2023 17:39:21 +0500
+
 wb-mqtt-homeui (2.75.19) stable; urgency=medium
 
   * Preserve focus after saving in rules editor


### PR DESCRIPTION
  * Fix SVG bindings parameters editor layout on medium screens
  * Remove clear button from option selects in SVG bindings parameters editor

Было
![image](https://github.com/wirenboard/homeui/assets/86825564/cd2f6937-29b3-4afb-8a0b-fbf7de939a8b)

Стало
![image](https://github.com/wirenboard/homeui/assets/86825564/af7be729-a582-46c5-983f-cbcf1258be93)
