### PR TITLE
Fix saving history to csv file

### DIFF
--- a/app/scripts/controllers/historyController.js
+++ b/app/scripts/controllers/historyController.js
@@ -955,12 +955,15 @@ class HistoryCtrl {
       const row = [];
 
       for (let j = 0; j < cols.length; j++) {
-        // warp channel name's in quotes to protect chanel name that contain ',' symbol
-        if (i === 0 && j > 0) {
-          row.push(`"${cols[j].innerText}"`);
-        } else {
-          row.push(cols[j].innerText);
-        }
+        /*
+         See https://www.ietf.org/rfc/rfc4180.txt:
+         6. Fields containing line breaks (CRLF), double quotes, and commas
+            should be enclosed in double-quotes.
+         7. If double-quotes are used to enclose fields, then a double-quote
+            appearing inside a field must be escaped by preceding it with
+            another double quote.
+        */
+        row.push(`"${cols[j].innerText.replace(/"/g, '""')}"`);
       }
 
       csv.push(row.join(','));

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.103.6) stable; urgency=medium
+
+  * Fix saving history to csv file
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 15 Nov 2024 22:00:00 +0400
+
 wb-mqtt-homeui (2.103.5) stable; urgency=medium
 
   * Fix config editors not opening error
@@ -274,7 +280,7 @@ wb-mqtt-homeui (2.93.3) stable; urgency=medium
 
   * Add missed units translations
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com> Wed, 17 Jul 2024 16:06:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 17 Jul 2024 16:06:00 +0400
 
 wb-mqtt-homeui (2.93.2) stable; urgency=medium
 


### PR DESCRIPTION
Before:
```csv
Date and time,"Network / Active Connections"
Nov 15, 2024 1:00:42 AM,["Mi9T","lo","tailscale0","wb-ap"]
Nov 15, 2024 1:20:42 AM,["Mi9T","lo","tailscale0","wb-ap"]
Nov 15, 2024 1:40:42 AM,["Mi9T","lo","tailscale0","wb-ap"]
```
<img width="862" alt="Näyttökuva 2024-11-16 kello 2 25 38" src="https://github.com/user-attachments/assets/8174307c-fb59-43e5-9477-2495ca1b85bc">

After:
```csv
"Date and time","Network / Active Connections"
"Nov 15, 2024 2:40:42 AM","[""Mi9T"",""lo"",""tailscale0"",""wb-ap""]"
"Nov 15, 2024 3:00:42 AM","[""Mi9T"",""lo"",""tailscale0"",""wb-ap""]"
"Nov 15, 2024 3:20:42 AM","[""Mi9T"",""lo"",""tailscale0"",""wb-ap""]"
```
<img width="677" alt="Näyttökuva 2024-11-16 kello 2 26 03" src="https://github.com/user-attachments/assets/96b6ff78-62a8-4adc-b451-866f55779c03">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CSV export functionality to comply with RFC 4180 standards, ensuring all relevant fields are properly formatted.
  
- **Bug Fixes**
	- Fixed issues related to saving history to a CSV file.

- **Documentation**
	- Updated changelog to reflect new version (2.103.6) and recent improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->