### PR TITLE
Postinst: replace config with a correct board-one, if config was not …

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.86.7) stable; urgency=medium
+
+  * Postinst: replace config with a correct board-one, if config was not edited by user
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 24 Jun 2024 10:12:21 +0300
+
 wb-mqtt-homeui (2.86.6) stable; urgency=medium
 
   * Detect, is running via cloud or not; pass "from_cloud" flag

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/wirenboard/homeui
 Package: wb-mqtt-homeui
 Architecture: all
 Conflicts: wb-homa-webinterface
-Depends: ${shlibs:Depends}, ${misc:Depends}, mosquitto, mqtt-wss, mqtt-tools, nginx-extras, wb-utils (>= 4.20.1),
+Depends: ${shlibs:Depends}, ${misc:Depends}, mosquitto, mqtt-wss, mqtt-tools, nginx-extras, diffutils, wb-utils (>= 4.20.1),
   wb-configs (>= 3.21.0)
 Recommends: wb-mqtt-logs, wb-device-manager
 Suggests: wb-mqtt-confed (>= 1.4.0),

--- a/debian/postinst
+++ b/debian/postinst
@@ -39,6 +39,14 @@ function install_default_config()
     ucf --debconf-ok $BOARD_CONF $CONFFILE
 }
 
+function is_config_untouched()
+{
+    for fname in $(ls /usr/share/wb-mqtt-homeui/config.*.json); do
+        diff -q $CONFFILE $fname && return 0
+    done
+    return 1
+}
+
 case "$1" in
     configure)
 
@@ -58,7 +66,11 @@ case "$1" in
             if `dpkg --compare-versions "${OLD_VERSION}" "lt" "2.0~beta9"`; then
                 convert_config
             else
-                install_default_config
+                if is_config_untouched; then
+                    cp $BOARD_CONF $CONFFILE
+                else
+                    install_default_config
+                fi
             fi
         fi
     ;;


### PR DESCRIPTION
…edited by user

Есть проблема: в wb8 уже выехал homeui без board-конфига для wb8 => при установке, пользователи получат окошко debconf-a "ай-ай, конфиг поменялся"

предлагаю хак: если конфиг совпадает с чем-то из /usr/share/(где лежат board-конфиги) => считаем конфиг нетронутым пользователем => меняем на актуальный board-конфиг

если пользователь трогал конфиг - так и так вылезал debconf