### PR TITLE
Feature: Ask user confirmation before writing to the channel

### DIFF
--- a/app/scripts/i18n/react/locales/en/translations.json
+++ b/app/scripts/i18n/react/locales/en/translations.json
@@ -187,6 +187,7 @@
          "write-enable": "Write",
          "check": "Ask before write",
          "question": "Question before writing",
+         "default-question": "Do you want to change it?",
          "read-enable": "Read",
          "style-enable": "Style",
          "visible-enable": "Visible",

--- a/app/scripts/i18n/react/locales/en/translations.json
+++ b/app/scripts/i18n/react/locales/en/translations.json
@@ -185,6 +185,8 @@
          "common-parameters-fullscreen": "Fit fullscreen",
          "bindings-title": "Bindings",
          "write-enable": "Write",
+         "check": "Ask before write",
+         "question": "Question before writing",
          "read-enable": "Read",
          "style-enable": "Style",
          "visible-enable": "Visible",

--- a/app/scripts/i18n/react/locales/ru/translations.json
+++ b/app/scripts/i18n/react/locales/ru/translations.json
@@ -185,6 +185,7 @@
          "write-enable": "Запись в канал",
          "check": "Спросить перед записью",
          "question": "Вопрос перед записью",
+         "default-question": "Вы хотите изменить это?",
          "read-enable": "Чтение",
          "style-enable": "Стиль оформления",
          "visible-enable": "Видимость",

--- a/app/scripts/i18n/react/locales/ru/translations.json
+++ b/app/scripts/i18n/react/locales/ru/translations.json
@@ -183,6 +183,8 @@
          "common-parameters-fullscreen": "Растягивать во весь экран",
          "bindings-title": "Привязки",
          "write-enable": "Запись в канал",
+         "check": "Спросить перед записью",
+         "question": "Вопрос перед записью",
          "read-enable": "Чтение",
          "style-enable": "Стиль оформления",
          "visible-enable": "Видимость",

--- a/app/scripts/react-directives/edit-svg-dashboard/bindingsStore.js
+++ b/app/scripts/react-directives/edit-svg-dashboard/bindingsStore.js
@@ -53,7 +53,7 @@ const addEnableStore = (formStore, name) => {
   );
 };
 
-const makeWriteBindingStore = (devices, name) => {
+const makeLongPressWriteBindingStore = (devices, name) => {
   let res = new FormStore();
   addEnableStore(res, name);
   addChannelsStore(res, devices);
@@ -73,6 +73,24 @@ const makeWriteBindingStore = (devices, name) => {
     })
   );
   res.add('value', valueStore);
+  return res;
+};
+
+const makeWriteBindingStore = (devices, name) => {
+  let res = makeLongPressWriteBindingStore(devices, name);
+  res.add(
+    "check",
+    new BooleanStore({
+      name: i18n.t("edit-svg-dashboard.labels.check"),
+    })
+  );
+  res.add(
+    "question",
+    new StringStore({
+      name: i18n.t("edit-svg-dashboard.labels.question"),
+      validator: makeNotEmptyValidator(),
+    })
+  );
   return res;
 };
 
@@ -218,7 +236,7 @@ class SvgElementBindingsStore {
         );
         this.addParam(
           'long-press-write',
-          makeWriteBindingStore(devices, 'edit-svg-dashboard.labels.long-press-write-enable')
+          makeLongPressWriteBindingStore(devices, 'edit-svg-dashboard.labels.long-press-write-enable')
         );
         this.tagName = element.tagName;
       }

--- a/app/scripts/react-directives/edit-svg-dashboard/bindingsStore.js
+++ b/app/scripts/react-directives/edit-svg-dashboard/bindingsStore.js
@@ -53,7 +53,7 @@ const addEnableStore = (formStore, name) => {
   );
 };
 
-const makeLongPressWriteBindingStore = (devices, name) => {
+const makeWriteBindingStore = (devices, name) => {
   let res = new FormStore();
   addEnableStore(res, name);
   addChannelsStore(res, devices);
@@ -73,21 +73,16 @@ const makeLongPressWriteBindingStore = (devices, name) => {
     })
   );
   res.add('value', valueStore);
-  return res;
-};
-
-const makeWriteBindingStore = (devices, name) => {
-  let res = makeLongPressWriteBindingStore(devices, name);
   res.add(
-    "check",
+    'check',
     new BooleanStore({
-      name: i18n.t("edit-svg-dashboard.labels.check"),
+      name: i18n.t('edit-svg-dashboard.labels.check'),
     })
   );
   res.add(
-    "question",
+    'question',
     new StringStore({
-      name: i18n.t("edit-svg-dashboard.labels.question"),
+      name: i18n.t('edit-svg-dashboard.labels.question'),
       validator: makeNotEmptyValidator(),
     })
   );
@@ -236,7 +231,7 @@ class SvgElementBindingsStore {
         );
         this.addParam(
           'long-press-write',
-          makeLongPressWriteBindingStore(devices, 'edit-svg-dashboard.labels.long-press-write-enable')
+          makeWriteBindingStore(devices, 'edit-svg-dashboard.labels.long-press-write-enable')
         );
         this.tagName = element.tagName;
       }

--- a/app/scripts/react-directives/edit-svg-dashboard/visualBindingsEditor.jsx
+++ b/app/scripts/react-directives/edit-svg-dashboard/visualBindingsEditor.jsx
@@ -77,26 +77,42 @@ export const ClickBindingForm = observer(({ title, clickStore, writeStore, write
         />
       </div>
       {enabled && (
-        <div className="radios">
-          <Radio
-            id={writeStore.params.enable.id}
-            label={writeStore.params.enable.name}
-            value={writeStore.params.enable.value}
-            onChange={checked => {
-              writeStore.params.enable.setValue(checked);
-              clickStore.params.enable.setValue(!checked);
-            }}
-          />
-          <Radio
-            id={clickStore.params.enable.id}
-            label={clickStore.params.enable.name}
-            value={clickStore.params.enable.value}
-            onChange={checked => {
-              clickStore.params.enable.setValue(checked);
-              writeStore.params.enable.setValue(!checked);
-            }}
-          />
-        </div>
+        <>
+          <div className="radios">
+            <Radio
+              id={writeStore.params.enable.id}
+              label={writeStore.params.enable.name}
+              value={writeStore.params.enable.value}
+              onChange={(checked) => {
+                writeStore.params.enable.setValue(checked);
+                clickStore.params.enable.setValue(!checked);
+              }}
+            />
+            <Radio
+              id={clickStore.params.enable.id}
+              label={clickStore.params.enable.name}
+              value={clickStore.params.enable.value}
+              onChange={(checked) => {
+                clickStore.params.enable.setValue(checked);
+                writeStore.params.enable.setValue(!checked);
+              }}
+            />
+          </div>
+          {writeStore.params.check && (
+            <>
+              <Checkbox
+                label={writeStore.params.check.name}
+                value={writeStore.params.check.value}
+                onChange={e => (
+                  writeStore.params.check.setValue(e.target.checked)
+                )}
+              />
+              {writeStore.params.check.value && (
+                <FormStringEdit store={writeStore.params.question} />
+              )}
+            </>
+          )}
+        </>
       )}
       <MoveToBindingFormContent store={clickStore} />
       <WriteBindingFormContent store={writeStore} />

--- a/app/scripts/react-directives/view-svg-dashboard/svgView.jsx
+++ b/app/scripts/react-directives/view-svg-dashboard/svgView.jsx
@@ -132,7 +132,12 @@ const SvgView = observer(({ svg, params, values, className, onSwitchValue, onMov
         }
         if (param?.write?.enable) {
           disposers.push(
-            setClickHandler(el, () => onSwitchValue(param.write.channel, param.write.value))
+            setClickHandler(el, () => {
+              const question = param?.write?.question || 'Do you want to change it?';
+              if (!param?.write?.check || confirm(question)) {
+                onSwitchValue(param.write.channel, param.write.value);
+              }
+            })
           );
         } else {
           if (param?.click?.enable) {

--- a/app/scripts/react-directives/view-svg-dashboard/svgView.jsx
+++ b/app/scripts/react-directives/view-svg-dashboard/svgView.jsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite';
 import React, { useRef, useLayoutEffect } from 'react';
 import { get, reaction } from 'mobx';
+import i18n from '../../i18n/react/config';
 
 const getSvgElement = (svg, id) => {
   return svg.querySelector(`#${id}`) || svg.querySelector(`[data-svg-param-id=${id}]`);
@@ -133,7 +134,7 @@ const SvgView = observer(({ svg, params, values, className, onSwitchValue, onMov
         if (param?.write?.enable) {
           disposers.push(
             setClickHandler(el, () => {
-              const question = param?.write?.question || 'Do you want to change it?';
+              const question = param?.write?.question || i18n.t('edit-svg-dashboard.labels.default-question');
               if (!param?.write?.check || confirm(question)) {
                 onSwitchValue(param.write.channel, param.write.value);
               }


### PR DESCRIPTION
### Description  
Added a confirmation alert option for element clicks. Now, each element can be configured to prompt the user before writing data to the channel.  

### Features  
- A new **"Ask before write"** checkbox is available in the element settings.  
- When enabled, users will see a confirmation popup before writing data to the channel.
- A custom confirmation question can be set for each element, or a default question can be used.  

### Example Configuration  
Here’s how the new option looks in the element settings:  

![Element settings screenshot](https://github.com/user-attachments/assets/f9ddbf99-11f3-4e7f-a23b-03b77f476c96)

### User Confirmation Popup  
When clicking an element with confirmation enabled, users will see this popup:  

![Confirmation alert screenshot](https://github.com/user-attachments/assets/e5e6e37c-0a24-4682-a07d-fe4c75f015de)

### Benefits  
This feature helps prevent accidental writes to the channel and ensures more deliberate user interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the editing dashboard with additional confirmation prompts before executing write actions.
  - Introduced a toggle and associated input field to allow custom confirmation queries.
  - Updated language support with new localized prompts for English and Russian to improve clarity during write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->