### PR TITLE
Add WB Cloud widget for wb-2207 release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildDebArchAll defaultDebianRelease: 'stretch'
+buildDebSbuild defaultTargets: 'stretch-host'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PATH := /usr/local/bin:$(PATH)
 all: build
 
 clean:
-	npm run clean
+	if [ -n "$(SCHROOT_SESSION_ID)" ]; then npm install rimraf; npm run clean ; fi
 
 build:
 	# FIXME: this replaces git:// with https:// somewhere in node modules

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -65,6 +65,7 @@ import MQTTCtrl from './controllers/MQTTChannelsController';
 import AccessLevelCtrl from './controllers/accessLevelController';
 import DateTimePickerModalCtrl from './controllers/dateTimePickerModalController';
 import DiagnosticCtrl from './controllers/diagnosticController';
+import CloudWidgetCtrl from './controllers/cloudWidgetController';
 
 // homeui modules: directives
 import cellDirective from './directives/cell';
@@ -185,7 +186,8 @@ module
     .controller('MQTTCtrl', MQTTCtrl)
     .controller('AccessLevelCtrl', AccessLevelCtrl)
     .controller('DateTimePickerModalCtrl', DateTimePickerModalCtrl)
-    .controller('DiagnosticCtrl', DiagnosticCtrl);
+    .controller('DiagnosticCtrl', DiagnosticCtrl)
+    .controller('CloudWidgetCtrl', CloudWidgetCtrl);
 
 module
     .controller('NavigationCtrl', NavigationCtrl)

--- a/app/scripts/controllers/cloudWidgetController.js
+++ b/app/scripts/controllers/cloudWidgetController.js
@@ -1,0 +1,31 @@
+class CloudWidgetCtrl {
+  constructor($scope, mqttClient) {
+    'ngInject';
+
+    $scope.cloudAvailable = false;
+    $scope.cloudOk = false;
+    $scope.cloudError = null;
+    $scope.activationLink = null;
+    $scope.cloudLink = "https://wirenboard.cloud/";
+
+    mqttClient.addStickySubscription('/devices/system__wb-cloud-agent/controls/status', function(msg) {
+      if (msg.payload == "") {
+        $scope.cloudAvailable = false;
+      } else {
+        $scope.cloudAvailable = true;
+        $scope.cloudOk = (msg.payload == "ok");
+        $scope.cloudError = (msg.payload == "ok") ? null : msg.payload;
+      }
+    });
+
+    mqttClient.addStickySubscription('/devices/system__wb-cloud-agent/controls/activation_link', function(msg) {
+      $scope.activationLink = (msg.payload.startsWith("http")) ? msg.payload : null;
+    });
+
+    mqttClient.addStickySubscription('/devices/system/controls/Short SN', function(msg) {
+      $scope.cloudLink = "https://wirenboard.cloud/controllers/" + msg.payload;
+    });
+  }
+}
+
+export default CloudWidgetCtrl;

--- a/app/scripts/i18n/system/en.json
+++ b/app/scripts/i18n/system/en.json
@@ -19,6 +19,14 @@
             "reboot": "Rebooting, please wait",
             "uploading": "Uploading firmware file",
             "uploaded": "Upload complete"
+        },
+        "cloud-status": {
+            "title": "Cloud status",
+            "activation-link-preamble": "To connect this Wiren Board to cloud, press",
+            "activation-link": "this link",
+            "status-ok": "Connected to cloud",
+            "status-error": "Cloud connection error",
+            "goto-cloud": "Open this controller in cloud"
         }
     },
     "collector": {

--- a/app/scripts/i18n/system/ru.json
+++ b/app/scripts/i18n/system/ru.json
@@ -19,6 +19,14 @@
             "reboot": "Перезагрузка, пожалуйста, подождите",
             "uploading": "Файл прошивки загружается",
             "uploaded": "Загрузка завершена"
+        },
+        "cloud-status": {
+            "title": "Подключение к облаку",
+            "activation-link-preamble": "Почти готово! Для подключения контроллера к Wiren Board Cloud, нажмите",
+            "activation-link": "эту ссылку",
+            "status-ok": "Этот контроллер подключен к облаку",
+            "status-error": "Ошибка подключения к облаку",
+            "goto-cloud": "Перейти в Wiren Board Cloud"
         }
     },
     "collector": {

--- a/app/views/system.html
+++ b/app/views/system.html
@@ -1,6 +1,30 @@
 
 <h1 class="page-header" translate>{{'system.title'}}</h1>
 
+<div ng-controller="CloudWidgetCtrl">
+    <div class="panel panel-default" ng-if="cloudAvailable">
+        <div class="panel-heading">
+            <h3 class="panel-title"><i class="glyphicon glyphicon-cloud"></i> {{'system.cloud-status.title' | translate}}</h3>
+        </div>
+        <div class="panel-body">
+            <div ng-show="cloudOk && !activationLink">
+                <div class="alert alert-success">
+                    <i class="glyphicon glyphicon-ok"></i> {{'system.cloud-status.status-ok' | translate}}
+                </div>
+                <a href="{{cloudLink}}" target="_blank" class="btn btn-success btn-lg">
+                    <i class="glyphicon glyphicon-cloud"></i> {{'system.cloud-status.goto-cloud' | translate}}
+                </a>
+            </div>
+            <div class="alert alert-danger" ng-show="!cloudOk">
+                <i class="glyphicon glyphicon-remove"></i> {{'system.cloud-status.status-error' | translate}}: {{cloudError}}
+            </div>
+            <div class="alert alert-info" ng-show="activationLink && cloudOk">
+                {{'system.cloud-status.activation-link-preamble' | translate}} <a href="{{activationLink}}" target="_blank" class="alert-link">{{'system.cloud-status.activation-link' | translate}}</a>
+            </div>
+        </div>
+    </div>
+</div>
+
 <div class="panel panel-default" ng-controller="FirmwareCtrl">
     <div class="panel-heading">
         <h3 class="panel-title"><i class="glyphicon glyphicon-upload"></i> {{'system.update.title' | translate}}</h3>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.44.4-wb101) stable; urgency=medium
+
+  * Add Wiren Board cloud widget
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 07 Dec 2023 16:20:25 +0600
+
 wb-mqtt-homeui (2.44.4-wb100) stable; urgency=medium
 
   * Fix MAI6 config editing

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,8 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), pkg-config, nodejs (<< 13), npm, node-rimraf
+Build-Depends: debhelper (>= 9), pkg-config, nodejs-12
+Build-Conflicts: nodejs (> 12)
 
 Package: wb-mqtt-homeui
 Architecture: all

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "A workflow for Angular made with Webpack",
   "scripts": {
-    "clean": "rimraf dist coverage ./tmp",
-    "build": "rimraf dist && webpack --bail --progress --profile",
+    "clean": "rimraf -G dist coverage ./tmp",
+    "build": "rimraf -G dist && webpack --bail --progress --profile",
     "server": "webpack-dev-server --history-api-fallback --inline --progress",
-    "test": "rimraf coverage && karma start karma_ci.conf.js",
+    "test": "rimraf -G coverage && karma start karma_ci.conf.js",
     "test-watch": "karma start karma_dev.conf.js",
     "start": "npm run server",
     "start-dist": "cd ./dist && python3 ../test/dist_server.py "


### PR DESCRIPTION
Переписал виджет из #492 на чистый angularjs, сразу добавил переход по ссылке на страницу текущего контроллера.

Зависит от https://github.com/wirenboard/wb-cloud-agent/pull/6

Testing set: `deb http://deb.wirenboard.com/all experimental.cloud-2207 main`