### PR TITLE
Fix port delete in wb-mqtt-serial config editor

### DIFF
--- a/app/scripts/react-directives/device-manager/config-editor/configEditorPage.jsx
+++ b/app/scripts/react-directives/device-manager/config-editor/configEditorPage.jsx
@@ -49,7 +49,14 @@ function getTabPaneContent(
   onUpdateBootloader
 ) {
   if (tab.type == TabType.PORT) {
-    return <PortTabContent tab={tab} index={index} onDeletePortDevices={onDeletePortDevices} />;
+    return (
+      <PortTabContent
+        tab={tab}
+        index={index}
+        onDeleteTab={onDeleteTab}
+        onDeletePortDevices={onDeletePortDevices}
+      />
+    );
   }
   if (tab.type == TabType.DEVICE) {
     return (

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.105.2) stable; urgency=medium
+
+  * Fix port delete in wb-mqtt-serial config editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 27 Nov 2024 16:42:39 +0500
+
 wb-mqtt-homeui (2.105.1) stable; urgency=medium
 
   * Fix alarm title translation


### PR DESCRIPTION
Сломал тут https://github.com/wirenboard/homeui/pull/659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tab deletion functionality in the configuration editor for improved user experience.

- **Bug Fixes**
	- Fixed an issue with the deletion of ports in the `wb-mqtt-serial` configuration editor.

- **Chores**
	- Updated changelog to reflect the new version (2.105.2) and recent fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->