### PR TITLE
fix device units white space

### DIFF
--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -120,6 +120,7 @@ div[uib-datepicker-popup-wrap] {
 
 .device-panel .display-cell{
   cursor: pointer;
+  overflow: hidden;
 }
 
 .cell.cell-value {
@@ -129,7 +130,8 @@ div[uib-datepicker-popup-wrap] {
 .cell-value .value {
   margin-right: -10px;
   width: 110px;
-  display: inline-block;
+  display: flex;
+  align-items: center;
 }
 
 .cell-value span{
@@ -148,7 +150,6 @@ div[uib-datepicker-popup-wrap] {
 
 .cell-value .units {
   width: 20px;
-  white-space: nowrap;
 }
 
 .value .decimal, .value .comma {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.93.13) stable; urgency=medium
+
+  * Fix device units white space
+
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Mon, 26 Aug 2024 15:50:00 +0300
+
 wb-mqtt-homeui (2.93.12) stable; urgency=medium
 
   * Change collapsing logic — all panes are expanded by default


### PR DESCRIPTION
Текст переносится на новую строку, все выравнено по центру.
![image](https://github.com/user-attachments/assets/a20d3364-922a-4b67-8a77-b03d35377349)
