### PR TITLE
fix url params transition

### DIFF
--- a/app/scripts/directives/displaycell.js
+++ b/app/scripts/directives/displaycell.js
@@ -4,12 +4,13 @@ function displayCellDirective(displayCellConfig, $compile) {
   'ngInject';
 
   class DisplayCellController {
-    constructor($scope, $state, $element, $attrs, handleData, historyUrlService) {
+    constructor($scope, $state, $element, $attrs, handleData, historyUrlService, $location) {
       'ngInject';
       this.$scope = $scope;
       this.cell = $scope.cell;
       this.cell.copy = this.copy.bind(this);
       this.$state = $state;
+      this.$location = $location;
       //console.log("+++++++++this.cell",this.cell);
 
       this.handleData = handleData;
@@ -46,8 +47,10 @@ function displayCellDirective(displayCellConfig, $compile) {
 
     redirect(contr) {
       var [device, control] = contr.split('/');
+      const currentParams = this.$location.search();
       this.$state.go('history.sample', {
         data: this.historyUrlService.encodeControl(device, control),
+        ...currentParams,
       });
     }
   }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.108.2) stable; urgency=medium
+
+  * Fix url params transition between dashboard and history
+
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Thu, 06 Feb 2025 12:40:31 +0300
+
 wb-mqtt-homeui (2.108.1) stable; urgency=medium
 
   * Add seconds to journal start date timepicker


### PR DESCRIPTION
Починил сохранение searchparams при переходе между дашбордом и историей

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved navigation by ensuring URL parameters are retained when moving between pages, such as from the dashboard to history views. This enhances continuity in your search or filter settings during transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->