### PR TITLE
Fix inverted switch controls in text dashboards

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.114.4) stable; urgency=medium
+
+  * Fix inverted switch controls in text dashboards
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 18 Mar 2025 18:20:31 +0500
+
 wb-mqtt-homeui (2.114.3) stable; urgency=medium
 
   * Fix progress text overflow

--- a/frontend/app/scripts/directives/switchcell.js
+++ b/frontend/app/scripts/directives/switchcell.js
@@ -14,8 +14,11 @@ function switchCellDirective() {
       scope.$watch(
         () => scope._value,
         (newValue, oldValue) => {
-          if (newValue !== oldValue && scope._value != scope.cell.value) {
-            scope.cell.value = scope.cell.extra.invert ? !scope._value : scope._value;
+          if (newValue !== oldValue) {
+            const valueToSet = scope.cell.extra.invert ? !scope._value : scope._value;
+            if (scope.cell.value != valueToSet) {
+              scope.cell.value = valueToSet;
+            }
           }
         }
       );


### PR DESCRIPTION
В текстовых дашбордах, если сделать инвертированный переключатель, не отправлялись значения в MQTT