### PR TITLE
Fix default value for parameters in group-editor

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.115.7) stable; urgency=medium
+
+  * Fix default values in MAI6 config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 02 Apr 2025 09:21:27 +0500
+
 wb-mqtt-homeui (2.115.6) stable; urgency=medium
 
   * Change text for oneOf JSON-editor error

--- a/frontend/app/scripts/json-editor/group-editor.js
+++ b/frontend/app/scripts/json-editor/group-editor.js
@@ -80,6 +80,11 @@ class Editor {
           this.editor.disable();
         }
       }
+      // Multiple editor sets null as default value in disabled state
+      // So set the correct default value
+      if (!this.editor.isEnabled()) {
+        this.editor.editors[this.editor.type].setValue(this.editor.editors[this.editor.type].getDefault());
+      }
     }
     if (this.isEnabled) {
       if (this.isTopLevelEditor()) {


### PR DESCRIPTION
Multiple editor sets null as default value in disabled state, so set the correct default value

___________________________________
**Что происходит; кому и зачем нужно:**

https://github.com/user-attachments/assets/e8f1b35e-edc9-4bf9-8078-ae01c0088119

Значения по умолчанию не подставлялись в редактор. Это баг json-editor, он некорректно вычисляет значение по умолчнию. Лезть в json-editor не хочу, поправил в коде homeui, который использует этот редактор

___________________________________
**Что поменялось для пользователей:**

https://github.com/user-attachments/assets/3397eaa3-da97-482b-86fa-a34280af6228



___________________________________
**Как проверял/а:**

Открыть шаблон MAI6 и выбрать для канала 4-20
