### PR TITLE
Fix validation depending from condition

### DIFF
--- a/app/scripts/json-editor/wb-json-editor.js
+++ b/app/scripts/json-editor/wb-json-editor.js
@@ -86,6 +86,32 @@ export function createJSONEditor(element, schema, value, locale, root, data) {
   return new JSONEditor(element, options);
 }
 
+function conditionalOneOfValidator(schema, value, path) {
+  if (
+    schema.options &&
+    schema.options.wb &&
+    schema.options.wb.groups &&
+    schema.format != 'wb-multiple'
+  ) {
+    const editor = this.jsoneditor.getEditor(path);
+    const paramValues = editor?.conditions?.makeParamValues(value);
+    Object.entries(schema.properties).forEach(([key, subSchema]) => {
+      if (subSchema.hasOwnProperty('oneOf')) {
+        subSchema.oneOf.forEach(item => {
+          if (item.condition && !editor?.conditions?.check(item.condition, paramValues)) {
+            angular.merge(item.options, { wb: { error: 'disabled' } });
+          } else {
+            if (item.options && item.options.wb) {
+              delete item.options.wb.error;
+            }
+          }
+        });
+      }
+    });
+  }
+  return [];
+}
+
 function overrideJSONEditor(data) {
   JSONEditor.defaults.options.show_errors = 'always';
   JSONEditor.defaults.options.iconlib = 'wb-bootstrap3';
@@ -107,43 +133,7 @@ function overrideJSONEditor(data) {
     return errors;
   });
 
-  JSONEditor.defaults.custom_validators.push((schema, value, path) => {
-    if (
-      schema.options &&
-      schema.options.wb &&
-      schema.options.wb.groups &&
-      schema.format != 'wb-multiple'
-    ) {
-      var paramValues = [];
-      var paramNames = [];
-      Object.entries(value).forEach(([k, v]) => {
-        paramNames.push(k);
-        paramValues.push(v);
-      });
-      paramNames = paramNames.join(',');
-      var checkCondition = function (condition) {
-        try {
-          return new Function(paramNames, 'return ' + condition + ';').apply(null, paramValues);
-        } catch (e) {
-          return false;
-        }
-      };
-      Object.entries(schema.properties).forEach(([key, subSchema]) => {
-        if (subSchema.hasOwnProperty('oneOf')) {
-          subSchema.oneOf.forEach(item => {
-            if (item.condition && !checkCondition(item.condition)) {
-              angular.merge(item.options, { wb: { error: 'disabled' } });
-            } else {
-              if (item.options && item.options.wb) {
-                delete item.options.wb.error;
-              }
-            }
-          });
-        }
-      });
-    }
-    return [];
-  });
+  JSONEditor.defaults.custom_validators.push(conditionalOneOfValidator);
 
   JSONEditor.defaults.custom_validators.push((schema, value, path) => {
     const errors = [];
@@ -207,7 +197,9 @@ function overrideJSONEditor(data) {
     schema => schema.format === 'unknown-device' && 'unknown-device'
   );
   JSONEditor.defaults.resolvers.unshift(schema => schema.format === 'wb-optional' && 'wb-optional');
-  JSONEditor.defaults.resolvers.unshift(schema => schema.format === 'wb-autocomplete' && 'wb-autocomplete');
+  JSONEditor.defaults.resolvers.unshift(
+    schema => schema.format === 'wb-autocomplete' && 'wb-autocomplete'
+  );
   JSONEditor.defaults.resolvers.unshift(
     schema => schema.type === 'array' && schema.format === 'wb-array' && 'wb-array'
   );

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.85.1) stable; urgency=medium
+
+  * Fix WB-LED configuration
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 15 May 2024 16:07:51 +0500
+
 wb-mqtt-homeui (2.85.0) stable; urgency=medium
 
   * Add separate chunks to decrease bundle weight


### PR DESCRIPTION
Это валидатор, который проверяет соответствие схеме после вычисления условий.

В шаблоне устройства wb-mqtt-serial, могут быть несколько параметров с одним именем, но разной структурой. Каждый такой параметр имеет поле `condition`, где прописано логическое выражение. При подстановке текущих зачений настроек устройства в такое выражение получаем true или false. Если true, то используется этот вариант описания параметра. wb-mqtt-serial объединяет такие параметры в схему с `oneOf`, где элементы - варианты описания параметра. Для валидации конфига по такой схеме надо знать, какой элемент выбрать в oneOf. Раньше проходили по списку и пытались вычислить `condition` для каждого элемента. При вычислении надо знать все возможные параметры конфигурации устройства. В начальной реализации использовались только параметры, которые есть в текущем конфиге. При этом неверно вычислялись условия вида `параметр!=1`, если параметр отсутствовал в текущих настройках. Такое выражение должно быть true, но интерпретатор JS не находил объявления параметра и падал с ошибкой, что трактуется как false. В результате валидация корректных настроек проваливалась. Теперь валидатор идёт в редактор и забирает из него корректно сформированные функции для вычисления `condition`. 