### PR TITLE
Preserve history plot height

### DIFF
--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -699,6 +699,10 @@ class HistoryCtrl {
       }
     });
     this.fixAxes(minValue, maxValue);
+    // 450 - default height in plotly.js
+    // 19 - minimal legend item height in plotly.js sources
+    // It can be bigger if font is bigger, but it is too difficult to calculate, so use minimal value
+    // See computeTextDimensions in components/legend/draw.js in plotly.js sources
     this.layoutConfig.height = 450 + this.chartConfig.length * 19;
   }
 

--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -699,6 +699,7 @@ class HistoryCtrl {
       }
     });
     this.fixAxes(minValue, maxValue);
+    this.layoutConfig.height = 450 + this.chartConfig.length * 19;
   }
 
   getMax(v1, v2) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.85.2) stable; urgency=medium
+
+  * Preserve history plot height
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 23 May 2024 14:02:48 +0500
+
 wb-mqtt-homeui (2.85.1) stable; urgency=medium
 
   * Fix WB-LED configuration


### PR DESCRIPTION
Сохраняю размер полотна с графиком. Раньше, чем больше графиков было, тем оно было сплюснутее, т.к. место под легенду расходовалось