### PR TITLE
Remove tab text left margin in json-editor

### DIFF
--- a/app/scripts/json-editor/wb-bootstrap3-theme.js
+++ b/app/scripts/json-editor/wb-bootstrap3-theme.js
@@ -21,7 +21,6 @@ function makeWbBootstrap3Theme() {
       a.setAttribute('aria-controls', tabId);
       a.setAttribute('role', 'tab');
       a.setAttribute('data-toggle', 'tab');
-      text.style.marginLeft = '5px';
       li.appendChild(a);
       return li;
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.81.2) stable; urgency=medium
+
+  * Adjust text style on tabs. No functional changes
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 22 Mar 2024 09:56:24 +0500
+
 wb-mqtt-homeui (2.81.1) stable; urgency=medium
 
   * Use Back button to navigate from device settings to the list of devices and ports in wb-mqtt-serial config in mobile mode 


### PR DESCRIPTION
Текст при переносе уезжал. Зачем там этот отступ был, не понимаю
![image](https://github.com/wirenboard/homeui/assets/86825564/997594fd-fd50-4a2f-bde9-cbcc4484c119)
