### PR TITLE
Fix OneOfStore

### DIFF
--- a/app/scripts/react-directives/forms/oneOfStore.js
+++ b/app/scripts/react-directives/forms/oneOfStore.js
@@ -39,7 +39,7 @@ export class OneOfStore {
     if (index === -1) {
       this.optionsStore.setValue(null);
     } else {
-      this.items[index].setValue(value);
+      this.items.at(index).setValue(value);
       this.optionsStore.setValue(index);
     }
   }

--- a/app/scripts/react-directives/forms/oneOfStore.js
+++ b/app/scripts/react-directives/forms/oneOfStore.js
@@ -35,15 +35,12 @@ export class OneOfStore {
   }
 
   setValue(value) {
-    const index = this.matchFns.findIndex((fn, index) => {
-      if (fn(value)) {
-        this.optionsStore.setValue(index);
-        return true;
-      }
-      return false;
-    });
+    const index = this.matchFns.findIndex(fn => fn(value));
     if (index === -1) {
       this.optionsStore.setValue(null);
+    } else {
+      this.items[index].setValue(value);
+      this.optionsStore.setValue(index);
     }
   }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.104.1) stable; urgency=medium
+
+  * Fix loading wb-mqtt-mbgate config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 18 Nov 2024 17:36:01 +0500
+
 wb-mqtt-homeui (2.104.0) stable; urgency=medium
 
   * Add link to Wiren Board devices firmware change log


### PR DESCRIPTION
setValue does not set value to selected sub store. It only changes select's value. Now sub store is populated properly

Редактор oneOf - выпадающий список. В нём можно выбрать какой-то тип данных. Для выбранного типа должен отображаться свой редактор. setValue искало нужный тип, но не заполняло его данными

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with loading the `wb-mqtt-mbgate` configuration in version 2.104.1.
  
- **Documentation**
	- Updated the changelog to reflect the new version and recent fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->