### PR TITLE
Change text for oneOf JSON-editor error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.115.6) stable; urgency=medium
+
+  * Change text for oneOf JSON-editor error
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Mon, 31 Mar 2025 12:00:00 +0300
+
 wb-mqtt-homeui (2.115.5) stable; urgency=medium
 
   * Fix devices layout

--- a/frontend/app/scripts/json-editor/json-editor-ru.js
+++ b/frontend/app/scripts/json-editor/json-editor-ru.js
@@ -25,7 +25,7 @@ const JsonEditorRussianTranslation = {
    * When a value doesn't validate
    * @variables This key takes one variable: The number of schemas the value does not validate
    */
-  error_oneOf: 'Один или несколько параметров заданы неверно',
+  error_oneOf: 'Параметры заданы неверно',
   /**
    * When a value does not validate a 'not' schema
    */

--- a/frontend/app/scripts/json-editor/wb-json-editor.js
+++ b/frontend/app/scripts/json-editor/wb-json-editor.js
@@ -232,7 +232,7 @@ function overrideJSONEditor(data) {
   JSONEditor.defaults.editors['wb-array'] = makeWbArrayEditor();
   JSONEditor.defaults.editors['wb-first-oneof'] = makeFirstOneOfEditor();
 
-  JSONEditor.defaults.languages.en.error_oneOf = 'One or more parameters are invalid';
+  JSONEditor.defaults.languages.en.error_oneOf = 'Parameters are set incorrectly';
 
   JSONEditor.defaults.themes['wb-bootstrap3'] = makeWbBootstrap3Theme();
   JSONEditor.defaults.iconlibs['wb-bootstrap3'] = makeWbBootstrap3Iconlib();


### PR DESCRIPTION
Изменен текст ошибки oneOf

![image](https://github.com/user-attachments/assets/daaf49ab-959e-486a-aa2a-962f7d01ace8)

Было
- Один или несколько параметров заданы неверно
- One or more parameters are invalid

Стало
- Параметры заданы неверно
- Parameters are set incorrectly