### PR TITLE
Fix displaying of cells with long text

### DIFF
--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -1,3 +1,4 @@
+import angular from 'angular';
 import template from './displaycell.html';
 
 function displayCellDirective(displayCellConfig, $compile) {
@@ -78,9 +79,13 @@ function displayCellDirective(displayCellConfig, $compile) {
           ).directive;
 
           $compile('<' + directive + '></' + directive + '>')(scope, clonedElement => {
-            angular
-              .element(element[0].querySelector('.display-cell-content').children[0])
-              .replaceWith(clonedElement);
+            let element_wrapper = element[0].querySelector('.display-cell-content');
+            if (displayType == 'text') {
+              element_wrapper.style.overflowX = 'scroll';
+            } else {
+              element_wrapper.style.overflowX = null;
+            }
+            angular.element(element_wrapper.children[0]).replaceWith(clonedElement);
           });
         }
       );

--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -1,4 +1,3 @@
-import angular from 'angular';
 import template from './displaycell.html';
 
 function displayCellDirective(displayCellConfig, $compile) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.78.5) stable; urgency=medium
+
+  * Fix displaying of cells with long text
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 22 Jan 2024 15:47:00 +0500
+
 wb-mqtt-homeui (2.78.4) stable; urgency=medium
 
   * Add coloring of urri controls in red in case of error


### PR DESCRIPTION
![image](https://github.com/wirenboard/homeui/assets/86825564/7ecc607d-0f85-4a46-a76f-50c2fea5693c)

Раньше за отображение текста отвечал div с классом text-cell, в котором есть overflow-x: auto. Это добавляло длинному тексту скролл по ширине. 
[Тут](https://github.com/wirenboard/homeui/pull/434) обернули всё в ещё один div. Этот div просто расширяется на всю длину текста. Пришлось прописывать ему явно overflow-x

А почему бы не воткнуть overflow-x в класс display-cell-content? У нас странная вёрстка ячеек с числовым значением и единицами измерения. Единицы измерения ограничены шириной в 20px и фактически часто сейчас переполняются. Если сделать overflow-x в класс, у таких ячеек тоже появится скролл.

Вот так
![image](https://github.com/wirenboard/homeui/assets/86825564/61486104-f11b-4a09-9d3d-059121d8a7a1)
