### PR TITLE
Fix build, enable lintian

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,2 @@
-buildDebSbuild defaultTargets: 'bullseye-armhf'
+buildDebSbuild defaultTargets: 'bullseye-armhf',
+               defaultRunLintian: true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.115.9) stable; urgency=medium
+
+  * Fix build
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 23 Apr 2025 10:40:00 +0400
+
 wb-mqtt-homeui (2.115.8) stable; urgency=medium
 
   * Fix device cell width overflow
@@ -66,7 +72,7 @@ wb-mqtt-homeui (2.114.3) stable; urgency=medium
 
 wb-mqtt-homeui (2.114.2) stable; urgency=medium
 
-* Fix searching for disconnected devices on TCP gateways
+  * Fix searching for disconnected devices on TCP gateways
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 14 Mar 2025 10:47:30 +0500
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,8 @@ Conflicts: wb-homa-webinterface
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          wb-homeui-backend (= ${binary:Version}),
-         diffutils
+         diffutils,
+         ucf
 Recommends: wb-mqtt-logs, wb-device-manager
 Suggests: wb-mqtt-confed (>= 1.4.0),
 Breaks: wb-mqtt-confed (<< 1.0.3),

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Package: wb-homeui-backend
 Architecture: all
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         ${python3:Depends},
+         python3,
          fcgiwrap,
          pigz,
          jq,

--- a/debian/wb-mqtt-homeui.lintian-overrides
+++ b/debian/wb-mqtt-homeui.lintian-overrides
@@ -1,0 +1,1 @@
+dir-or-file-in-var-www

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -5,6 +5,7 @@ PATH := /usr/local/bin:$(PATH)
 all: build
 
 clean:
+	npm install
 	npm run clean
 
 test:


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* Install rimraf before make clean
```sh
dh clean --parallel --with config-package
   dh_auto_clean
	make -j8 clean
make[1]: Entering directory '/home/jenkins/builder/workspace/wirenboard_homeui_feature_trixie/project'
make -C frontend clean
make[2]: Entering directory '/home/jenkins/builder/workspace/wirenboard_homeui_feature_trixie/project/frontend'
npm run clean

> homeui@0.1.0 clean
> node_modules/.bin/rimraf -G dist coverage ./tmp

sh: 1: rimraf: not found
```
Не стреляло, так как в devenv был предустановлен rimraf.
 * Enable lintian
___________________________________
**Что поменялось для пользователей:**
Nothing

___________________________________
**Как проверял/а:**


