### PR TITLE
Hotfix/2404 version bump

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.82.1-wb105) stable; urgency=medium
+
+  * Version increase for technical reasons, no functional changes
+
+ -- Aleskandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 26 Jun 2024 12:00:17 +0500
+
 wb-mqtt-homeui (2.82.1-wb104) stable; urgency=medium
 
   * Add download configs and download everything buttons under System page

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-homeui (2.82.1-wb105) stable; urgency=medium
 
-  * Version increase for technical reasons, no functional changes
+  * Version increment for technical reasons, no functional changes
 
  -- Aleskandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 26 Jun 2024 12:00:17 +0500
 


### PR DESCRIPTION
Надо чтобы собрался новый релизный пакет, wb104 по моей оплошности собрался из отщепленной от релиза ветки release/wb-2404-backport-бла-бла-бла.