### PR TITLE
Fix showing of wb-rules debug console

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -154,7 +154,7 @@
       </button>
   </div>
 
-  <button type="button" class=" btn-default btn-lg show-console"
+  <button type="button" class="btn-default btn-lg show-console-button"
           ng-hide="consoleVisible"
           ng-click="consoleVisible = true">
       <span class="glyphicon glyphicon-wrench"></span>

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -391,7 +391,7 @@ footer{
   font-size: 12px;
 }
 
-button.show-console {
+.show-console-button {
   position: fixed;
   right: 30px;
   bottom: 30px;
@@ -401,16 +401,16 @@ button.show-console {
 }
 
 @media (min-width: 1200px) {
-  button.show-console {
+  .show-console-button {
     right: 40px;
   }
 }
 
-.show-console:hover {
+.show-console-button:hover {
   opacity: 1;
 }
 
-button.show-console span {
+.show-console-button span {
   vertical-align: -1px;
 }
 
@@ -1104,7 +1104,8 @@ body.hmi #widgets-list {
 
 body.hmi #wrapper .navbar,
 body.hmi .page-header,
-body.hmi .show-console {
+body.hmi .show-console-button,
+body.hmi .console {
   display: none
 }
 
@@ -1146,7 +1147,8 @@ body.hmi .show-console {
   }
 
   body.fullscreen .access-level-label,
-  body.fullscreen .show-console {
+  body.fullscreen .show-console-button,
+  body.fullscreen .console {
     display: none;
   }
 
@@ -1250,6 +1252,11 @@ button.dashboard-back:active {
   padding-left: 20px;
 }
 
-body.no-console .show-console {
+body.no-console .show-console-button,
+body.no-console .console {
   display: none
+}
+
+body.no-console .show-console #page-wrapper {
+  padding-bottom: 10px;
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.107.2) stable; urgency=medium
+
+  * Fix loading of wb-mqtt-serial configuration when showing wb-rules debug console
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 13 Dec 2024 16:13:48 +0500
+
 wb-mqtt-homeui (2.107.1) stable; urgency=medium
 
   * Fix mqtt channels value cell's width


### PR DESCRIPTION
wb-mqtt-serial config now displays correctly


Если включить консоль отладки и перейти на вкладку настроек wb-mqtt-serial, отображался чёрный экран. Поправил это

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated button for toggling console visibility with a new class name.
	- Enhanced functionality for loading configurations in the debug console.

- **Bug Fixes**
	- Improved loading of configuration settings in the debug console.

- **Style**
	- Renamed CSS class for the console toggle button and adjusted related styles for better responsiveness and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->