### PR TITLE
change mbgate default varchar register size to 1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.120.2) stable; urgency=medium
+
+  * Change mbgate default varchar register size to 1
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 31 Jul 2025 13:47:28 +0300
+
 wb-mqtt-homeui (2.120.1) stable; urgency=medium
 
   * Fix login expiration

--- a/frontend/app/scripts/react-directives/mbgate/pageStore.js
+++ b/frontend/app/scripts/react-directives/mbgate/pageStore.js
@@ -75,7 +75,7 @@ function makeWordRegisterBinding(topic, format) {
     unitId: 1,
     address: 1,
     format: format,
-    size: format == 'varchar' ? 0 : 2,
+    size: format == 'varchar' ? 1 : 2,
     max: 0,
     scale: 1,
     byteswap: false,


### PR DESCRIPTION
Поменял для `mbgate` размер `varchar` регистра по умолчанию на 1.
https://github.com/wirenboard/wb-mqtt-mbgate/pull/59

