### PR TITLE
Do not collapse white spaces in rules console

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -487,6 +487,10 @@ button.show-console span {
   color: #009;
 }
 
+.console .console-view .console-message-text {
+  white-space: pre;
+}
+
 .spinner {
   padding: 30px 0;
   text-align: center;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.101.1) stable; urgency=medium
+
+  * Do not collapse white spaces in rules console messages 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 16 Oct 2024 12:33:18 +0500
+
 wb-mqtt-homeui (2.101.0) stable; urgency=medium
 
   * Add firmware recovery for devices in bootloader mode


### PR DESCRIPTION
Теперь все пробелы отображаются, а не схлопываются

![изображение](https://github.com/user-attachments/assets/8c2f4f30-ff2c-44da-b812-bd2078c81f5a)
