### PR TITLE
Remove obsolete code in SVG dashboards

### DIFF
--- a/app/scripts/react-directives/view-svg-dashboard/pageStore.js
+++ b/app/scripts/react-directives/view-svg-dashboard/pageStore.js
@@ -111,8 +111,8 @@ class ViewSvgDashboardPageStore {
       return;
     }
     try {
-      let cell = this.deviceData.cell(channel);
-      cell.value = cell.value == value.on ? value.off : value.on;
+      const cell = this.deviceData.cell(channel);
+      cell.value = cell.value === value.on ? value.off : value.on;
     } catch (e) {
       // Do nothing if cell is not found
     }

--- a/app/scripts/react-directives/view-svg-dashboard/pageStore.js
+++ b/app/scripts/react-directives/view-svg-dashboard/pageStore.js
@@ -15,7 +15,6 @@ class ViewSvgDashboardPageStore {
     this.editFn = null;
     this.moveToDashboardFn = null;
     this.dashboardId = null;
-    this.switchValueFn = null;
     this.key = Math.random();
     this.dashboardIndex = 0;
     this.editAccessLevelStore = new AccessLevelStore(rolesFactory);
@@ -51,10 +50,6 @@ class ViewSvgDashboardPageStore {
       this.channelValues,
       id => this?.editFn(id),
       id => this.moveToDashboard(id),
-      (channel, value) => {
-        let cell = this.deviceData.cell(channel);
-        cell.value = cell.value == value.on ? value.off : value.on;
-      },
       (channel, value) => this.switchValue(channel, value)
     );
     store.setForceFullscreen(this.forceFullscreen);
@@ -112,8 +107,15 @@ class ViewSvgDashboardPageStore {
   }
 
   switchValue(channel, value) {
-    let cell = this.deviceData.cell(channel);
-    cell.value = cell.value == value.on ? value.off : value.on;
+    if (!this.deviceData) {
+      return;
+    }
+    try {
+      let cell = this.deviceData.cell(channel);
+      cell.value = cell.value == value.on ? value.off : value.on;
+    } catch (e) {
+      // Do nothing if cell is not found
+    }
   }
 
   editDashboard() {
@@ -126,14 +128,6 @@ class ViewSvgDashboardPageStore {
 
   setMoveToDashboardFn(moveToDashboardFn) {
     this.moveToDashboardFn = moveToDashboardFn;
-  }
-
-  setSwitchValueFn(switchValueFn) {
-    this.switchValueFn = switchValueFn;
-  }
-
-  switchValue(channel, value) {
-    this?.switchValueFn(channel, value);
   }
 
   moveToDashboard(dashboardId) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.107.1) stable; urgency=medium
+
+  * Fix switch handling in SVG dashboards
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 13 Dec 2024 12:19:22 +0500
+
 wb-mqtt-homeui (2.107.0) stable; urgency=medium
 
   * Fix displaying of Mercury 230 devices in config of wb-mqtt-serial


### PR DESCRIPTION
Remove parts of legacy switch handling core in SVG dashboards

Была какая-то каша из старого кода, который задавал функцию изменения состояния переключателя. Убрал всё лишнее.
Добавил обработку исключений, если в дашборде прописан канал, которого реально нет в MQTT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved switch handling functionality in SVG dashboards.

- **Bug Fixes**
	- Enhanced error handling for value switching in the dashboard.

- **Documentation**
	- Updated changelog to reflect changes in version `2.107.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->