### PR TITLE
Fix "delete" button hiding on history page

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.129.1) stable; urgency=medium
+
+  * Fix "delete" button hiding on history page
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 05 Sep 2025 16:00:00 +0400
+
 wb-mqtt-homeui (2.129.0) stable; urgency=medium
 
   * Count admin cookie lifetime from the last request

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Priority: optional
 Standards-Version: 4.5.1
 X-Python3-Version: >= 3.9
 Build-Depends: debhelper (>= 10),
-               pkg-config,
                nodejs (>= 18),
                j2cli,
                minify,

--- a/frontend/app/views/history.html
+++ b/frontend/app/views/history.html
@@ -14,7 +14,7 @@
         </div>
         <div class="col-xs-4 col-md-2">
             <div>
-                <div ng-hide="($index==0 && $ctrl.selectedControls.length==1) || !$ctrl.selectedControls[1]"
+                <div ng-hide="$index==0 && $ctrl.selectedControls.length==1"
                      ng-disabled="$ctrl.disableUi"
                      class="btn btn-danger" ng-click="$ctrl.deleteTopic($index)" translate>{{'history.buttons.delete'}}
                 </div>


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Когда выбран только один канал, а второй добавлен, но не выбран, то кнопки удалить нет, но если не удалить второй пункт, то невозможно загрузить историю, приходится сначала что-то выбрать во втором списке и тогда появится кнопка его удалить.

___________________________________
**Что поменялось для пользователей:**
есть кнопка удалить

___________________________________
**Как проверял/а:**
локально

