### PR TITLE
Fix json-editor groups-editor groups display

### DIFF
--- a/app/scripts/json-editor/group-editor.js
+++ b/app/scripts/json-editor/group-editor.js
@@ -377,6 +377,10 @@ function makeGroupsEditor() {
     preBuildEditors() {
       Object.entries(this.schema.properties).forEach(([key, schema]) => {
         var group = this.groups.get(schema.group);
+        // schema.group is not declared in groups array, use root group
+        if (!group) {
+          group = this.groups.get(undefined);
+        }
         group.addEditor(key, this.storeEditor(key, undefined, group, schema));
       });
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.78.5) stable; urgency=medium
+
+  * Fix display of wb-mqtt-serial device configurations with incorrectly defined groups in template 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 19 Jan 2024 15:03:01 +0500
+
 wb-mqtt-homeui (2.78.4) stable; urgency=medium
 
   * Add coloring of urri controls in red in case of error


### PR DESCRIPTION
If a group in parameter is not defined in groups array show the parameter in root group