### PR TITLE
Do not redirect to HTTPS on localhost

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.130.1) stable; urgency=medium
+
+  * Do not redirect to HTTPS on localhost or 127.0.0.1
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 08 Sep 2025 11:27:02 +0500
+
 wb-mqtt-homeui (2.130.0) stable; urgency=medium
 
   * Open interface with admin privileges if there are no users

--- a/frontend/app/scripts/utils/httpsUtils.js
+++ b/frontend/app/scripts/utils/httpsUtils.js
@@ -81,8 +81,8 @@ async function hasInvalidCertificate(certStatus) {
 
 /**
  * Checks the current protocol and attempts to redirect to an HTTPS version of the site if applicable.
- * 
- * If the current protocol is HTTPS, the function returns 'ok'.
+ *
+ * If the current protocol is HTTPS or the hostname is a local domain, the function returns 'ok'.
  * If the hostname is an IP address or a local domain, it fetches device information using both HTTP and HTTPS.
  * If the device information matches, it redirects the browser to the HTTPS URL.
  * 
@@ -94,7 +94,9 @@ async function hasInvalidCertificate(certStatus) {
  * - 'redirected': If the browser is redirected to an HTTPS URL.
  */
 export async function checkHttps() {
-  if (window.location.protocol === 'https:') {
+  if (window.location.protocol === 'https:' ||
+      window.location.hostname === 'localhost' ||
+      window.location.hostname === '127.0.0.1') {
     return 'ok';
   }
 

--- a/frontend/app/scripts/utils/httpsUtils.js
+++ b/frontend/app/scripts/utils/httpsUtils.js
@@ -82,7 +82,7 @@ async function hasInvalidCertificate(certStatus) {
 /**
  * Checks the current protocol and attempts to redirect to an HTTPS version of the site if applicable.
  *
- * If the current protocol is HTTPS or the hostname is a local domain, the function returns 'ok'.
+ * If the current protocol is HTTPS or the hostname is a localhost or 127.0.0.1, the function returns 'ok'.
  * If the hostname is an IP address or a local domain, it fetches device information using both HTTP and HTTPS.
  * If the device information matches, it redirects the browser to the HTTPS URL.
  * 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При открытии интерфейса через браузер, установленный на контроллере, не делаем принудительный переход на https и не ругаемся, если он не настроен

___________________________________
**Что поменялось для пользователей:**
Часто используется для hdmi-экранов, там https не важен

___________________________________
**Как проверял/а:**
Локально

https://wirenboard.youtrack.cloud/issue/SOFT-5893/Ne-proveryat-HTTPS-dlya-lokalnyh-podklyuchenij

