### PR TITLE
Fix login expiration

### DIFF
--- a/backend/wb/homeui_backend/main.py
+++ b/backend/wb/homeui_backend/main.py
@@ -86,8 +86,8 @@ def get_current_user(
         cookie_id = request_cookie.get("id")
         if cookie_id is not None:
             cookie_data = decode_cookie_data(cookie_id.value, keys_storage)
-            now = datetime.now(timezone.utc)
-            exp = datetime.fromtimestamp(int(cookie_data.get("exp", int(now.timestamp()))), tz=timezone.utc)
+            now = int(datetime.now(timezone.utc).timestamp())
+            exp = int(cookie_data.get("exp", now))
             if exp < now:
                 request.log_error("Cookie expired")
                 return None

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.119.4) stable; urgency=medium
+
+  * Fix login expiration
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 28 Jul 2025 15:33:48 +0500
+
 wb-mqtt-homeui (2.119.3) stable; urgency=medium
 
   * Change the title translation for scenarios


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Криво сравнивал время, с одной стороны были целочисленные секунды, с другой стороны posix timestamp в float с большим разрешением. В результате значения могли быть неравны и авторизация проваливалась из-за типа протушей печеньки

___________________________________
**Что поменялось для пользователей:**
Не будет неожиданных запросов ввода логина, будет стабильнее подключаться в mqtt

___________________________________
**Как проверял/а:**


