### PR TITLE
Add customized oneOf editor to json-editor

### DIFF
--- a/app/scripts/json-editor/first-oneof-editor.js
+++ b/app/scripts/json-editor/first-oneof-editor.js
@@ -1,0 +1,20 @@
+'use strict';
+
+import { JSONEditor } from '../../3rdparty/jsoneditor';
+
+// The editor is derived from multiple editor.
+// It is used with oneOf nodes and shows editor only for the first item in oneOf array
+function makeFirstOneOfEditor() {
+  return class extends JSONEditor.defaults.editors['multiple'] {
+    build() {
+      super.build();
+      this.switcher.style.display = 'none';
+      this.header.style.display = 'none';
+      if (this.editors[this.type].header) {
+        this.editors[this.type].header.style.display = '';
+      }
+    }
+  };
+}
+
+export default makeFirstOneOfEditor;

--- a/app/scripts/json-editor/wb-json-editor.js
+++ b/app/scripts/json-editor/wb-json-editor.js
@@ -18,6 +18,7 @@ import makeOptionalEditorWithDropDown from './optional-editor-with-dropdown';
 import makeWbBootstrap3Theme from './wb-bootstrap3-theme';
 import makeWbBootstrap3Iconlib from './wb-bootstrap3-iconlib';
 import makeWbArrayEditor from './wb-array-editor';
+import makeFirstOneOfEditor from './first-oneof-editor';
 import { compileTemplate } from '../services/dumbtemplate';
 
 var needOverride = true;
@@ -190,6 +191,9 @@ function overrideJSONEditor() {
     schema => schema.oneOf && schema.format === 'wb-multiple' && 'wb-multiple'
   );
   JSONEditor.defaults.resolvers.unshift(
+    schema => schema.oneOf && schema.format === 'wb-first-oneof' && 'wb-first-oneof'
+  );
+  JSONEditor.defaults.resolvers.unshift(
     schema => schema.type === 'object' && schema.format === 'merge-default' && 'merge-default'
   );
   JSONEditor.defaults.resolvers.unshift(
@@ -228,6 +232,7 @@ function overrideJSONEditor() {
   JSONEditor.defaults.editors['groups'] = makeGroupsEditor();
   JSONEditor.defaults.editors['wb-optional'] = makeOptionalEditorWithDropDown();
   JSONEditor.defaults.editors['wb-array'] = makeWbArrayEditor();
+  JSONEditor.defaults.editors['wb-first-oneof'] = makeFirstOneOfEditor();
 
   JSONEditor.defaults.languages.en.error_oneOf = 'One or more parameters are invalid';
 

--- a/app/styles/css/device-manager.css
+++ b/app/styles/css/device-manager.css
@@ -183,3 +183,9 @@
         padding-bottom: 10px;
     }
 }
+
+@media (min-width: 992px) {
+    .device-manager-page .group-editor {
+        margin-top: 15px;
+    }
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.82.1) stable; urgency=medium
+
+  * Fix slave id editor in wb-mqtt-serial config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 27 Mar 2024 10:47:41 +0500
+
 wb-mqtt-homeui (2.82.0) stable; urgency=medium
 
   * Load device settings in wb-mqtt-serial config editor on demand


### PR DESCRIPTION
The editor shows only first oneOf item

Для редактирования и валидации конфига wb-mqtt-serial теперь используется одна и та же схема. Проблема в том, что параметр `slave_id` может быть задан в конфиге числом или строкой. Это описано в схеме как oneOf. json-editor в таком случае рисует выпадающий список с выбором типа редактора. Это всё выглядит некрасиво. Сделал редактор, который отображает только первый элемент из oneOf и не даёт переключаться. wb-mqtt-serial при этом отдаёт в web-интерфейс `slave_id` всегда как строку.