### PR TITLE
SOFT-5972

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-homeui (2.134.1) stable; urgency=medium
+
+  * Fix cell error display
+  * Fix page scroll on dropdown open
+  * Fix history cell accessibility
+
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Mon, 15 Sep 2025 15:55:51 +0300
+
 wb-mqtt-homeui (2.134.0) stable; urgency=medium
 
   * Update dashboard page

--- a/frontend/src/components/cell/cell-button.tsx
+++ b/frontend/src/components/cell/cell-button.tsx
@@ -9,6 +9,7 @@ export const CellButton = observer(({ cell, name }: { cell: Cell; name?: string 
     <Button
       label={name || cell.name}
       size="small"
+      variant={cell.error ? 'danger' : 'primary'}
       disabled={cell.readOnly}
       onClick={() => cell.value = true}
     />

--- a/frontend/src/components/cell/cell-colorpicker.tsx
+++ b/frontend/src/components/cell/cell-colorpicker.tsx
@@ -12,6 +12,7 @@ export const CellColorpicker = observer(({ cell }: { cell: Cell }) => (
       value={cell.value as string}
       id={cell.id}
       isDisabled={cell.readOnly}
+      isInvalid={!!cell.error}
       ariaLabel={cell.name}
       onChange={(value) => cell.value = value}
     />

--- a/frontend/src/components/cell/cell-history.tsx
+++ b/frontend/src/components/cell/cell-history.tsx
@@ -19,7 +19,9 @@ export const CellHistory = observer(({ cell }: { cell: Cell }) => {
   return (
     <a href={getChartUrl} aria-label={`${t('widget.labels.graph')} ${cell.name}`}>
       <Tooltip text={t('widget.labels.graph')} placement="top-end">
-        <StatsIcon className="deviceCell-historyLink" />
+        <span>
+          <StatsIcon className="deviceCell-historyLink" />
+        </span>
       </Tooltip>
     </a>
   );

--- a/frontend/src/components/cell/cell-range.tsx
+++ b/frontend/src/components/cell/cell-range.tsx
@@ -15,6 +15,7 @@ export const CellRange = observer(({ cell }: { cell: Cell }) => {
       max={cell.max}
       step={cell.step}
       isDisabled={cell.readOnly}
+      isInvalid={!!cell.error}
       ariaLabel={cell.name}
       units={t(`units.${cell.units}`, cell.units)}
       onChange={(value) => cell.value = value}

--- a/frontend/src/components/cell/cell-switch.tsx
+++ b/frontend/src/components/cell/cell-switch.tsx
@@ -13,6 +13,7 @@ export const CellSwitch = observer(({ cell, inverted }: { cell: Cell; inverted?:
       id={cell.id}
       isDisabled={cell.readOnly}
       ariaLabel={cell.name}
+      isInvalid={!!cell.error}
       onChange={(value) => cell.value = inverted ? !value : value}
     />
   </>

--- a/frontend/src/components/cell/cell-text.tsx
+++ b/frontend/src/components/cell/cell-text.tsx
@@ -36,6 +36,7 @@ export const CellText = observer(({ cell, isCompact }: { cell: Cell; isCompact: 
       {(!cell.readOnly && cell.isEnum) && (
         <Dropdown
           size="small"
+          isInvalid={!!cell.error}
           options={cell.enumValues.map(({ name, value }) => ({ label: name, value }))}
           value={cell.value as string | number}
           onChange={(option: Option<string>) => cell.value = option.value}
@@ -46,6 +47,7 @@ export const CellText = observer(({ cell, isCompact }: { cell: Cell; isCompact: 
           id={cell.id}
           value={cell.value as string}
           isDisabled={cell.readOnly}
+          isInvalid={!!cell.error}
           size="small"
           ariaLabel={cell.name}
           isWithExplicitChanges

--- a/frontend/src/components/cell/cell-value.tsx
+++ b/frontend/src/components/cell/cell-value.tsx
@@ -51,6 +51,7 @@ export const CellValue = observer(({ cell }: { cell: Cell }) => {
             <CellHistory cell={cell} />
             <Dropdown
               size="small"
+              isInvalid={!!cell.error}
               options={cell.enumValues.map(({ name, value }) => ({ label: name, value }))}
               value={cell.value as string | number}
               ariaLabel={cell.name}
@@ -64,6 +65,7 @@ export const CellValue = observer(({ cell }: { cell: Cell }) => {
               id={cell.id}
               type="number"
               size="small"
+              isInvalid={!!cell.error}
               className="deviceCell-text"
               value={cell.value as number}
               isDisabled={cell.readOnly}

--- a/frontend/src/components/colorpicker/colorpicker.tsx
+++ b/frontend/src/components/colorpicker/colorpicker.tsx
@@ -1,9 +1,10 @@
+import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import { ColorpickerProps } from './types';
 import './styles.css';
 
 export const Colorpicker = ({
-  value, id, isDisabled, onChange, ariaLabel,
+  value, id, isDisabled, isInvalid, onChange, ariaLabel,
 }: ColorpickerProps) => {
   const [proxyValue, setProxyValue] = useState('#000000');
 
@@ -14,7 +15,9 @@ export const Colorpicker = ({
   return (
     <input
       type="color"
-      className="colorpicker"
+      className={classNames('colorpicker', {
+        'colorpicker-invalid': isInvalid,
+      })}
       id={id}
       disabled={isDisabled}
       aria-label={ariaLabel}

--- a/frontend/src/components/colorpicker/styles.css
+++ b/frontend/src/components/colorpicker/styles.css
@@ -15,8 +15,13 @@
 
 .colorpicker:disabled {
     cursor: not-allowed;
+    opacity: 0.5;
 }
 
 .colorpicker:focus {
     box-shadow: var(--input-active-shadow);
+}
+
+.colorpicker-invalid {
+    background: var(--danger-color);
 }

--- a/frontend/src/components/colorpicker/types.ts
+++ b/frontend/src/components/colorpicker/types.ts
@@ -1,7 +1,8 @@
 export interface ColorpickerProps {
   id: string;
   value: string;
-  isDisabled: boolean;
+  isDisabled?: boolean;
+  isInvalid?: boolean;
   ariaLabel?: string;
   onChange: (_val: string) => void;
 }

--- a/frontend/src/components/dropdown/dropdown.tsx
+++ b/frontend/src/components/dropdown/dropdown.tsx
@@ -29,6 +29,7 @@ export const Dropdown = ({
   size = 'default',
   ariaLabel,
   isDisabled,
+  isInvalid,
   isSearchable = false,
   isButton,
   minWidth = '150px',
@@ -51,6 +52,7 @@ export const Dropdown = ({
       inputId={id}
       className={classNames(getClassNames(className, size), {
         'dropdown-button': isButton,
+        'dropdown-invalid': isInvalid,
       })}
       classNamePrefix="dropdown"
       options={options}
@@ -62,6 +64,7 @@ export const Dropdown = ({
       menuPortalTarget={document.body}
       menuPlacement="auto"
       maxMenuHeight={240}
+      menuPosition="fixed"
       components={{
         MenuPortal: (props) => MenuPortal(props, size),
         DropdownIndicator: (props) => DropdownIndicator(props, isButton),

--- a/frontend/src/components/dropdown/styles.css
+++ b/frontend/src/components/dropdown/styles.css
@@ -115,3 +115,8 @@
 .dropdown-icon {
   width: 12px;
 }
+
+.dropdown-invalid .dropdown__control {
+  color: var(--danger-color);
+  border-color: var(--danger-color);
+}

--- a/frontend/src/components/dropdown/types.ts
+++ b/frontend/src/components/dropdown/types.ts
@@ -15,5 +15,6 @@ export interface DropdownProps<T = string | boolean | number | null | unknown> {
   isDisabled?: boolean;
   isButton?: boolean;
   isSearchable?: boolean;
+  isInvalid?: boolean;
   minWidth?: string;
 }

--- a/frontend/src/components/input/input.tsx
+++ b/frontend/src/components/input/input.tsx
@@ -12,6 +12,7 @@ export const Input = ({
   onChangeEvent,
   type = 'text',
   isFullWidth = false,
+  isInvalid,
   size = 'default',
   ariaLabel,
   ariaDescribedby,
@@ -62,6 +63,7 @@ export const Input = ({
         'input-m': size === 'default',
         'input-s': size === 'small',
         'input-fullWidth': isFullWidth,
+        'input-invalid': isInvalid,
       })}
       disabled={isDisabled}
       value={internalValue}

--- a/frontend/src/components/input/styles.css
+++ b/frontend/src/components/input/styles.css
@@ -27,3 +27,12 @@
 .input-fullWidth {
     width: 100%;
 }
+
+.input-invalid {
+    color: var(--danger-color);
+    border-color: var(--danger-color);
+}
+
+input[type=number]::-webkit-inner-spin-button {
+    margin-left: 6px;
+}

--- a/frontend/src/components/input/types.ts
+++ b/frontend/src/components/input/types.ts
@@ -23,6 +23,7 @@ type BaseInputProps = {
   ariaInvalid?: boolean;
   ariaErrorMessage?: string;
   isFullWidth?: boolean;
+  isInvalid?: boolean;
   isWithExplicitChanges?: boolean;
   onChange?: (_val: string | number, _badInput?: boolean) => void;
   onChangeEvent?: (_ev: any) => void;

--- a/frontend/src/components/range/range.tsx
+++ b/frontend/src/components/range/range.tsx
@@ -4,7 +4,7 @@ import { RangeProps } from './types';
 import './styles.css';
 
 export const Range = ({
-  value, id, isDisabled, min, max, step, units, onChange, ariaLabel,
+  value, id, isDisabled, min, max, step, units, isInvalid, onChange, ariaLabel,
 }: RangeProps) => {
   const [proxyValue, setProxyValue] = useState(0);
   const input = useRef<HTMLInputElement>(null);
@@ -23,7 +23,11 @@ export const Range = ({
   }, [value]);
 
   return (
-    <div className="range-container">
+    <div
+      className={classNames('range-container', {
+        'range-invalid': isInvalid,
+      })}
+    >
       <input
         ref={input}
         type="range"

--- a/frontend/src/components/range/styles.css
+++ b/frontend/src/components/range/styles.css
@@ -45,6 +45,14 @@
     transition: background .15s ease-in-out, var(--input-active-shadow-transition);
 }
 
+.range-invalid .range::-moz-range-thumb {
+    background: var(--danger-color);
+}
+
+.range-invalid .range::-webkit-slider-thumb {
+    background: var(--danger-color);
+}
+
 .range::-webkit-slider-thumb {
     appearance: none;
     width: 16px;

--- a/frontend/src/components/range/types.ts
+++ b/frontend/src/components/range/types.ts
@@ -5,6 +5,7 @@ export interface RangeProps {
   max: number;
   step: number;
   units?: string;
+  isInvalid?: boolean;
   isDisabled: boolean;
   ariaLabel?: string;
   onChange: (_val: number) => void;

--- a/frontend/src/components/switch/styles.css
+++ b/frontend/src/components/switch/styles.css
@@ -47,3 +47,11 @@
 .toggle-switchy > input + .toggle:before {right:50%; font-size: 12px;}
 .toggle-switchy > input + .toggle:after {left:50%; font-size: 12px;}
 
+.toggle-switchy-invalid .toggle {
+    background: var(--danger-color) !important;
+}
+
+.toggle-switchy-invalid .switch {
+    border-color: var(--danger-color) !important;
+}
+

--- a/frontend/src/components/switch/switch.tsx
+++ b/frontend/src/components/switch/switch.tsx
@@ -1,12 +1,15 @@
+import classNames from 'classnames';
 import { SwitchProps } from './types';
 import './styles.css';
 
 export const Switch = ({
-  value, id, isDisabled, onChange = () => {}, ariaLabel,
+  value, id, isDisabled, isInvalid, onChange = () => {}, ariaLabel,
 }: SwitchProps) => (
   <label
     htmlFor={id}
-    className="toggle-switchy"
+    className={classNames('toggle-switchy', {
+      'toggle-switchy-invalid': isInvalid,
+    })}
     onClick={(ev) => {
       ev.stopPropagation();
     }}

--- a/frontend/src/components/switch/types.ts
+++ b/frontend/src/components/switch/types.ts
@@ -2,6 +2,7 @@ export interface SwitchProps {
   id: string;
   value: boolean;
   isDisabled?: boolean;
+  isInvalid?: boolean;
   ariaLabel?: string;
   onChange: (_val: boolean) => void;
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Исправил:

1. Выпадающие списки и поля ввода не окрашиваются красным при ошибке
2. Кнопочки изменения значения у полей ввода прижаты к самому значению
3. Неправильно зачитывается кнопка история со скринридера
4. При открытии dropdown может появится скролл у страницы

<img width="784" height="1013" alt="image" src="https://github.com/user-attachments/assets/38241e9c-7fad-4aed-ab11-1601c74c15fa" />

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
Локально

