### PR TITLE
Fix uptime history plot

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.97.1) stable; urgency=medium
+
+  * Fix uptime history plot
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 12 Sep 2024 17:59:25 +0500
+
 wb-mqtt-homeui (2.97.0) stable; urgency=medium
 
   * Add notification about new available firmware for Modbus device


### PR DESCRIPTION
Uptime передаётся строками и рисовался как набор строк. 
Теперь при отрисовке графика перевожу время в секунды и подрисовываю точечки в момент перезагрузки.
Ещё пришлось руками вычислять подписи для оси ординат

Было
![Screenshot_20240912_180122](https://github.com/user-attachments/assets/390eb72b-417b-4a46-9398-e185082e5e81)


Стало
![Screenshot_20240912_180058](https://github.com/user-attachments/assets/609d10fe-0988-4335-8b06-21a17c796bca)
