### PR TITLE
Fix requesting firmware info of reconnected devices

### DIFF
--- a/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
@@ -480,15 +480,16 @@ class ConfigEditorPageStore {
   }
 
   setDeviceDisconnected(topic, error) {
-    const tab = this.tabs.findDeviceTabByTopic(topic);
-    if (!tab) {
+    const deviceTab = this.tabs.findDeviceTabByTopic(topic);
+    if (!deviceTab) {
       return;
     }
     const isDisconnected = error == 'r';
-    tab.setDisconnected(isDisconnected);
+    deviceTab.setDisconnected(isDisconnected);
     if (!isDisconnected) {
-      if (['tcp', 'serial'].includes(this.tabs.selectedPortTab.portType)) {
-        tab.updateFirmwareVersion(this.tabs.selectedPortTab.baseConfig);
+      const portTab = this.tabs.findPortTabByDevice(deviceTab);
+      if (portTab && ['tcp', 'serial'].includes(portTab.portType)) {
+        deviceTab.updateFirmwareVersion(portTab.baseConfig);
       }
     }
   }
@@ -510,7 +511,7 @@ class ConfigEditorPageStore {
 
   updateFirmwareUpdateState(data) {
     data.devices.forEach(device => {
-      const portTab = this.tabs.findPortTab(device.port.path);
+      const portTab = this.tabs.findPortTabByPath(device.port.path);
       if (portTab) {
         const deviceTab = portTab.children.find(tab => tab.slaveId == device.slave_id);
         if (deviceTab) {

--- a/app/scripts/react-directives/device-manager/config-editor/tabsStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/tabsStore.js
@@ -285,10 +285,19 @@ export class TabsStore {
     });
   }
 
-  findPortTab(portPath) {
+  findPortTabByPath(portPath) {
     return this.items.find(item => {
       if (item.type == TabType.PORT) {
         return item.path == portPath;
+      }
+      return false;
+    });
+  }
+
+  findPortTabByDevice(deviceTab) {
+    return this.items.find(item => {
+      if (item.type == TabType.PORT) {
+        return item.children.includes(deviceTab);
       }
       return false;
     });

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.98.1) stable; urgency=medium
+
+  * Fix requesting firmware info of reconnected devices
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 20 Sep 2024 10:07:45 +0500
+
 wb-mqtt-homeui (2.98.0) stable; urgency=medium
 
   * Add config editor for wb-mqtt-mbgate 1.8.0


### PR DESCRIPTION
При запросе версии прошивки у вновь подключившегося устройства использовались настройки выбранного в интерфейсе порта. Выбран мог быть совсем не тот порт, на котором подключилось устройство