### PR TITLE
Fix displaying of WB-MIO firmware update progress

### DIFF
--- a/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
@@ -583,7 +583,7 @@ class ConfigEditorPageStore {
       this.tabs
         .findPortTabByPath(device.port.path)
         ?.children?.filter(
-          deviceTab => getIntAddress(deviceTab.slaveId) == getIntAddress(device.slave_id)
+          deviceTab => getIntAddress(deviceTab.slaveId) === getIntAddress(device.slave_id)
         )
         .forEach(deviceTab => {
           deviceTab.clearError();

--- a/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
@@ -580,11 +580,15 @@ class ConfigEditorPageStore {
 
   setEmbeddedSoftwareUpdateProgress(data) {
     data.devices.forEach(device => {
-      const tab = this.tabs
+      this.tabs
         .findPortTabByPath(device.port.path)
-        ?.children?.find(deviceTab => deviceTab.slaveId == device.slave_id);
-      tab?.clearError();
-      tab?.setEmbeddedSoftwareUpdateProgress(device);
+        ?.children?.filter(
+          deviceTab => getIntAddress(deviceTab.slaveId) == getIntAddress(device.slave_id)
+        )
+        .forEach(deviceTab => {
+          deviceTab.clearError();
+          deviceTab.setEmbeddedSoftwareUpdateProgress(device);
+        });
     });
   }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.106.3) stable; urgency=medium
+
+  * Fix displaying of WB-MIO firmware update progress
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 10 Dec 2024 19:53:37 +0500
+
 wb-mqtt-homeui (2.106.2) stable; urgency=medium
 
   * Make Wiren Board Modbus device update errors more verbose


### PR DESCRIPTION
У нас есть устройства, которые подключаются через шлюз WB-MIO. У них вместо адреса задаётся адрес самого шлюза и через двоеточие смещение регистров в адресном пространстве. Таких устройств может быть несколько на одном шлюзе. Им нельзя обновить прошивку, но можно обновить прошивку шлюза. В интерфейсе на вкладках таких подключенных устройств показывается, что есть новая прошивка. При получении статуса обновления сравнивались строки: адрес шлюза (т.к. именно он обновляется) и адрес подключенного устройства со смещением. Из-за этого прогресс в интерфейсе не отображался, не отображался и прогресс на вкладках других подключенных к этому же шлюзу устройств.
Теперь сравниваю адреса без смещения и обновляю прогресс у всех подключенных устройств.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved logic for updating embedded software progress, allowing multiple device tabs with the same slave ID to be updated simultaneously.
	- Fixed display of firmware update progress for the WB-MIO device in the latest version (2.106.3) of the software package.

- **Bug Fixes**
	- Enhanced error verbosity for Wiren Board Modbus device updates in the previous version (2.106.2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->