### PR TITLE
Move selection to next device after deletion

### DIFF
--- a/app/scripts/react-directives/device-manager/config-editor/portTab.jsx
+++ b/app/scripts/react-directives/device-manager/config-editor/portTab.jsx
@@ -47,16 +47,14 @@ export const PortTabContent = ({ tab, index, onDeleteTab }) => {
   return (
     <div>
       {tab.childrenHasErrors && <ErrorBar msg={t('device-manager.errors.device-config')} />}
-      <div>
+      <div className="port-tab-content-header">
         <span>{tab.title}</span>
-        <div className="pull-right button-group">
-          <Button
-            key="delete"
-            label={t('device-manager.buttons.delete')}
-            type="danger"
-            onClick={onDeleteTab}
-          />
-        </div>
+        <Button
+          key="delete"
+          label={t('device-manager.buttons.delete')}
+          type="danger"
+          onClick={onDeleteTab}
+        />
       </div>
       <JsonEditor
         schema={tab.schema}

--- a/app/scripts/react-directives/device-manager/config-editor/tabsStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/tabsStore.js
@@ -120,19 +120,31 @@ export class TabsStore {
 
   deleteSelectedTab() {
     const tab = this.items[this.selectedTabIndex];
-    if (tab?.type == TabType.PORT) {
-      this.items.splice(this.selectedTabIndex, tab.children.length + 1);
-    } else if (tab?.type == TabType.DEVICE) {
-      let portTab = this.selectedPortTab;
-      portTab.children.splice(portTab.children.indexOf(tab), 1);
-      this.items.splice(this.selectedTabIndex, 1);
-    } else {
-      return;
+    switch (tab?.type) {
+      case TabType.PORT: {
+        this.items.splice(this.selectedTabIndex, tab.children.length + 1);
+        break;
+      }
+      case TabType.DEVICE: {
+        let portTab = this.selectedPortTab;
+        const childIndex = portTab.children.indexOf(tab);
+        portTab.children.splice(childIndex, 1);
+        this.items.splice(this.selectedTabIndex, 1);
+        if (
+          (childIndex == 0 && !portTab.children.length) ||
+          (childIndex != 0 && childIndex == portTab.children.length)
+        ) {
+          this.selectedTabIndex = this.selectedTabIndex - 1;
+        }
+        break;
+      }
+      default: {
+        return;
+      }
     }
-
-    this.selectedTabIndex = 0;
     this.hasModifiedStructure = true;
     this.mobileModeStore.showTabsPanel();
+    this.onSelectTab(this.selectedTabIndex);
   }
 
   copySelectedTab() {

--- a/app/styles/css/device-manager.css
+++ b/app/styles/css/device-manager.css
@@ -206,3 +206,13 @@
         width: 100%;
     }
 }
+
+.device-manager-page .port-tab-content-header {
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+}
+
+.device-manager-page .port-tab-content-header span{
+    flex-grow: 1;
+}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.84.7) stable; urgency=medium
+
+  * Move selection to next device after deletion on wb-mqtt-serial config page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 26 Apr 2024 18:43:57 +0500
+
 wb-mqtt-homeui (2.84.6) stable; urgency=medium
 
   * Fixes around cloud connection status, no functional changes


### PR DESCRIPTION
После удаления устройства, фокус всегда переходил на самый первый порт, сделал, чтоб переходил на ближайшее устройство или порт