### PR TITLE
fix diag-collect "download" button, if connected via cloud

### DIFF
--- a/app/scripts/controllers/diagnosticController.js
+++ b/app/scripts/controllers/diagnosticController.js
@@ -74,7 +74,7 @@ class DiagnosticCtrl {
           $scope.path = names['fullname'];
           $scope.basename = names['basename'];
           var url = getUrl();
-          fileIsOk('http://' + url + '/diag/' + $scope.basename, callbackFileIsOk);
+          fileIsOk(location.protocol + '//' + url + '/diag/' + $scope.basename, callbackFileIsOk);
         },
         err => {
           $scope.collecting = false;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.78.1) stable; urgency=medium
+
+  * Fix diag-collect "download" button, if connected via cloud
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 07 Dec 2023 10:21:21 +0500
+
 wb-mqtt-homeui (2.78.0) stable; urgency=medium
 
   * Add update with reset button to system options page


### PR DESCRIPTION
не работал diag-collect, если ходить через клауд
симптомы - крутилка крутится, и ничего не происходит

было:

https://github.com/wirenboard/homeui/assets/25829054/b8a66761-6ae9-44d8-9179-ac2a0f487f36

стало:

https://github.com/wirenboard/homeui/assets/25829054/c8df1bcd-b83f-4133-a672-69f2172311f8


без клауда - тоже чекнул; не сломалось