### PR TITLE
Fix firmware version checking

### DIFF
--- a/app/scripts/react-directives/device-manager/scan/scanPageStore.js
+++ b/app/scripts/react-directives/device-manager/scan/scanPageStore.js
@@ -246,7 +246,7 @@ class DevicesStore {
 
     const deviceTypes = this.deviceTypesStore.findDeviceTypes(
       scannedDevice.device_signature,
-      scannedDevice.fw
+      scannedDevice.fw?.version
     );
 
     let d = new SingleDeviceStore(

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.86.5) stable; urgency=medium
+
+  * Fix loading of device templates with defined firmware versions
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 19 Jun 2024 10:21:47 +0500
+
 wb-mqtt-homeui (2.86.4) stable; urgency=medium
 
   * Make tables responsive (json-editor updated to 2.5.3-wb11)


### PR DESCRIPTION
Если в шаблоне устройства была прописана версия прошивки, то проверка валилась, т.к. для сравнения передавалась не строка с версией, а объект