### PR TITLE
Fix enum translations in text dashboards

### DIFF
--- a/app/scripts/controllers/widgetsController.js
+++ b/app/scripts/controllers/widgetsController.js
@@ -30,6 +30,7 @@ class WidgetsCtrl {
       };
     }
 
+    $scope.locale = $locale.id;
     $scope.$locale = $locale;
     $scope.roles = rolesFactory;
     $scope.rows = [];

--- a/app/scripts/directives/widget.js
+++ b/app/scripts/directives/widget.js
@@ -25,6 +25,7 @@ function widgetDirective(DeviceData, rolesFactory, uiConfig) {
       this.multipleDashboards = false;
       this.$translate = $translate;
       this.$locale = $locale;
+      $scope.locale = $locale.id;
       $scope.$locale = $locale;
       $scope.$watch(
         () => this._source(),

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.107.4) stable; urgency=medium
+
+  * Fix enum translations in text dashboards
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 24 Dec 2024 09:51:56 +0500
+
 wb-mqtt-homeui (2.107.3) stable; urgency=medium
 
   * Fix loading of wb-mqtt-serial configuration when showing wb-rules debug console


### PR DESCRIPTION
Не везде переводились элементы в выпадающем списке

![изображение](https://github.com/user-attachments/assets/42337806-c0f9-467f-958d-2d731cc420f5)

Стало
![изображение](https://github.com/user-attachments/assets/67c3744e-d361-4ea6-9c1b-bea11f5d51e4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced localization capabilities in the widget controller and directive.
	- Improved access to locale information within templates and scope functionalities.

- **Bug Fixes**
	- Fixed enum translations in text dashboards for version `2.107.4`.

- **Documentation**
	- Updated changelog to reflect new version `2.107.4` and associated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->