### PR TITLE
Handle network connection creation cancel

### DIFF
--- a/app/scripts/react-directives/network-connections/pageStore.js
+++ b/app/scripts/react-directives/network-connections/pageStore.js
@@ -128,7 +128,14 @@ class NetworkConnectionsPageStore {
 
   async createConnection() {
     if (await this.allowConnectionSwitch()) {
-      const connectionType = await this.selectNewConnectionModalState.show();
+      let connectionType;
+      try {
+        connectionType = await this.selectNewConnectionModalState.show();
+      } catch (err) {
+        if (err == 'cancel') {
+          return;
+        }
+      }
       this.connections.setSelectedConnectionIndex(
         this.connections.addConnection({ type: connectionType, state: 'new' })
       );

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.78.10) stable; urgency=medium
+
+  * Handle network connection creation cancel. No functional changes
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 20 Feb 2024 10:50:12 +0500
+
 wb-mqtt-homeui (2.78.9) stable; urgency=medium
 
   * Fix displaying of cells with long text in Chrome-based browsers


### PR DESCRIPTION
Handle uncaught (in promise) error on cancel


Если при создании соединения нажать "Отмена", в консоль выпадет отмена. Ни на что не влияет, но не красиво.
![Screenshot_20240220_105219](https://github.com/wirenboard/homeui/assets/86825564/931c5345-b16e-4d81-83ea-a85ae0b905a2)
