### PR TITLE
Add link to firmware recover instruction

### DIFF
--- a/app/scripts/i18n/react/locales/en/translations.json
+++ b/app/scripts/i18n/react/locales/en/translations.json
@@ -21,6 +21,7 @@
          "firmware": "Firmware",
          "available": "available {{version}}",
          "in-bootloder": "in bootloader",
+         "in-bootloader-link": "in bootloader, <0 href=\"https://wirenboard.com/wiki/Wb-mcu-fw-updater#%D0%92%D0%BE%D1%81%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5_(recover)\">how to recover</0>",
          "not-polled": "not polled",
          "offline": "offline",
          "duplicate": "duplicate",

--- a/app/scripts/i18n/react/locales/en/translations.json
+++ b/app/scripts/i18n/react/locales/en/translations.json
@@ -20,7 +20,7 @@
          "sn": "Serial number",
          "firmware": "Firmware",
          "available": "available {{version}}",
-         "in-bootloder": "in bootloader",
+         "in-bootloader": "in bootloader",
          "in-bootloader-link": "in bootloader, <0 href=\"https://wirenboard.com/wiki/Wb-mcu-fw-updater#%D0%92%D0%BE%D1%81%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5_(recover)\">how to recover</0>",
          "not-polled": "not polled",
          "offline": "offline",

--- a/app/scripts/i18n/react/locales/ru/translations.json
+++ b/app/scripts/i18n/react/locales/ru/translations.json
@@ -22,6 +22,7 @@
          "sn": "Серийный номер",
          "firmware": "Прошивка",
          "in-bootloder": "в загрузчике",
+         "in-bootloader-link": "в загрузчике, <0 href=\"https://wirenboard.com/wiki/Wb-mcu-fw-updater#%D0%92%D0%BE%D1%81%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5_(recover)\">инструкция по восстановлению</0>",
          "not-polled": "не опрашивается",
          "offline": "не отвечает",
          "duplicate": "дубликат",

--- a/app/scripts/i18n/react/locales/ru/translations.json
+++ b/app/scripts/i18n/react/locales/ru/translations.json
@@ -21,7 +21,7 @@
          "port": "Порт",
          "sn": "Серийный номер",
          "firmware": "Прошивка",
-         "in-bootloder": "в загрузчике",
+         "in-bootloader": "в загрузчике",
          "in-bootloader-link": "в загрузчике, <0 href=\"https://wirenboard.com/wiki/Wb-mcu-fw-updater#%D0%92%D0%BE%D1%81%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5_(recover)\">инструкция по восстановлению</0>",
          "not-polled": "не опрашивается",
          "offline": "не отвечает",

--- a/app/scripts/react-directives/device-manager/scan/common.jsx
+++ b/app/scripts/react-directives/device-manager/scan/common.jsx
@@ -6,10 +6,11 @@ export function WarningTag({ text }) {
   return <span className="tag bg-warning text-nowrap">{text}</span>;
 }
 
-export function ErrorTag({ text, title }) {
+export function ErrorTag({ text, title, children }) {
   return (
     <span className="tag bg-danger text-nowrap" title={title}>
       {text}
+      {children}
     </span>
   );
 }
@@ -56,6 +57,21 @@ const DeviceNameLabel = ({ title, selectable, selected, onSelectionChange, disab
   return <b>{title}</b>;
 };
 
+const InBootloaderErrorTag = ({ bootloaderMode, selectable }) => {
+  const { t } = useTranslation();
+  if (!bootloaderMode) {
+    return null;
+  }
+  if (selectable) {
+    return <ErrorTag text={t('scan.labels.in-bootloder')} />;
+  }
+  return (
+    <ErrorTag>
+      <Trans i18nKey={'scan.labels.in-bootloader-link'} components={[<a></a>]} />
+    </ErrorTag>
+  );
+};
+
 export const DeviceName = ({
   title,
   bootloaderMode,
@@ -80,7 +96,7 @@ export const DeviceName = ({
         onSelectionChange={onSelectionChange}
         disabled={unknownType}
       />
-      {bootloaderMode && <ErrorTag text={t('scan.labels.in-bootloder')} />}
+      <InBootloaderErrorTag bootloaderMode={bootloaderMode} selectable={selectable} />
       {duplicateMqttTopic && <ErrorTag text={t('scan.labels.duplicate-topic')} />}
       {unknownType && <ErrorTag text={t('scan.labels.unknown-device-type')} />}
       {otherMatchingDeviceTypesNames.length > 0 && (

--- a/app/scripts/react-directives/device-manager/scan/common.jsx
+++ b/app/scripts/react-directives/device-manager/scan/common.jsx
@@ -63,7 +63,7 @@ const InBootloaderErrorTag = ({ bootloaderMode, selectable }) => {
     return null;
   }
   if (selectable) {
-    return <ErrorTag text={t('scan.labels.in-bootloder')} />;
+    return <ErrorTag text={t('scan.labels.in-bootloader')} />;
   }
   return (
     <ErrorTag>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-homeui (2.103.3) stable; urgency=medium
 
-  * Add link to firmware recover instruction
+  * Add link to firmware recovery instruction
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 06 Nov 2024 12:17:42 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.103.3) stable; urgency=medium
+
+  * Add link to firmware recover instruction
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 06 Nov 2024 12:17:42 +0500
+
 wb-mqtt-homeui (2.103.2) stable; urgency=medium
 
   * Fix error during device configuration when adding from scan to wb-mqtt-serial config


### PR DESCRIPTION
![изображение](https://github.com/user-attachments/assets/a10e0183-2db8-4c76-b85d-88129437b107)

Добавил ссылку на инструкцию по восстановлению прошивки, если нашли устройство в загрузчике

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new link to recovery instructions for devices in bootloader mode in both English and Russian translations.
	- Introduced a new error handling component that displays relevant messages when devices are in bootloader mode.

- **Bug Fixes**
	- Corrected spelling of the existing label from "in-bootloder" to "in-bootloader" in Russian translations.

- **Documentation**
	- Updated changelog to include new version (2.103.3) with enhancements for user guidance on firmware recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->