### PR TITLE
Better handle admin cookie expiration

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.128.2) stable; urgency=medium
+
+  * Better handle admin cookie expiration
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 02 Sep 2025 17:50:38 +0500
+
 wb-mqtt-homeui (2.128.1) stable; urgency=medium
 
   * Handle components update error more accuracy

--- a/frontend/app/scripts/services/mqttService.js
+++ b/frontend/app/scripts/services/mqttService.js
@@ -240,9 +240,19 @@ function mqttClient(
         context.errorCode +
         ')'
     );
-    ngToast.dismiss();
-    $translate('mqtt.errors.connect', params).then(m => ngToast.danger(m));
-    reconnectAfterTimeout();
+    fetch('/auth/who_am_i').then(response => {
+      if (response.status === 401) {
+        location.reload();
+        return;
+      }
+      ngToast.dismiss();
+      $translate('mqtt.errors.connect', params).then(m => ngToast.danger(m));
+      reconnectAfterTimeout();
+    }).catch(() => {
+      ngToast.dismiss();
+      $translate('mqtt.errors.connect', params).then(m => ngToast.danger(m));
+      reconnectAfterTimeout();
+    });
   };
 
   //...........................................................................


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
https://wirenboard.youtrack.cloud/issue/SOFT-5739/Ne-obrabatyvaetsya-protuhanie-kuki-v-processe-raboty

Если куки оказалось невалидным в момент открытия веб сокета, перезагружаем страницу, что приводит к запросу ввода логина и пароля.

___________________________________
**Что поменялось для пользователей:**
В редких ситуациях, когда страница была долго открыта или поднята из кэша, запрос открытия веб сокета вернёт 401. Это значит, что куки протухла, и надо авторизоваться заново. Раньше просто висело сообщение, что не удалось подключиться, теперь будет открываться окно с логином.

___________________________________
**Как проверял/а:**
Смоделировал ответы от nginx

