### PR TITLE
Fix loading of Alice integration page

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.123.2) stable; urgency=medium
+
+  * Fix loading of Alice integration page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 25 Aug 2025 18:57:50 +0500
+
 wb-mqtt-homeui (2.123.1) stable; urgency=medium
 
   * Update README

--- a/frontend/src/stores/device/device.ts
+++ b/frontend/src/stores/device/device.ts
@@ -2,6 +2,16 @@ import { makeAutoObservable } from 'mobx';
 import i18n from '~/i18n/react/config';
 import { DeviceMeta, NameTranslations } from './types';
 
+function getFoldedDevices(): string[] {
+  try {
+    const stored = localStorage.getItem('foldedDevices');
+    if (stored !== null){
+      return JSON.parse(stored);
+    }
+  } catch (error) {}
+  return [];
+}
+
 export default class Device {
   public id: string;
   public cellIds: string[] = [];
@@ -12,7 +22,7 @@ export default class Device {
 
   constructor(id: string) {
     this.id = id;
-    this.isVisible = !JSON.parse(localStorage.getItem('foldedDevices')).includes(this.id);
+    this.isVisible = !getFoldedDevices().includes(this.id);
     makeAutoObservable(this, {}, { autoBind: true });
   }
 
@@ -38,7 +48,7 @@ export default class Device {
   }
 
   toggleDeviceVisibility() {
-    const foldedDevices = JSON.parse(localStorage.getItem('foldedDevices'));
+    const foldedDevices = getFoldedDevices();
     const updatedFoldedDevices = foldedDevices.includes(this.id)
       ? foldedDevices.filter((deviceId: string) => deviceId !== this.id)
       : [...foldedDevices, this.id];

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -355,7 +355,8 @@ module.exports = (function makeWebpackConfig() {
           '/auth/logout',
           '/mqtt',
           '/device/info',
-          '/api/https/setup'
+          '/api/https/setup',
+          '/api/integrations/alice'
         ],
         target: process.env.MQTT_BROKER_URI,
         ws: true,


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Исправил ошибку в процессе загрузки страницы интеграции с Алисой.
Проблема была в обращении к localStorage к объекту с ключём foldedDevices. Если его нет, для null пытались вызвать includes и получали исключение. Это исключение никак не обрабатывалось. Оно выпадало в контексте обработки сообщения от MQTT. Соединение с брокером рвалось.

___________________________________
**Что поменялось для пользователей:**
Настройками можно пользоваться

___________________________________
**Как проверял/а:**
Удалил из localStorage foldedDevices и грузил страницу Алисы

