### PR TITLE
css: fix History input box overlapping

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -812,6 +812,7 @@ button.show-console span {
 
 .history-time-col-r {
     padding-top: 34px;
+    padding-left: 2em;
 }
 
 .jarviswidget > div {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.76.2) stable; urgency=medium
+
+  * Css: fix "History" input box overlapping
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 21 Nov 2023 19:21:12 +0500
+
 wb-mqtt-homeui (2.76.1) stable; urgency=medium
 
   * Fix translation


### PR DESCRIPTION
было

https://github.com/wirenboard/homeui/assets/25829054/63c0482b-917a-4100-88da-9d4b70e34955

стало

https://github.com/wirenboard/homeui/assets/25829054/9e2665f1-3a95-4efb-b784-d58673df70ac


