### PR TITLE
Handle malformed MQTT data

### DIFF
--- a/app/scripts/services/mqttService.js
+++ b/app/scripts/services/mqttService.js
@@ -346,13 +346,20 @@ function mqttClient(
         if (!topicMatches(pattern, topic)) {
           return;
         }
-        callbackMap[pattern].forEach(function (callback) {
-          callback({
+        let data;
+        try {
+          data = {
             topic: topic,
             payload: message.payloadString,
             qos: message.qos,
             retained: message.retained,
-          });
+          };
+        } catch (err) {
+          console.error('malformed data in MQTT topic %s: %s', topic, String(err));
+          return;
+        }
+        callbackMap[pattern].forEach(function (callback) {
+          callback(data);
         });
       });
     if (!messageDigestTimer)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.84.1) stable; urgency=medium
+
+  * Do not disconnect from controller after receiving malformed data from MQTT 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 22 Apr 2024 09:29:38 +0500
+
 wb-mqtt-homeui (2.84.0) stable; urgency=medium
 
   * Add wb8 config


### PR DESCRIPTION
Do not disconnect from controller after receiving malformed data from MQTT

Мы предполагаем, что в топике будет корректная UTF8 строка. Если там не UTF8, `message.payloadString` выкидывает исключение, которое никак не обрабатывается и приводит к отключению вебсокета.