### PR TITLE
 Fix device selection on scan page

### DIFF
--- a/app/scripts/react-directives/device-manager/scan/mobile.jsx
+++ b/app/scripts/react-directives/device-manager/scan/mobile.jsx
@@ -47,7 +47,7 @@ const AlreadyConfiguredDevicesHeader = observer(
   }
 );
 
-const DevicePanel = ({ deviceStore }) => {
+const DevicePanel = observer(({ deviceStore }) => {
   const { t } = useTranslation();
   const panelClasses = deviceStore.selectable
     ? 'panel panel-default'
@@ -86,7 +86,7 @@ const DevicePanel = ({ deviceStore }) => {
       </div>
     </div>
   );
-};
+});
 
 const DevicesList = observer(({ newDevices, alreadyConfiguredDevices, collapseButtonState }) => {
   return (

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.105.2) stable; urgency=medium
+
+  * Fix device selection on scan page in wb-mqtt-serial config editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 27 Nov 2024 17:32:19 +0500
+
 wb-mqtt-homeui (2.105.1) stable; urgency=medium
 
   * Fix alarm title translation


### PR DESCRIPTION
![Screenshot_20241127_173408](https://github.com/user-attachments/assets/30464bc1-5ab6-4a01-8550-557b6fc16465)

Чекбокс не менял своё состояние

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced reactivity of the DevicePanel and DevicesList components for dynamic updates based on device state.
	- Updated device selection functionality on the scan page within the configuration editor.
  
- **Bug Fixes**
	- Fixed an issue with device selection in the wb-mqtt-serial configuration editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->