### PR TITLE
Fix json-editor error handling

### DIFF
--- a/app/scripts/json-editor/wb-json-editor.js
+++ b/app/scripts/json-editor/wb-json-editor.js
@@ -99,6 +99,9 @@ function conditionalOneOfValidator(schema, value, path) {
       if (subSchema.hasOwnProperty('oneOf')) {
         subSchema.oneOf.forEach(item => {
           if (item.condition && !editor?.conditions?.check(item.condition, paramValues)) {
+            if (!item.hasOwnProperty('options')) {
+              item.options = {};
+            }
             angular.merge(item.options, { wb: { error: 'disabled' } });
           } else {
             if (item.options && item.options.wb) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.93.10) stable; urgency=medium
+
+  * Fix WB-MRWM2 config page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 29 Jul 2024 18:22:54 +0500
+
 wb-mqtt-homeui (2.93.9) stable; urgency=medium
 
   * Fix device copying between ports


### PR DESCRIPTION
`angular.merge` падал, если не было параметра `item.options`.

Коллеги сделали новый шаблон для WB-MRWM2, на котором это вылезло