### PR TITLE
Fix unsaved changes tracking

### DIFF
--- a/app/scripts/react-directives/components/json-editor/jsonEditor.jsx
+++ b/app/scripts/react-directives/components/json-editor/jsonEditor.jsx
@@ -7,7 +7,10 @@ import { isEqual } from 'lodash';
 const JsonEditor = observer(props => {
   const container = useRef();
   var jse = useRef(null);
+  const stateRef = useRef();
   const [schema, setSchema] = useState(undefined);
+  const [firstStart, setFirstStart] = useState(true);
+  stateRef.current = firstStart;
 
   const constructEditor = props => {
     var editor = createJSONEditor(
@@ -19,7 +22,10 @@ const JsonEditor = observer(props => {
     );
     editor.on('change', () => {
       if (props.onChange) {
-        props.onChange(editor.getValue(), editor.validate(), false);
+        props.onChange(editor.getValue(), editor.validate(), stateRef.current);
+      }
+      if (stateRef.current) {
+        setFirstStart(false);
       }
     });
     // json-editor can modify an internal schema object,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.82.1) stable; urgency=medium
+
+  * Improve unsaved changes tracking on wb-mqtt-serial config page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 26 Mar 2024 16:57:36 +0500
+
 wb-mqtt-homeui (2.82.0) stable; urgency=medium
 
   * Load device settings in wb-mqtt-serial config editor on demand


### PR DESCRIPTION
json-editor modifies resulting JSON after initialization. It adds properties with default values. It is not tracked as config modification now

Здесь первое изменение от json-editor просто сохраняется как текущее значение, т.к. фактически это просто добавление полей со значениями по умолчанию. При сохранении в конфиг они вычищаются, а тут добавляются снова.
Это хорошо проявлялось после сохранения настроек и при переключении между вкладками устройств. К сожалению, остался ещё баг в json-editor, из-за которого при переключении между устройствами всё ещё может измениться json, хотя фактически настройки не изменятся