### PR TITLE
Hide alert in hmi and fullscreen modes

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -25,11 +25,11 @@
   
   <div id="wrapper" class="fade" ng-class="{ 'show-console': consoleVisible }">
       <exp-check-widget></exp-check-widget>
-      <div class="alert alert-danger" role="alert" ng-cloak ng-if="noHttps">
+      <div class="alert alert-danger" role="alert" id="no-https-alert" ng-cloak ng-if="noHttps">
         <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
         <span translate>{{'app.errors.no-https'}}</span>
       </div>
-      <div class="alert alert-danger" role="alert" ng-cloak ng-if="roles.notConfiguredAdmin">
+      <div class="alert alert-danger" role="alert" id="not-configured-admin-alert" ng-cloak ng-if="roles.notConfiguredAdmin">
         <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
         <span translate>{{'app.errors.not-configured-admin'}}</span>
       </div>

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1091,11 +1091,18 @@ body.hmi #widgets-list {
   padding: 5px 7px;
 }
 
+body.hmi #not-configured-admin-alert,
+body.hmi #no-https-alert,
 body.hmi #wrapper .navbar,
 body.hmi .page-header,
 body.hmi .show-console-button,
 body.hmi .console {
   display: none
+}
+
+body.fullscreen #not-configured-admin-alert,
+body.fullscreen #no-https-alert {
+  display: none;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
Не показываю предупреждения о ненастроенных https и пользователях в полноэкранных режимах. Эти режимы предназначены для организации всяких панелек, так админ и https не сильно нужны, а пугать будут