### PR TITLE
Remove useless scrollbars on wb-mqtt-serial config page

### DIFF
--- a/app/styles/css/device-manager.css
+++ b/app/styles/css/device-manager.css
@@ -114,13 +114,13 @@
 }
 
 .device-manager-page .settings-panel {
-    overflow-y: scroll;
+    overflow-y: auto;
     padding-bottom: 10px;
     flex-grow: 1;
 }
 
 .device-manager-page .device-list {
-    overflow-y: scroll;
+    overflow-y: auto;
     flex-grow: 1;
 }
 

--- a/app/styles/css/scan.css
+++ b/app/styles/css/scan.css
@@ -44,7 +44,7 @@
 }
 
 .scan-page .scrollable-table-wrapper {
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .scan-page .scrollable-table-wrapper table thead {
@@ -106,5 +106,5 @@
 
 
 .scan-page .mobile-devices-list {
-    overflow-y: scroll;
+    overflow-y: auto;
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.84.3) stable; urgency=medium
+
+  * Remove useless scrollbars on wb-mqtt-serial config page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 23 Apr 2024 22:23:52 +0500
+
 wb-mqtt-homeui (2.84.2) stable; urgency=medium
 
   * Generate configs, no functional changes


### PR DESCRIPTION
В хромиуме рисовались неактивные скроллбары

![image](https://github.com/wirenboard/homeui/assets/86825564/5e1936a6-edf1-41ae-8c18-978412a1cd6b)
