### PR TITLE
Use the same cookie for HTTP and HTTPS

### DIFF
--- a/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
+++ b/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
@@ -224,7 +224,6 @@ server {
 		limit_except POST {
 			deny all;
 		}
-		proxy_set_header X-Forwarded-Scheme $scheme;
 		proxy_pass http://wb-homeui-back/auth/login;
 	}
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.141.1) stable; urgency=medium
+
+  * Use the same cookie for HTTP and HTTPS
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 03 Oct 2025 11:27:08 +0500
+
 wb-mqtt-homeui (2.141.0) stable; urgency=medium
 
   * Change switch's off color


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Использую одну и ту же cookie для HTTP и HTTPS

___________________________________
**Что поменялось для пользователей:**
Если пользователь получил куки через HTTPS, а потом переключился на HTTP, он не мог залогиниться. Бэк выдавал новую куки с тем же именем, но без Secure. Браузеры не принимают такие куки, т.к. они перезаписывают уже сохранённые куки с Secure. Ошибок внятных не выдаётся, просто не логинится.

___________________________________
**Как проверял/а:**
Попробовал то, что описано в тикете https://wirenboard.youtrack.cloud/issue/SOFT-6036/Avtorizaciya-v-https-meshaet-http

