### PR TITLE
Do not show new bootloader notification

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.115.12) stable; urgency=medium
+
+  * Show notification about new bootloader only if a new firmware is also available
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 23 May 2025 10:10:17 +0500
+
 wb-mqtt-homeui (2.115.11) stable; urgency=medium
 
   * Fix wrong duplicate MQTT topic error in wb-mqtt-serial config editor

--- a/frontend/app/scripts/react-directives/device-manager/config-editor/deviceTabStore.js
+++ b/frontend/app/scripts/react-directives/device-manager/config-editor/deviceTabStore.js
@@ -188,7 +188,7 @@ export class EmbeddedSoftware {
   }
 
   get hasUpdate() {
-    return this.firmware.hasUpdate || this.bootloader.hasUpdate;
+    return this.firmware.hasUpdate;
   }
 
   get hasError() {


### PR DESCRIPTION
Show notification about new bootloader only if a new firmware is also available

___________________________________
**Что происходит; кому и зачем нужно:**
Показываем оповещение о новом загрузчике только, если есть и новая прошивка. Аналогично ведёт себя консольная утилита.
Загрузчики выходят слишком часто, это раздражает пользователей, а толку мало.
Другой задачей будут решать, как оповещать только о нужных обновлениях. 

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


