### PR TITLE
Fix searching of a disconnected device

### DIFF
--- a/app/scripts/react-directives/device-manager/scan/scanPageStore.js
+++ b/app/scripts/react-directives/device-manager/scan/scanPageStore.js
@@ -349,7 +349,7 @@ class CommonScanStore {
           preserve_old_results: false,
         };
         if (this.portPath) {
-          params.port_path = this.portPath;
+          params.port = { path: this.portPath };
         }
         await this.deviceManagerProxy.Start(params);
         this.acceptUpdates = true;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.99.2) stable; urgency=medium
+
+  * Fix searching of a disconnected device
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 26 Sep 2024 16:48:39 +0500
+
 wb-mqtt-homeui (2.99.1) stable; urgency=medium
 
   * Add link to Wiren Board Modbus device firmware recovery instruction


### PR DESCRIPTION
Correctly specify port in RPC request

Неверно передавался порт в запросе 