### PR TITLE
hide network disconection alert on reconnect

### DIFF
--- a/app/scripts/react-directives/network-connections/network-connections.js
+++ b/app/scripts/react-directives/network-connections/network-connections.js
@@ -46,6 +46,12 @@ function networkConnectionsDirective(mqttClient, whenMqttReady, ConfigEditorProx
       const re = new RegExp('/devices/system__networks__([^/]+)/');
       const getUuidFromTopic = topic => topic.match(re)?.[1];
 
+      scope.$watch(() => mqttClient.isConnected(), (isConnected) => {
+        if (scope.store.error && isConnected) {
+          scope.store.setError('');
+        }
+      });
+
       whenMqttReady().then(() => {
         ConfigEditorProxy.Load({ path: scope.path })
           .then(r => {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.93.14) stable; urgency=medium
+
+  * Fix network disconection alert on reconnect
+
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Mon, 27 Aug 2024 11:30:00 +0300
+
 wb-mqtt-homeui (2.93.13) stable; urgency=medium
 
   * Fix device units white space

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-homeui (2.93.14) stable; urgency=medium
 
   * Fix network disconection alert on reconnect
 
- -- Victor Vedenin <victor.vedenin@wirenboard.com>  Mon, 27 Aug 2024 11:30:00 +0300
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Tue, 27 Aug 2024 11:30:00 +0300
 
 wb-mqtt-homeui (2.93.13) stable; urgency=medium
 


### PR DESCRIPTION
Теперь отслеживаем переподключились ли мы, и ексли да то прячем алерт о дисконнекте.