### PR TITLE
Add custom menu backend

### DIFF
--- a/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
+++ b/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
@@ -257,4 +257,11 @@ server {
 		}
 		proxy_pass http://wb-homeui-back/api/https/setup;
 	}
+
+	location /ui/menu {
+		limit_except GET {
+			deny all;
+		}
+		proxy_pass http://wb-homeui-back/ui/menu;
+	}
 }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.120.0) stable; urgency=medium
+
+  * Add custom menu backend
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 24 Jul 2025 11:46:23 +0500
+
 wb-mqtt-homeui (2.119.2) stable; urgency=medium
 
   * Backup users db in /mnt/data


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сделал http endpoint /ui/menu, чтобы получать описание пользовательских пунктов меню.

- Содержимое ответа формируется из отдельных файлов *.json, которые можно положить в /usr/share/wb-mqtt-homeui/custom-menu.
- Файлы сортируются по названию.
- /usr/share/wb-mqtt-homeui/custom-menu может содержать подкаталоги, которые описывают подменю. Каждый подкаталон должен иметь файл folder.json с описанием заглавного пункта подменю. Файлы из под каталога добавляюься в ответе в поле items.

___________________________________
**Что поменялось для пользователей:**
Пока ничего, надо со стороны фронта реализовать обработку этого запроса

___________________________________
**Как проверял/а:**
Запросом

