### PR TITLE
Improve wb-mqtt-serial config loading errors handling

### DIFF
--- a/app/scripts/react-directives/device-manager/configUtils.js
+++ b/app/scripts/react-directives/device-manager/configUtils.js
@@ -36,7 +36,7 @@ export async function addToConfig(config, devices, deviceTypesStore) {
         res.unknown.push(device);
         return;
       }
-      let port = config.ports.find(p => p.path == device.port);
+      let port = config?.ports?.find(p => p.path == device.port);
       if (!port) {
         return;
       }

--- a/app/scripts/react-directives/device-manager/pageStore.js
+++ b/app/scripts/react-directives/device-manager/pageStore.js
@@ -182,7 +182,7 @@ class DeviceManagerPageStore {
           this.tabs.setModifiedStructure();
         }
       }
-      config.ports.forEach(port => {
+      config?.ports?.forEach(port => {
         const portTab = this.createPortTab(port);
         if (portTab === undefined) {
           return;
@@ -204,8 +204,16 @@ class DeviceManagerPageStore {
     this.pageWrapperStore.setLoading(false);
   }
 
-  setError(msg) {
-    this.pageWrapperStore.setError(msg);
+  setError(error) {
+    if (typeof error === 'object') {
+      if (error.hasOwnProperty('code')) {
+        this.pageWrapperStore.setError(`${error.message}: ${error.data}(${error.code})`);
+      } else {
+        this.pageWrapperStore.setError(error.message);
+      }
+      return;
+    }
+    this.pageWrapperStore.setError(error);
   }
 
   async addPort() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.82.3) stable; urgency=medium
+
+  * Improve wb-mqtt-serial config loading errors handling
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 29 Mar 2024 11:50:40 +0500
+
 wb-mqtt-homeui (2.82.2) stable; urgency=medium
 
   * Improve unsaved changes tracking on wb-mqtt-serial config page


### PR DESCRIPTION
- Не падаем, если в конфиге нет параметра `ports` 
- Выводим текcт ошибки, если это ошибка RPC