### PR TITLE
Fix configured devices matching

### DIFF
--- a/app/scripts/react-directives/device-manager/config-editor/configuredDevices.js
+++ b/app/scripts/react-directives/device-manager/config-editor/configuredDevices.js
@@ -47,10 +47,11 @@ function isPotentiallySameDevice(scannedDevice, configuredDevice) {
 }
 
 function hasSameSerialConfig(port, scannedDevice) {
+  // WB devices can operate regardless to stop bits setting, so compare baud rate, parity and data bits
   return (
     port.config?.baudRate == scannedDevice.cfg.baud_rate &&
     port.config?.parity == scannedDevice.cfg.parity &&
-    port.config?.stopBits == scannedDevice.cfg.stop_bits
+    port.config?.dataBits == scannedDevice.cfg.data_bits
   );
 }
 

--- a/app/scripts/react-directives/device-manager/config-editor/portTabStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/portTabStore.js
@@ -151,6 +151,7 @@ export class PortTab {
         baudRate: this.editedData.baud_rate,
         stopBits: this.editedData.stop_bits,
         parity: this.editedData.parity,
+        dataBits: this.editedData.data_bits,
       };
     }
     if (this.portType === 'tcp' || this.portType === 'modbus tcp') {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.98.2) stable; urgency=medium
+
+  * Fix configured devices list on new devices searching page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 23 Sep 2024 11:05:41 +0500
+
 wb-mqtt-homeui (2.98.1) stable; urgency=medium
 
   * Fix filter when searching for disconnected devices


### PR DESCRIPTION
WB devices can operate regardless to stop bits setting, so do not use it in configured devices matching