### PR TITLE
Allow to find only Wiren Board disconnected devices

### DIFF
--- a/app/scripts/react-directives/device-manager/common/deviceTypesStore.js
+++ b/app/scripts/react-directives/device-manager/common/deviceTypesStore.js
@@ -90,6 +90,10 @@ class DeviceTypesStore {
     const id = this.deviceTypesMap[deviceType]?.['mqtt-id'] || deviceType;
     return `${id}_${slaveId}`;
   }
+
+  isWbDevice(deviceType) {
+    return !!this.deviceTypesMap?.[deviceType]?.hw;
+  }
 }
 
 export default DeviceTypesStore;

--- a/app/scripts/react-directives/device-manager/config-editor/deviceTab.jsx
+++ b/app/scripts/react-directives/device-manager/config-editor/deviceTab.jsx
@@ -88,16 +88,18 @@ const SameMqttIdError = ({ devicesWithTheSameId, onSetUniqueMqttTopic }) => {
   return null;
 };
 
-const DisconnectedError = ({ isDisconnected, onSearchDisconnectedDevice }) => {
+const DisconnectedError = ({ isDisconnected, isWbDevice, onSearchDisconnectedDevice }) => {
   const { t } = useTranslation();
   if (isDisconnected) {
     return (
       <ErrorBar msg={t('device-manager.errors.is-disconnected')}>
-        <Button
-          label={t('device-manager.buttons.search-disconnected-device')}
-          type="danger"
-          onClick={onSearchDisconnectedDevice}
-        />
+        {isWbDevice && (
+          <Button
+            label={t('device-manager.buttons.search-disconnected-device')}
+            type="danger"
+            onClick={onSearchDisconnectedDevice}
+          />
+        )}
       </ErrorBar>
     );
   }
@@ -131,6 +133,7 @@ export const DeviceTabContent = observer(
         <DeprecatedWarning isDeprecated={tab.isDeprecated} />
         <DisconnectedError
           isDisconnected={tab.isDisconnected}
+          isWbDevice={tab.isWbDevice}
           onSearchDisconnectedDevice={onSearchDisconnectedDevice}
         />
         <DuplicateSlaveIdError isDuplicate={tab.slaveIdIsDuplicate} />

--- a/app/scripts/react-directives/device-manager/config-editor/deviceTabStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/deviceTabStore.js
@@ -55,6 +55,7 @@ export class DeviceTab {
       setLoading: action,
       setUniqueMqttTopic: action,
       hasInvalidConfig: computed,
+      isWbDevice: computed,
     });
   }
 
@@ -178,6 +179,10 @@ export class DeviceTab {
     return this.editedData.slave_id === undefined || this.editedData.slave_id === ''
       ? undefined
       : this.editedData.slave_id;
+  }
+
+  get isWbDevice() {
+    return this.deviceTypesStore.isWbDevice(this.deviceType);
   }
 
   setSlaveIdIsDuplicate(value) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.96.3) stable; urgency=medium
+
+  * Allow to find only Wiren Board disconnected devices
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 12 Sep 2024 10:38:27 +0500
+
 wb-mqtt-homeui (2.96.2) stable; urgency=medium
 
   * Fix loading system logs


### PR DESCRIPTION
Не показываем кнопку поиска отключенных устройств, если это не устройство WirenBoard. Всё равно ничего не найдём, т.к. поиск заточен под WB