### PR TITLE
Fix displaying of cells with long text in Chrome

### DIFF
--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -80,7 +80,7 @@ function displayCellDirective(displayCellConfig, $compile) {
           $compile('<' + directive + '></' + directive + '>')(scope, clonedElement => {
             let element_wrapper = element[0].querySelector('.display-cell-content');
             if (displayType == 'text') {
-              element_wrapper.style.overflowX = 'scroll';
+              element_wrapper.style.overflowX = 'auto';
             } else {
               element_wrapper.style.overflowX = null;
             }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.78.9) stable; urgency=medium
+
+  * Fix displaying of cells with long text in Chrome-based browsers
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 25 Jan 2024 10:43:45 +0500
+
 wb-mqtt-homeui (2.78.8) stable; urgency=medium
 
   * Handle network configuration save errors


### PR DESCRIPTION
Chrome принудительно рисует скрол, даже если текст помещается. Убрал это поведение

![image_2024-01-25_09-34-45](https://github.com/wirenboard/homeui/assets/86825564/540fcca4-8ec4-4da1-8e29-1968c08bcfb0)
 