### PR TITLE
Fix alarm title translation

### DIFF
--- a/app/scripts/directives/alarmcell.html
+++ b/app/scripts/directives/alarmcell.html
@@ -9,5 +9,5 @@
     'focus': 'mouseleave'
   }"
 >
-    {{ cell.getName($locale.id) }}
+    {{ cell.getName(locale) }}
 </h4>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.105.1) stable; urgency=medium
+
+  * Fix alarm title translation
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 21 Nov 2024 23:55:00 +0400
+
 wb-mqtt-homeui (2.105.0) stable; urgency=medium
 
   * Add button to delete all port devices in wb-mqtt-serial config


### PR DESCRIPTION
Test instruction:
```js
defineVirtualDevice('test-device', {
    title: {en: 'Test Device', ru: 'Тест устройство'} ,
    cells: {
        test: {
          title: {en: 'Test', ru: 'Тест'},
          type: "alarm",
          value: false,
          readonly: true,
        },
    }
});
```

Before:
<img width="456" alt="Näyttökuva 2024-11-22 kello 0 06 10" src="https://github.com/user-attachments/assets/9042c020-8a86-4185-b8ef-b0fd297431b7">

After:
<img width="455" alt="Näyttökuva 2024-11-22 kello 0 06 19" src="https://github.com/user-attachments/assets/7253eba9-a2ae-4472-b060-d902552d4919">

See https://github.com/wirenboard/homeui/pull/610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the alarm title translation for improved clarity.
- **Bug Fixes**
	- Adjusted the locale reference in the alarm cell template for better readability.
- **Documentation**
	- Updated changelog to reflect version 2.105.1 and recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->