### PR TITLE
Encode URL on history page

### DIFF
--- a/app/scripts/services/historyUrl.js
+++ b/app/scripts/services/historyUrl.js
@@ -15,7 +15,7 @@ function historyUrlService() {
       s: startDate,
       e: endDate,
     };
-    return LZString.compressToEncodedURIComponent(JSON.stringify(data));
+    return encodeURIComponent(LZString.compressToEncodedURIComponent(JSON.stringify(data)));
   };
 
   this.encodeControl = function (deviceId, controlId, startDate, endDate) {
@@ -37,7 +37,7 @@ function historyUrlService() {
   // }
   this.decode = function (data) {
     try {
-      var res = JSON.parse(LZString.decompressFromEncodedURIComponent(data));
+      var res = JSON.parse(LZString.decompressFromEncodedURIComponent(decodeURIComponent(data)));
       if (res.s) {
         res.s = new Date(res.s);
       }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.105.6) stable; urgency=medium
+
+  * Fix URL encoding of parameters on history page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 03 Dec 2024 10:12:42 +0500
+
 wb-mqtt-homeui (2.105.5) stable; urgency=medium
 
   * Add wb85 config


### PR DESCRIPTION
Parameters on history page are encoded in URL. LZString uses + and $ symbols without proper encoding. Add proper URL encoding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced URL encoding for parameters on the history page, improving data handling and user experience.
  
- **Bug Fixes**
	- Improved robustness of encoding and decoding processes for control data, ensuring accurate handling of special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->