### PR TITLE
Fix unexpected cookie expiration

### DIFF
--- a/backend/wb/homeui_backend/main.py
+++ b/backend/wb/homeui_backend/main.py
@@ -40,6 +40,10 @@ DEFAULT_DB_FILE = "/var/lib/wb-homeui/users.db"
 
 ADMIN_COOKIE_LIFETIME = timedelta(days=14)
 
+# A very long lifetime as we don't want cookies to expire by browser policy
+# We will check cookie validity internally
+DEFAULT_COOKIE_LIFETIME = timedelta(days=365 * 20)
+
 
 def make_password_hash(password: str) -> str:
     return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
@@ -55,6 +59,8 @@ def make_id_cookie(session: Session, secure: bool) -> cookies.SimpleCookie:
     cookie["id"]["path"] = "/"
     cookie["id"]["httponly"] = True
     cookie["id"]["samesite"] = "Lax"
+    expires = session.start_date + DEFAULT_COOKIE_LIFETIME
+    cookie["id"]["expires"] = expires.strftime("%a, %d %b %Y %H:%M:%S GMT")
     if secure:
         cookie["id"]["secure"] = True
     return cookie

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.134.3) stable; urgency=medium
+
+  * Fix unexpected cookie expiration
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 17 Sep 2025 15:30:27 +0500
+
 wb-mqtt-homeui (2.134.2) stable; urgency=medium
 
   * Fixed synchronization of saves between text and svg dashboards (broken in 2.134.0)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Задал время жизни cookie. Когда оно не было указано, браузер сам решал, когда удалить cookie. Браузерный механизм не используется, потому задал очень большой срок.

Для пользователя и оператора куки вечные. Для админа - 2 недели с момента последнего взаимодействия. Это проверяется в бэке отдельно.

___________________________________
**Что поменялось для пользователей:**
Не будет неожиданных запросов на ввод логина и пароля

___________________________________
**Как проверял/а:**
Браузером

