### PR TITLE
Remove debian/wb-mqtt-homeui.dirs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.107.7) stable; urgency=medium
+
+  * Remove debian/wb-mqtt-homeui.dirs, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 27 Jan 2025 13:11:00 +0400
+
 wb-mqtt-homeui (2.107.6) stable; urgency=medium
 
   * Exclude shared ethernet connections from switching

--- a/debian/wb-mqtt-homeui.dirs
+++ b/debian/wb-mqtt-homeui.dirs
@@ -1,4 +1,0 @@
-var/www/images
-var/www/css
-var/www/views
-usr/share/wb-mqtt-homeui


### PR DESCRIPTION
wb-mqtt-homeui.dirs не нужен, так как эти директории создаются в Makefile.

See https://www.debian.org/doc/manuals/maint-guide/dother.en.html#dirs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
  - Upgraded package to version 2.107.7
- **Package Management**
  - Removed `wb-mqtt-homeui.dirs` file
  - No functional changes to the application's core features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->