### PR TITLE
Fix filter when searching for disconnected devices

### DIFF
--- a/app/scripts/react-directives/device-manager/scan/searchDisconnectedScanPageStore.js
+++ b/app/scripts/react-directives/device-manager/scan/searchDisconnectedScanPageStore.js
@@ -24,15 +24,11 @@ class SearchDisconnectedScanPageStore {
       return;
     }
 
-    const data = JSON.parse(stringDataToRender);
-    if (!data.error) {
-      if (!this.commonScanStore.acceptUpdates) {
-        return;
-      }
-      data.devices = data.devices.filter(device =>
-        this.signatures.includes(device.device_signature)
-      );
+    let data = JSON.parse(stringDataToRender);
+    if (!data.error && !this.commonScanStore.acceptUpdates) {
+      return;
     }
+    data.devices = data.devices.filter(device => this.signatures.includes(device.device_signature));
     this.commonScanStore.update(data);
   }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.98.1) stable; urgency=medium
+
+  * Fix filter when searching for disconnected devices
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 20 Sep 2024 15:49:15 +0500
+
 wb-mqtt-homeui (2.98.0) stable; urgency=medium
 
   * Add config editor for wb-mqtt-mbgate 1.8.0


### PR DESCRIPTION
Scan status with error prevented from filtering devices by type

Искали WB-LED, а показываем всё подряд, а должны показывать только того типа, что ищем
![изображение](https://github.com/user-attachments/assets/37d291f2-d411-4f0a-884d-b7a06dbf21c2)

Ошибка в статусе - нормальное состояние, там могут быть ошибки сканирования по другим портам. Это не причина показывать всё, что насканировали