### PR TITLE
Fix OneOfStore (#658)

### DIFF
--- a/app/scripts/react-directives/forms/oneOfStore.js
+++ b/app/scripts/react-directives/forms/oneOfStore.js
@@ -35,15 +35,12 @@ export class OneOfStore {
   }
 
   setValue(value) {
-    const index = this.matchFns.findIndex((fn, index) => {
-      if (fn(value)) {
-        this.optionsStore.setValue(index);
-        return true;
-      }
-      return false;
-    });
+    const index = this.matchFns.findIndex(fn => fn(value));
     if (index === -1) {
       this.optionsStore.setValue(null);
+    } else {
+      this.items.at(index).setValue(value);
+      this.optionsStore.setValue(index);
     }
   }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.103.3-wb101) stable; urgency=medium
+
+  * Fix loading wb-mqtt-mbgate config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 20 Nov 2024 12:30:01 +0500
+
 wb-mqtt-homeui (2.103.3-wb100) stable; urgency=medium
 
   * Fix config editors not opening error


### PR DESCRIPTION
setValue does not set value to selected sub store. It only changes select's value. Now sub store is populated properly

backport of https://github.com/wirenboard/homeui/pull/658