### PR TITLE
Handle device schema loading errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.115.10) stable; urgency=medium
+
+  * Show error when trying to add device with invalid template to wb-mqtt-serial config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 29 Apr 2025 17:51:06 +0500
+
 wb-mqtt-homeui (2.115.9) stable; urgency=medium
 
   * Fix build

--- a/frontend/app/scripts/react-directives/device-manager/config-editor/deviceTabStore.js
+++ b/frontend/app/scripts/react-directives/device-manager/config-editor/deviceTabStore.js
@@ -1,16 +1,14 @@
-'use strict';
-
-import { makeObservable, observable, action, runInAction, computed } from 'mobx';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
-import { getDefaultObject } from './jsonSchemaUtils';
-import { TabType } from './tabsStore';
+import { makeObservable, observable, action, runInAction, computed } from 'mobx';
 import i18n from '../../../i18n/react/config';
 import { firmwareIsNewer, firmwareIsNewerOrEqual } from '../../../utils/fwUtils';
 import { getIntAddress } from '../common/modbusAddressesSet';
+import { getDefaultObject } from './jsonSchemaUtils';
+import { TabType } from './tabsStore';
 
 function toRpcPortConfig(portConfig) {
-  if (portConfig.hasOwnProperty('address')) {
+  if (Object.hasOwn(portConfig, 'address')) {
     return {
       address: portConfig.address,
       port: portConfig.port,
@@ -277,7 +275,7 @@ export class DeviceTab {
     }
     this.isDirty = !isEqual(this.data, data);
     this.editedData = cloneDeep(data);
-    this.hasJsonValidationErrors = errors.length != 0;
+    this.hasJsonValidationErrors = errors.length !== 0;
     this.updateName();
   }
 
@@ -287,6 +285,7 @@ export class DeviceTab {
       this.schema = await this.deviceTypesStore.getSchema(type);
     } catch (err) {
       this.setError(err.message);
+      this.hasJsonValidationErrors = true;
       this.setLoading(false);
       return;
     }
@@ -344,6 +343,7 @@ export class DeviceTab {
       this.schema = await this.deviceTypesStore.getSchema(this.deviceType);
     } catch (err) {
       this.setError(err.message);
+      this.hasJsonValidationErrors = true;
       this.setLoading(false);
       return;
     }
@@ -435,7 +435,7 @@ export class DeviceTab {
   }
 
   setError(err) {
-    this.error = err.message;
+    this.error = err;
   }
 
   clearError() {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Делаем невалидный шаблон, но валидный json с корректными полями типа устройства.
Добавляем руками устройство с этим шаблоном.
Получем белый экран, т.к. не обрабатывается ошибка валидации шаблона. 

___________________________________
**Что поменялось для пользователей:**
![Screenshot_20250429_175348](https://github.com/user-attachments/assets/dc2e5a84-0c10-426d-8a1e-5ad5acb6114b)
Большая мерзкая ошибка

___________________________________
**Как проверял/а:**
В имя канала добавил символ / и выбрал шаблон

