### PR TITLE
Fix dirty page confirm dialog

### DIFF
--- a/app/scripts/services/pagestate.js
+++ b/app/scripts/services/pagestate.js
@@ -1,4 +1,10 @@
-function pageStateService($rootScope, $window, forceBeforeUnloadConfirmationForTests, $translate) {
+function pageStateService(
+  $rootScope,
+  $window,
+  forceBeforeUnloadConfirmationForTests,
+  $translate,
+  $transitions
+) {
   'ngInject';
 
   var dirty = false;
@@ -12,10 +18,15 @@ function pageStateService($rootScope, $window, forceBeforeUnloadConfirmationForT
   updateTranslations();
   $rootScope.$on('$translateChangeSuccess', () => updateTranslations());
 
-  $rootScope.$on('$locationChangeStart', (event, newUrl, oldUrl) => {
-    if (!dirty) return;
-    if ($window.confirm(CONFIRMATION_MSG)) dirty = false;
-    else event.preventDefault();
+  $transitions.onBefore({}, function (transition) {
+    if (!dirty) {
+      return true;
+    }
+    if ($window.confirm(CONFIRMATION_MSG)) {
+      dirty = false;
+      return true;
+    }
+    return false;
   });
 
   // https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.79.1) stable; urgency=medium
+
+  * Fix dirty page confirm dialog
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 04 Mar 2024 12:42:00 +0500
+
 wb-mqtt-homeui (2.79.0) stable; urgency=medium
 
   * Add button to append scanned devices to wb-mqtt-serial config


### PR DESCRIPTION
При переходе со страницы с несохранёнными изменениями выскакивает диалог предупреждение. Он был сломан. Переход всё расно осуществлялся, не смотря на то, что нажали в диалоге. Это я сломал, когда перешёл на angular-ui-router 1.x, в нё м изменились события при переходе между состояниями.