### PR TITLE
Add /usr/share/wb-mqtt-homeui/nginx/includes

### DIFF
--- a/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
+++ b/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
@@ -38,6 +38,7 @@ map $wb_user_type $mosquitto_upstream {
 server {
 	include /etc/nginx/includes/default.wb.d/*.conf;
 	include /var/lib/wb-homeui/nginx/*.conf;
+	include /usr/share/wb-mqtt-homeui/nginx/includes/*.conf;
 
 	root /var/www;
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.120.0) stable; urgency=medium
+
+  * Add /usr/share/wb-mqtt-homeui/nginx/includes directory to nginx config
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 25 Jul 2025 15:42:50 +0500
+
 wb-mqtt-homeui (2.119.3) stable; urgency=medium
 
   * Change the title translation for scenarios

--- a/debian/wb-homeui-backend.dirs
+++ b/debian/wb-homeui-backend.dirs
@@ -1,0 +1,1 @@
+/usr/share/wb-mqtt-homeui/nginx/includes


### PR DESCRIPTION
The directory can be used by packages for custom includes in nginx config

___________________________________
**Что происходит; кому и зачем нужно:**
Добавил каталог /usr/share/wb-mqtt-homeui/nginx/includes. В него пакеты могут добавлять свои статические настройки. Например новые location для интеграции с алисой и т.п. 

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


