### PR TITLE
Fix default config generation

### DIFF
--- a/backend/21wb-homeui-backend
+++ b/backend/21wb-homeui-backend
@@ -1,3 +1,4 @@
+/usr/lib/wb-homeui-backend/generate-system-config.sh
 wb_move /var/lib/wb-homeui/users.db
 wb_move /etc/wb-webui.conf
 wb_move /etc/wb-homeui-backend.conf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.189.1) stable; urgency=medium
+
+  * Fix default config generation during first boot
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 24 Mar 2026 18:24:20 +0300
+
 wb-mqtt-homeui (2.189.0) stable; urgency=medium
 
   * Use wb-mqtt-serial instead of wb-device-manager for devices firmware updating

--- a/debian/wb-homeui-backend.service
+++ b/debian/wb-homeui-backend.service
@@ -7,7 +7,6 @@ Type=simple
 User=root
 EnvironmentFile=-/etc/default/wb-homeui-backend
 ExecStart=/usr/bin/wb-homeui-backend $WB_HOMEUI_BACKEND_OPTIONS
-ExecStartPre=/usr/lib/wb-homeui-backend/generate-system-config.sh
 Restart=on-failure
 RestartSec=2
 RestartPreventExitStatus=2 3 4 5 6 7


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Из за того, что переместили генерацию конфига из пост-инсталл скрипта на старт сервиса, получается, что при первом запуске wb-configs-early не может сделать симлинк, так как конфига еще не существует. В других сервисах (где не сделана та же схема), конфиги раскладываются на этапе сборки рутфс и при первом запуске все симлинки на месте
Жалоб от юзеров особо не было, но проявилось в виде бага в пакете демо-чемодана: после его установки чемоданные конфиги не подхватываются до первого ребута, так как конфигс не сделал симлинки.

https://github.com/wirenboard/homeui/pull/843
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
сделала фит и проверила