### PR TITLE
Fix optional parameter overlay in json-editor

### DIFF
--- a/app/scripts/json-editor/disabled-editor-wrapper.js
+++ b/app/scripts/json-editor/disabled-editor-wrapper.js
@@ -7,14 +7,9 @@ function makeDisabledEditorWrapper(Base) {
       this.disabledEditor = this.theme.getFormInputField(this.input_type);
       this.disabledEditor.style.display = 'none';
       this.disabledEditor.disabled = true;
-      if (
-        this.schema.options &&
-        this.schema.options.inputAttributes &&
-        this.schema.options.inputAttributes.placeholder
-      ) {
-        this.disabledEditor.value = this.translateProperty(
-          this.schema.options.inputAttributes.placeholder
-        );
+      var disabledEditorText = this?.schema?.options?.wb?.disabledEditorText;
+      if (disabledEditorText) {
+        this.disabledEditor.value = this.translateProperty(disabledEditorText);
       } else {
         this.disabledEditor.value = this.translate('unknown');
       }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.78.3) stable; urgency=medium
+
+  * Fix optional parameters display in network connections settings
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 20 Dec 2023 10:04:02 +0500
+
 wb-mqtt-homeui (2.78.2) stable; urgency=medium
 
   * Cloud link points to the device


### PR DESCRIPTION
Use wb.disabledEditorText instead of inputAttributes.placeholder as a source for disabled optional parameter overlay text

При редактировании параметров в json-editor, можно указать, что необязательный параметр рисуется с чекбоксом. Если чекбокс отмечен, активируется редактор для этого параметра. Если чекбокс не отмечен, то редактор делается неактивным. Для некоторых редакторов можно прописать текст, который будет отображаться поверх неактивного редактора. Текст брался из схемы параметра из inputAttributes.placeholder. Всё это наша доработка, а не стандартный функционал json-editor'а. Этот же текст используется для самого редактора, если ничего не задано. Оказалось, что это нудобно, и надо иметь разные тексты.
Добавил wb.disabledEditorText, в котором можно указать текст оверлея

![Screenshot_20231220_101456](https://github.com/wirenboard/homeui/assets/86825564/fe1a2983-2ed9-47d2-ade5-f74cefae4cae)

![Screenshot_20231220_101526](https://github.com/wirenboard/homeui/assets/86825564/7f217580-f875-4786-8e52-1e42b039f8e3)

В старой реализации в пустом поле бы выводилось серым `автоматически`