### PR TITLE
Use configured_device_type from wb-device-manager scn RPC

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.116.0) stable; urgency=medium
+
+  * Fix a bug where some devices were considered new when searching for new devices in the wb-mqtt-serial configuration editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 22 May 2025 12:50:23 +0500
+
 wb-mqtt-homeui (2.115.11) stable; urgency=medium
 
   * Fix wrong duplicate MQTT topic error in wb-mqtt-serial config editor

--- a/frontend/app/scripts/react-directives/device-manager/config-editor/configuredDevices.js
+++ b/frontend/app/scripts/react-directives/device-manager/config-editor/configuredDevices.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { getIntAddress } from '../common/modbusAddressesSet';
 
 /**
@@ -34,7 +32,7 @@ function makeConfiguredDevicesList(portTabChildren, deviceTypesStore) {
 
 function getConfiguredModbusDevices(portTabs, deviceTypesStore) {
   return portTabs.reduce((acc, portTab) => {
-    if (portTab.portType == 'serial' || portTab.portType == 'tcp') {
+    if (portTab.portType === 'serial' || portTab.portType === 'tcp') {
       acc[portTab.path] = {
         type: portTab.portType,
         config: portTab.baseConfig,
@@ -45,102 +43,18 @@ function getConfiguredModbusDevices(portTabs, deviceTypesStore) {
   }, {});
 }
 
-function isCompletelySameDevice(scannedDevice, configuredDevice) {
-  return (
-    configuredDevice.address == scannedDevice.cfg.slave_id &&
-    configuredDevice.signatures.includes(scannedDevice.device_signature) &&
-    configuredDevice.sn == scannedDevice.sn
-  );
-}
-
-function isPotentiallySameDevice(scannedDevice, configuredDevice) {
-  return (
-    configuredDevice.address == scannedDevice.cfg.slave_id &&
-    configuredDevice.signatures.includes(scannedDevice.device_signature) &&
-    !configuredDevice.sn
-  );
-}
-
-function hasSameSerialConfig(port, scannedDevice) {
-  // WB devices can operate regardless to stop bits setting, so compare baud rate, parity and data bits
-  return (
-    port.config?.baudRate == scannedDevice.cfg.baud_rate &&
-    port.config?.parity == scannedDevice.cfg.parity &&
-    port.config?.dataBits == scannedDevice.cfg.data_bits
-  );
-}
-
-function getConfiguredDevicesByAddress(configuredDevices, scannedDevice) {
-  if (!configuredDevices.hasOwnProperty(scannedDevice.port.path)) {
-    return [];
-  }
-  const port = configuredDevices[scannedDevice.port.path];
-  return port.devices.filter(
-    d =>
-      d.address == scannedDevice.cfg.slave_id &&
-      (port.type !== 'serial' || hasSameSerialConfig(port, scannedDevice))
-  );
-}
-
 class ConfiguredDevices {
   configuredDevices = [];
-
-  /**
-   * Key is the UUID of the scanned device
-   *
-   * @type {Object.<string, ConfiguredDevice>}
-   */
-  foundDevices = {};
 
   constructor(portTabs, deviceTypesStore) {
     this.configuredDevices = getConfiguredModbusDevices(portTabs, deviceTypesStore);
   }
 
   /**
-   * Finds a match for a scanned device in the configured devices.
-   *
-   * @param {Object} scannedDevice - The scanned device to find a match for.
-   * @returns {ConfiguredDevice|null} - The matched configured device, or null if no match is found.
-   */
-  findMatch(scannedDevice) {
-    let configuredDevice = this.foundDevices?.[scannedDevice.uuid];
-    if (configuredDevice) {
-      return configuredDevice;
-    }
-
-    const configuredDevicesWithSameAddress = getConfiguredDevicesByAddress(
-      this.configuredDevices,
-      scannedDevice
-    );
-
-    configuredDevice = configuredDevicesWithSameAddress.find(d =>
-      isCompletelySameDevice(scannedDevice, d)
-    );
-    if (configuredDevice) {
-      this.foundDevices[scannedDevice.uuid] = configuredDevice;
-      return configuredDevice;
-    }
-
-    // Config has devices without SN. They are configured but never polled, maybe found device is one of them
-    const maybeSameDevices = configuredDevicesWithSameAddress.filter(d =>
-      isPotentiallySameDevice(scannedDevice, d)
-    );
-
-    const foundDevicesList = Object.values(this.foundDevices);
-    const maybeSameDevice = maybeSameDevices.find(d => !foundDevicesList.includes(d));
-    if (maybeSameDevice) {
-      this.foundDevices[scannedDevice.uuid] = maybeSameDevice;
-      return maybeSameDevice;
-    }
-
-    return null;
-  }
-
-  /**
    * @returns {Map<string, Set<number>>} - Device addresses grouped by port path
    */
   getUsedAddresses() {
-    const getAddressesSet = devices => {
+    const getAddressesSet = (devices) => {
       return devices.reduce((addressAcc, d) => {
         const addrNumber = getIntAddress(d.address);
         return Number.isNaN(addrNumber) ? addressAcc : addressAcc.add(addrNumber);

--- a/frontend/app/scripts/react-directives/device-manager/scan/scanPageStore.js
+++ b/frontend/app/scripts/react-directives/device-manager/scan/scanPageStore.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { action, makeAutoObservable, makeObservable, observable, reaction, computed } from 'mobx';
 import i18n from '../../../i18n/react/config';
 import CollapseButtonState from '../../components/buttons/collapseButtonState';
@@ -35,7 +33,7 @@ class GlobalErrorStore {
       return;
     }
 
-    if (!error.hasOwnProperty('id')) {
+    if (!Object.hasOwn(error, 'id')) {
       this.error = error.message;
       return;
     }
@@ -85,14 +83,14 @@ class ScanningProgressStore {
     this.scanningPorts = scanningPorts;
     this.isExtendedScanning = isExtendedScanning;
 
-    if (this.actualState == this.requiredState) {
+    if (this.actualState === this.requiredState) {
       this.requiredState = ScanState.NotSpecified;
     }
   }
 
   startScan() {
     this.requiredState = ScanState.Started;
-    if (this.actualState == ScanState.Started) {
+    if (this.actualState === ScanState.Started) {
       return;
     }
     this.progress = 0;
@@ -105,7 +103,7 @@ class ScanningProgressStore {
 }
 
 class SingleDeviceStore {
-  constructor(scannedDevice, gotByFastScan, names, deviceTypes, selectable) {
+  constructor(scannedDevice, names, deviceTypes, selectable) {
     this.scannedDevice = scannedDevice;
     this.deviceTypes = deviceTypes;
     this.selectable = selectable;
@@ -114,7 +112,6 @@ class SingleDeviceStore {
     this.misconfiguredPort = false;
     this.duplicateMqttTopic = false;
     this.names = names;
-    this.gotByFastScan = gotByFastScan;
     this.disposer = undefined;
 
     makeObservable(this, {
@@ -171,6 +168,10 @@ class SingleDeviceStore {
     return undefined;
   }
 
+  get gotByFastScan() {
+    return this.scannedDevice?.fw?.ext_support;
+  }
+
   setSelected(value) {
     this.selected = this.selectable && value;
   }
@@ -205,7 +206,6 @@ class DevicesStore {
     this.newDevices = [];
     this.alreadyConfiguredDevices = [];
     this.configuredDevices = {};
-    this.devicesByUuid = new Set();
     this.deviceTypesStore = deviceTypesStore;
     this.selectionPolicy = SelectionPolicy.Multiple;
     this.allowToSelectDevicesInBootloader = false;
@@ -217,25 +217,16 @@ class DevicesStore {
     });
   }
 
-  addConfiguredDevice(scannedDevice, configuredDevice, gotByFastScan) {
-    const deviceStore = new SingleDeviceStore(
+  makeConfiguredDeviceStore(scannedDevice) {
+    return new SingleDeviceStore(
       scannedDevice,
-      gotByFastScan,
-      [this.deviceTypesStore.getName(configuredDevice.deviceType)],
-      [configuredDevice.deviceType],
+      [this.deviceTypesStore.getName(scannedDevice.configured_device_type)],
+      [scannedDevice.configured_device_type],
       false
     );
-    this.alreadyConfiguredDevices.push(deviceStore);
-    this.alreadyConfiguredDevices.sort((d1, d2) => {
-      if (d1.port == d2.port) {
-        return d1.address - d2.address;
-      }
-      return d1.port.localeCompare(d2.port);
-    });
-    this.devicesByUuid.add(scannedDevice.uuid);
   }
 
-  addNewDevice(scannedDevice, gotByFastScan) {
+  makeNewDeviceStore(scannedDevice) {
     const deviceTypes = this.deviceTypesStore.findNotDeprecatedDeviceTypes(
       scannedDevice.device_signature,
       scannedDevice.fw?.version
@@ -245,8 +236,7 @@ class DevicesStore {
 
     let deviceStore = new SingleDeviceStore(
       scannedDevice,
-      gotByFastScan,
-      deviceTypes.map(dt => this.deviceTypesStore.getName(dt)),
+      deviceTypes.map((dt) => this.deviceTypesStore.getName(dt)),
       deviceTypes,
       isSelectable
     );
@@ -259,46 +249,49 @@ class DevicesStore {
       deviceStore.disposer = disposer;
       deviceStore.setSelected(false);
     }
-    this.newDevices.push(deviceStore);
-    this.devicesByUuid.add(scannedDevice.uuid);
+    return deviceStore;
   }
 
-  addDevice(scannedDevice, gotByFastScan) {
-    if (this.devicesByUuid.has(scannedDevice.uuid)) {
-      return;
-    }
-
-    const configuredDevice = this.configuredDevices.findMatch(scannedDevice);
-    if (configuredDevice) {
-      this.addConfiguredDevice(scannedDevice, configuredDevice, gotByFastScan);
-    } else {
-      this.addNewDevice(scannedDevice, gotByFastScan);
-    }
-  }
-
-  setDevices(scannedDevicesList, gotByFastScan) {
+  setDevices(scannedDevicesList) {
     if (!Array.isArray(scannedDevicesList)) {
       return;
     }
-    scannedDevicesList.forEach(device => this.addDevice(device, gotByFastScan));
+
+    this.alreadyConfiguredDevices = [];
+    this.newDevices.forEach((device) => device.disposer?.());
+    this.newDevices = [];
+    scannedDevicesList.forEach((scannedDevice) => {
+      if (scannedDevice.configured_device_type) {
+        this.alreadyConfiguredDevices.push(this.makeConfiguredDeviceStore(scannedDevice));
+      } else {
+        this.newDevices.push(this.makeNewDeviceStore(scannedDevice));
+      }
+    });
+
+    this.alreadyConfiguredDevices.sort((d1, d2) => {
+      if (d1.port === d2.port) {
+        return d1.address - d2.address;
+      }
+      return d1.port.localeCompare(d2.port);
+    });
+
   }
 
   init(selectionPolicy, configuredDevices, allowToSelectDevicesInBootloader) {
     this.configuredDevices = configuredDevices;
     this.allowToSelectDevicesInBootloader = !!allowToSelectDevicesInBootloader;
-    this.newDevices.forEach(device => device.disposer?.());
+    this.newDevices.forEach((device) => device.disposer?.());
     this.selectionPolicy = selectionPolicy ?? SelectionPolicy.Multiple;
     this.newDevices = [];
     this.alreadyConfiguredDevices = [];
-    this.devicesByUuid.clear();
   }
 
   checkSingleSelection(selectedDevice) {
     if (!selectedDevice.selected) {
       return;
     }
-    this.newDevices.forEach(device => {
-      if (device != selectedDevice && device.selected) {
+    this.newDevices.forEach((device) => {
+      if (device !== selectedDevice && device.selected) {
         device.setSelected(false);
       }
     });
@@ -355,7 +348,7 @@ class CommonScanStore {
   setScanFailed(err) {
     this.acceptUpdates = false;
     this.scanStore.scanStopped();
-    if ('MqttTimeoutError'.localeCompare(err.data) == 0) {
+    if ('MqttTimeoutError'.localeCompare(err.data) === 0) {
       this.setDeviceManagerUnavailable();
     } else {
       this.globalError.setError(err.message);
@@ -364,15 +357,15 @@ class CommonScanStore {
 
   async startScanningCommon(type) {
     this.scanStore.startScan();
-    const preserve_old_results = type != 'extended';
-    if (!preserve_old_results) {
+    const preserveOldResults = type !== 'extended';
+    if (!preserveOldResults) {
       this.globalError.clearError();
     }
     try {
       if (await this.deviceManagerProxy.hasMethod('Start')) {
         let params = {
           scan_type: type,
-          preserve_old_results: preserve_old_results,
+          preserve_old_results: preserveOldResults,
         };
         if (this.portPath) {
           params.port = { path: this.portPath };
@@ -423,9 +416,9 @@ class CommonScanStore {
       data.scanning_ports,
       data.is_ext_scan
     );
-    this.devicesStore.setDevices(data.devices, data.is_ext_scan);
+    this.devicesStore.setDevices(data.devices);
     this.mqttStore.setStartupComplete();
-    if (this.scanStore.actualState == ScanState.Stopped) {
+    if (this.scanStore.actualState === ScanState.Stopped) {
       this.acceptUpdates = false;
     }
   }
@@ -455,8 +448,8 @@ class CommonScanStore {
 
   getSelectedDevices() {
     return this.devicesStore.newDevices
-      .filter(d => d.selected)
-      .map(d => {
+      .filter((d) => d.selected)
+      .map((d) => {
         return {
           title: d.title,
           port: d.port,
@@ -474,15 +467,15 @@ class CommonScanStore {
 
   get hasSelectedItems() {
     return (
-      this.devicesStore.newDevices.some(d => d.selected) &&
+      this.devicesStore.newDevices.some((d) => d.selected) &&
       this.scanStore.actualState !== ScanState.Started
     );
   }
 
   get isScanning() {
     return (
-      this.scanStore.requiredState == ScanState.Started ||
-      this.scanStore.actualState == ScanState.Started
+      this.scanStore.requiredState === ScanState.Started ||
+      this.scanStore.actualState === ScanState.Started
     );
   }
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Убрал логику поиска настроенных среди отсканированных устройств. Она не всегда работала https://wirenboard.youtrack.cloud/issue/SOFT-5148/MR6C-NC-vsegda-otobrazhayutsya-v-skanirovanii-kak-novye

Теперь информацию о настроенных устройствах выдает сам сканер
___________________________________
**Что поменялось для пользователей:**
Баг исправили

___________________________________
**Как проверял/а:**
Настроил как в тикете и сканировал

```
echo "deb http://deb.wirenboard.com/all experimental.new-scan main" > /etc/apt/sources.list.d/new-scan.list
```