### PR TITLE
Disable deletion of /dev/ttyRS485x ports

### DIFF
--- a/app/scripts/react-directives/device-manager/config-editor/portTab.jsx
+++ b/app/scripts/react-directives/device-manager/config-editor/portTab.jsx
@@ -26,12 +26,14 @@ export const PortTabContent = ({ tab, index, onDeleteTab }) => {
       {tab.childrenHasInvalidConfig && <ErrorBar msg={t('device-manager.errors.device-config')} />}
       <div className="port-tab-content-header">
         <span>{tab.title}</span>
-        <Button
-          key="delete"
-          label={t('device-manager.buttons.delete')}
-          type="danger"
-          onClick={onDeleteTab}
-        />
+        {tab.canDelete && (
+          <Button
+            key="delete"
+            label={t('device-manager.buttons.delete')}
+            type="danger"
+            onClick={onDeleteTab}
+          />
+        )}
       </div>
       <JsonEditor
         schema={tab.schema}

--- a/app/scripts/react-directives/device-manager/config-editor/portTabStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/portTabStore.js
@@ -72,6 +72,7 @@ export class PortTab {
       children: observable,
       hasChildren: computed,
       hasInvalidConfig: computed,
+      canDelete: computed,
     });
   }
 
@@ -165,5 +166,9 @@ export class PortTab {
 
   get isTcpGateway() {
     return this.portType === 'tcp' || this.portType === 'modbus tcp';
+  }
+
+  get canDelete() {
+    return !this.path.startsWith('/dev/ttyRS485');
   }
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.103.4) stable; urgency=medium
+
+  * Disable deletion of /dev/ttyRS485x ports in wb-mqtt-serial configuration
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 13 Nov 2024 11:24:05 +0500
+
 wb-mqtt-homeui (2.103.3) stable; urgency=medium
 
   * Add link to firmware recovery instruction


### PR DESCRIPTION
Скрываю кноку удаления порта для портов /dev/ttyRS485xxx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Conditional rendering of the delete button in the PortTabContent component, now only shown if deletion is permitted.
	- Introduced a new computed property `canDelete` for determining if a port can be deleted based on its path.

- **Bug Fixes**
	- Disabled deletion of `/dev/ttyRS485x` ports in the configuration management.

- **Chores**
	- Updated changelog to reflect the new version (2.103.4) and recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->