### PR TITLE
fix link to FIT image repo in Bullseye advert

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -141,7 +141,7 @@
                           <span style="font-weight: bold">{{'heading.bullseyeNotice1' | translate}}</span>
                           <span>{{'heading.bullseyeNotice2' | translate}}</span>
                           <span style="font-weight: bold">wb-release --update-debian-release</span>
-                          <span>{{'heading.bullseyeNotice3' | translate}} <a href="http://fw-releases.wirenboard.com/?prefix=fit_image/testing">{{'heading.bullseyeNotice4' | translate}}</a> {{'heading.bullseyeNotice5' | translate}} <a href="#!/system">{{'heading.bullseyeNotice6' | translate}}</a></span>
+                          <span>{{'heading.bullseyeNotice3' | translate}} <a href="http://fw-releases.wirenboard.com/?prefix=fit_image">{{'heading.bullseyeNotice4' | translate}}</a> {{'heading.bullseyeNotice5' | translate}} <a href="#!/system">{{'heading.bullseyeNotice6' | translate}}</a></span>
                         </div>
                         <% } %>
                       <!-- viewport for child view -->

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.44.4-wb102-upgrade3) stable; urgency=medium
+
+  * Fix link to FIT image repo in Bullseye advert
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Wed, 14 Feb 2024 20:00:10 +0600
+
 wb-mqtt-homeui (2.44.4-wb102-upgrade2) stable; urgency=medium
 
   * Fix web ui in cloud


### PR DESCRIPTION
Пользователь заметил, что обновиться для нового релиза можно не только на testing, так что поменял тут ссылку на фиты в целом. Обновлению всё равно почти два года.