### PR TITLE
Fix displaying of Mercury 230 in config of wb-mqtt-serial

### DIFF
--- a/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
+++ b/app/scripts/react-directives/device-manager/config-editor/configEditorPageStore.js
@@ -220,6 +220,13 @@ function getTopics(portTabs, deviceTypesStore) {
   return topics;
 }
 
+function getDeviceTypeFromConfig(deviceConfig) {
+  if (deviceConfig?.device_type) {
+    return deviceConfig.device_type;
+  }
+  return 'protocol:' + (deviceConfig?.protocol || 'modbus');
+}
+
 class ConfigEditorPageStore {
   constructor(
     loadConfigFn,
@@ -284,8 +291,12 @@ class ConfigEditorPageStore {
   }
 
   createDeviceTab(deviceConfig) {
-    const deviceType = deviceConfig?.device_type || deviceConfig?.protocol || 'modbus';
-    return new DeviceTab(deviceConfig, deviceType, this.deviceTypesStore, this.fwUpdateProxy);
+    return new DeviceTab(
+      deviceConfig,
+      getDeviceTypeFromConfig(deviceConfig),
+      this.deviceTypesStore,
+      this.fwUpdateProxy
+    );
   }
 
   createSettingsTab(config, schema) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-homeui (2.107.0) stable; urgency=medium
 
   * Fix displaying of Mercury 230 devices in config of wb-mqtt-serial
 
- -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 11 Dec 2024 12:05:00 +0500
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 11 Dec 2024 12:58:04 +0500
 
 wb-mqtt-homeui (2.106.2) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.107.0) stable; urgency=medium
+
+  * Fix displaying of Mercury 230 devices in config of wb-mqtt-serial
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 11 Dec 2024 12:05:00 +0500
+
 wb-mqtt-homeui (2.106.2) stable; urgency=medium
 
   * Make Wiren Board Modbus device update errors more verbose


### PR DESCRIPTION
При добавлении в настроки счётчика Меркурий 230. Отображалось, что это произвольное устройство с протоколом Меркурия. Проблема была в том, что wb-mqtt-serial возвращал список доступных шааблонов и протоклов с неуникальными ключами. 
Вот тут это поправил https://github.com/wirenboard/wb-mqtt-serial/pull/845. Но теперь ключ имеет немного другой формат, так что поправил ещё и загрузку конфигу тут


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a function to determine device type from configuration, improving clarity in device management.

- **Bug Fixes**
	- Fixed an issue with displaying Mercury 230 devices in the configuration settings.

- **Documentation**
	- Updated the changelog to reflect the new version and changes made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->