### PR TITLE
Fix SVG dashboard switches handling

### DIFF
--- a/app/scripts/react-directives/view-svg-dashboard/pageStore.js
+++ b/app/scripts/react-directives/view-svg-dashboard/pageStore.js
@@ -112,7 +112,7 @@ class ViewSvgDashboardPageStore {
     }
     try {
       const cell = this.deviceData.cell(channel);
-      cell.value = cell.value === value.on ? value.off : value.on;
+      cell.value = cell.stringValue() === String(value.on) ? value.off : value.on;
     } catch (e) {
       // Do nothing if cell is not found
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.107.5) stable; urgency=medium
+
+  * Fix default SVG dashboard switches handling
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 14 Jan 2025 17:51:42 +0500
+
 wb-mqtt-homeui (2.107.4) stable; urgency=medium
 
   * Fix enum translations in text dashboards


### PR DESCRIPTION
Настройки дашборда хранятся в JSON. В нём для каждого элемента, который можно нажать, есть два параметра `on` и `off`. В них хранятся значения, которые пишутся в MQTT топик при нажатии. 

Проблемы:
1. По идее в `on` и `off должны быть строки. Но! В дашбордах по умолчанию там встречаются числа.
2. Внутри кода homeui хранится список текущих значений топиков из MQTT. Для контролов типа `switch` в MQTT публикуется `0` или `1`. Но во внутреннем списке homeui они зачем-то преобразуются в `true` и `false`.

[Тут](https://github.com/wirenboard/homeui/pull/677) изменил сравнение значений из внутреннего списка и из настроек дашборда с `==` на `===`. Раньше из-за неявного преобразования типов всё вроде бы работало, но теперь всегда `boolean !== int`. Сделал сравнение текстовых представлений значений, которые публикуются в MQTT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of SVG dashboard switches to ensure correct default behavior
	- Fixed issue with switch value comparison and interpretation

- **New Version**
	- Released version 2.107.5 of wb-mqtt-homeui package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->