### PR TITLE
Fix mqtt channels value cell's width

### DIFF
--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -343,3 +343,7 @@ a[ng-click]:hover {
   text-decoration: none;
   cursor: pointer;
 }
+
+.mqtt-table-value {
+  word-break: break-all;
+}

--- a/app/styles/css/new.css
+++ b/app/styles/css/new.css
@@ -344,6 +344,28 @@ a[ng-click]:hover {
   cursor: pointer;
 }
 
+.mqtt-table-wrapper {
+  height: calc(100% - 150px);
+  overflow-y: auto !important;
+  border-top: 1px solid #ddd;
+}
+
+.mqtt-table-wrapper table {
+  border-top: 0 !important;
+  margin-top: 0 !important;
+}
+
+.mqtt-table-wrapper thead {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  box-shadow: 6px -6px #ddd inset;
+}
+
 .mqtt-table-value {
+  max-width: 300px;
+  width: max-content;
   word-break: break-all;
+  word-wrap: break-word;
+  white-space: break-spaces;
 }

--- a/app/views/MQTTChannels.html
+++ b/app/views/MQTTChannels.html
@@ -26,7 +26,7 @@
                 <span ng-show="row._metaReadonly">(ro)</span>
             </td>
             <td>/devices/{{row.deviceId}}/controls/{{row.controlId }}</td>
-            <td>{{row._value}}</td>
+            <td class="mqtt-table-value">{{row._value}}</td>
             <td>
                 <span ng-show="row.error" class="label label-danger">
                   {{'mqtt.error' | translate}}: {{row.error }}

--- a/app/views/MQTTChannels.html
+++ b/app/views/MQTTChannels.html
@@ -7,7 +7,7 @@
     </div>
 </div>
 
-<div class="table-responsive">
+<div class="table-responsive mqtt-table-wrapper">
     <table class="table table-bordered table-hover">
         <thead>
         <tr>
@@ -26,7 +26,9 @@
                 <span ng-show="row._metaReadonly">(ro)</span>
             </td>
             <td>/devices/{{row.deviceId}}/controls/{{row.controlId }}</td>
-            <td class="mqtt-table-value">{{row._value}}</td>
+            <td>
+                <div class="mqtt-table-value">{{row._value}}</div>
+            </td>
             <td>
                 <span ng-show="row.error" class="label label-danger">
                   {{'mqtt.error' | translate}}: {{row.error }}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.106.3) stable; urgency=medium
+
+  * Fix mqtt channels value cell's width
+
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Wed, 11 Dec 2024 16:10:10 +0300
+
 wb-mqtt-homeui (2.106.2) stable; urgency=medium
 
   * Make Wiren Board Modbus device update errors more verbose


### PR DESCRIPTION
Добавил перенос строк в значениях mqtt топиков
![image](https://github.com/user-attachments/assets/740a950a-06c2-4d58-9703-a11b690f5ca3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new CSS classes for enhanced table styling and text handling.
  
- **Bug Fixes**
	- Fixed the width of the MQTT channels value cell for better layout.

- **Documentation**
	- Updated version to 2.107.1 in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->