### PR TITLE
feat: add plugins support

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,0 +1,130 @@
+# Plugin System
+
+homeui supports runtime plugins that add new pages to the web interface without rebuilding the main application.
+
+## How it works
+
+1. Backend endpoint `GET /api/plugins` scans `/usr/share/wb-mqtt-homeui/plugins/*/manifest.json`
+2. Frontend reads manifests and registers menu items in the navigation panel
+3. When user navigates to a plugin page, `PluginHost` component dynamically loads the plugin script
+4. Plugin script accesses shared React and UI components via `window.__HOMEUI__`
+5. Plugin registers itself and its components through `window.__HOMEUI__.pluginRegistry`
+
+## Plugin structure
+
+```
+/usr/share/wb-mqtt-homeui/plugins/<plugin-id>/
+  manifest.json
+  index.js
+```
+
+## manifest.json
+
+```jsonc
+{
+  "id": "my-plugin",
+  "version": "1.0.0",
+  "title": { "ru": "My Plugin", "en": "My Plugin" },
+  // Cache-busting: increment ?v=N on each deploy
+  "entrypoint": "index.js?v=1",
+  "menu": {
+    // Parent section: "settings", "rules", "devices", etc.
+    "parentId": "settings",
+    "item": {
+      "id": "my-plugin",
+      // Format: plugins/<plugin-id>/<ComponentName>
+      "url": "plugins/my-plugin/MyPage",
+      "title": { "ru": "My Plugin", "en": "My Plugin" }
+    }
+  }
+}
+```
+
+## Plugin entry point
+
+Plugins are IIFE scripts that use `window.__HOMEUI__` instead of bundling their own React.
+
+```js
+(function () {
+  'use strict';
+
+  var HOMEUI = window.__HOMEUI__;
+  if (!HOMEUI || !HOMEUI.pluginRegistry) return;
+
+  var React = HOMEUI.React;
+  var h = React.createElement;
+  var useState = React.useState;
+
+  var C = HOMEUI.components;
+  var PageLayout = C.PageLayout;
+  var Card = C.Card;
+  var Button = C.Button;
+
+  function MyPage() {
+    return h(PageLayout, { title: 'My Plugin', hasRights: true },
+      h(Card, { heading: 'Hello' },
+        h('p', null, 'Plugin content here')
+      )
+    );
+  }
+
+  HOMEUI.pluginRegistry.register({
+    id: 'my-plugin',
+    components: { MyPage: MyPage },
+  });
+})();
+```
+
+## Plugin API (`window.__HOMEUI__`)
+
+| Property | Description |
+|---|---|
+| `version` | API version (currently `1`) |
+| `pluginRegistry` | `register(def)`, `get(id)`, `getAll()` |
+| `React` | Shared React instance |
+| `ReactDOM` | Shared ReactDOM/client |
+| `services` | Runtime services (injected by app.js after init) |
+| `components` | Shared UI components (see below) |
+
+### Available components
+
+**Layout:** `PageLayout`, `Card`, `Dialog`, `Confirm`
+
+**Input:** `Input`, `Range`, `Checkbox`, `Switch`, `Dropdown`
+
+**Display:** `Button`, `Table`, `TableRow`, `TableCell`, `Tag`, `Alert`, `Loader`
+
+**Navigation:** `Tabs`, `TabContent`
+
+### Services
+
+Services are available after the application initializes. Check availability before use.
+
+| Service | Description |
+|---|---|
+| `services.mqttClient` | MQTT client. Methods: `send(topic, value)`, `isConnected()`, `addStickySubscription(topic, handler)`, `unsubscribe(topic)` |
+| `services.ConfigEditorProxy` | Config editor RPC. Methods: `Load({path})`, `Save({path, content})` |
+| `services.EditorProxy` | Rules editor RPC |
+
+## Deployment
+
+1. Create plugin directory:
+   ```
+   /usr/share/wb-mqtt-homeui/plugins/<plugin-id>/
+   ```
+
+2. Place `manifest.json` and `index.js` inside
+
+3. Ensure nginx serves static files (symlink should exist):
+   ```
+   /var/www/plugins -> /usr/share/wb-mqtt-homeui/plugins
+   ```
+
+4. Reload the web interface
+
+## Existing plugins
+
+| Plugin | Menu location | Description |
+|---|---|---|
+| `wb-buzzer` | Settings > Buzzer | Buzzer control panel with presets |
+| `wb-scenarios-v2` | Rules > Scenarios V2 | Scenario CRUD editor |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Change listen settings in `/etc/nginx/includes/default.wb.d/listen.conf`.
 3. Create `.env` file and set `MQTT_BROKER_URI` if your controller is running on different IP (default is 10.200.200.1)
 4. Start the development server: `npm run start`
 
+## Plugins
+
+homeui supports runtime plugins that add new pages without rebuilding the application. See [PLUGINS.md](PLUGINS.md) for the full guide.
+
 ## Custom menu
 One can put a JSON-file with custom menu description in `/usr/share/wb-mqtt-homeui/custom-menu`.
 Items, defined in the file, will be added to left navigation panel.

--- a/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
+++ b/backend/configs/usr/share/wb-mqtt-homeui/nginx/default.conf
@@ -273,4 +273,13 @@ server {
 		}
 		proxy_pass http://wb-homeui-back/ui/menu;
 	}
+
+	location /api/plugins {
+		limit_except GET {
+			deny all;
+		}
+		proxy_pass http://wb-homeui-back/api/plugins;
+	}
+
+	# Plugin static files served via symlink /var/www/plugins -> /usr/share/wb-mqtt-homeui/plugins
 }

--- a/backend/wb/homeui_backend/main.py
+++ b/backend/wb/homeui_backend/main.py
@@ -40,6 +40,7 @@ from .users_storage import User, UsersStorage, UserType
 DEFAULT_SOCKET_FILE = "/tmp/wb-homeui.socket"
 DEFAULT_DB_FILE = "/var/lib/wb-homeui/users.db"
 CUSTOM_MENU_FOLDER = "/usr/share/wb-mqtt-homeui/custom-menu"
+PLUGINS_FOLDER = "/usr/share/wb-mqtt-homeui/plugins"
 
 ADMIN_COOKIE_LIFETIME = timedelta(days=14)
 
@@ -472,6 +473,18 @@ def security_check_handler(
     return response_200([["Content-type", "text/plain"]], "OK")
 
 
+def plugins_handler(_request: BaseHTTPRequestHandler, _context: WebRequestHandlerContext) -> HttpResponse:
+    plugins = []
+    if os.path.isdir(PLUGINS_FOLDER):
+        for entry in sorted(os.listdir(PLUGINS_FOLDER)):
+            manifest_path = os.path.join(PLUGINS_FOLDER, entry, "manifest.json")
+            if os.path.isfile(manifest_path):
+                data = load_json_file(manifest_path)
+                if data is not None:
+                    plugins.append(data)
+    return response_200([["Content-type", "application/json"]], json.dumps(plugins))
+
+
 def custom_menu_handler(_request: BaseHTTPRequestHandler, _context: WebRequestHandlerContext) -> HttpResponse:
     menu_items = []
     with os.scandir(CUSTOM_MENU_FOLDER) as entries:
@@ -564,6 +577,7 @@ class WebRequestHandler(BaseHTTPRequestHandler):
                 "/api/check": RequestHandler(fn=security_check_handler, rate_per_minute_limit=3),
                 "/api/https": RequestHandler(fn=get_https_handler),
                 "/ui/menu": RequestHandler(fn=custom_menu_handler),
+                "/api/plugins": RequestHandler(fn=plugins_handler),
             }
         )
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.189.2) stable; urgency=medium
+
+  * Add plugin support
+
+ -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Wed, 25 Mar 2026 17:15:00 +0300
+
 wb-mqtt-homeui (2.189.1) stable; urgency=medium
 
   * Fix safari code editor height

--- a/frontend/app/scripts/app.js
+++ b/frontend/app/scripts/app.js
@@ -2,6 +2,9 @@
 
 'use strict';
 
+// Initialize plugin API before anything else
+import './plugin-api';
+
 // Import slylesheets
 import '@/assets/styles/variables.css';
 import '@/assets/styles/animations.css';
@@ -37,6 +40,7 @@ import historyProxyService from './services/historyProxy';
 import logsProxyService from './services/logsProxy';
 import mqttRpcServiceModule from './services/rpc';
 import spinnerService from './services/spinner';
+import dumbTemplateModule from './services/dumbtemplate';
 import pageStateService from './services/pagestate';
 import deviceDataService from './services/devicedata';
 import hiliteService from './services/hilite';
@@ -55,6 +59,7 @@ import handleDataService from './services/handle-data';
 // homeui modules: controllers
 import AlertCtrl from './controllers/alertController';
 import HomeCtrl from './controllers/homeController';
+import MQTTCtrl from './controllers/MQTTChannelsController';
 import DateTimePickerModalCtrl from './controllers/dateTimePickerModalController';
 import DiagnosticCtrl from './controllers/diagnosticController';
 import BackupCtrl from './controllers/backupController';
@@ -74,7 +79,6 @@ import { switchToHttps } from '@/utils/httpsUtils';
 import { fillUserType}  from './utils/authUtils';
 import angular from 'angular';
 
-import { ConfigsStore} from '@/stores/configs';
 import { DashboardsStore } from '@/stores/dashboards';
 import { DevicesStore } from '@/stores/devices';
 import { RulesStore } from '@/stores/rules';
@@ -100,6 +104,7 @@ const module = angular
     'pascalprecht.translate',
     'angular-spinkit',
     routingModule,
+    dumbTemplateModule,
     'ngToast',
     'ui.scroll',
     'tmh.dynamicLocale',
@@ -143,6 +148,7 @@ module
   .value('AlertDelayMs', 5000)
   .controller('AlertCtrl', AlertCtrl)
   .controller('HomeCtrl', HomeCtrl)
+  .controller('MQTTCtrl', MQTTCtrl)
   .controller('DateTimePickerModalCtrl', DateTimePickerModalCtrl)
   .controller('DiagnosticCtrl', DiagnosticCtrl)
   .controller('BackupCtrl', BackupCtrl)
@@ -180,6 +186,7 @@ module
         'help',
         'system',
         'logs',
+        'configurations',
         'history',
       ].forEach(el => $translatePartialLoaderProvider.addPart(el));
       $translateProvider.useSanitizeValueStrategy('sceParameters');
@@ -295,7 +302,15 @@ const realApp = angular
       $rootScope.dashboardsStore = new DashboardsStore(ConfigEditorProxy);
       $rootScope.devicesStore = new DevicesStore(mqttClient);
       $rootScope.rulesStore = new RulesStore(mqttClient, whenMqttReady, EditorProxy);
-      $rootScope.configsStore = new ConfigsStore(whenMqttReady, ConfigEditorProxy);
+
+      // Expose services for plugins
+      if (window.__HOMEUI__) {
+        window.__HOMEUI__.services = {
+          ConfigEditorProxy,
+          EditorProxy,
+          mqttClient,
+        };
+      }
 
       $rootScope.$watch(() => $rootScope.dashboardsStore.description, (name) => {
         document.title = name ? `${name} | ${__APP_SHORT_NAME__ || __APP_NAME__}` : __APP_NAME__;

--- a/frontend/app/scripts/app.js
+++ b/frontend/app/scripts/app.js
@@ -40,7 +40,6 @@ import historyProxyService from './services/historyProxy';
 import logsProxyService from './services/logsProxy';
 import mqttRpcServiceModule from './services/rpc';
 import spinnerService from './services/spinner';
-import dumbTemplateModule from './services/dumbtemplate';
 import pageStateService from './services/pagestate';
 import deviceDataService from './services/devicedata';
 import hiliteService from './services/hilite';
@@ -59,7 +58,6 @@ import handleDataService from './services/handle-data';
 // homeui modules: controllers
 import AlertCtrl from './controllers/alertController';
 import HomeCtrl from './controllers/homeController';
-import MQTTCtrl from './controllers/MQTTChannelsController';
 import DateTimePickerModalCtrl from './controllers/dateTimePickerModalController';
 import DiagnosticCtrl from './controllers/diagnosticController';
 import BackupCtrl from './controllers/backupController';
@@ -79,6 +77,7 @@ import { switchToHttps } from '@/utils/httpsUtils';
 import { fillUserType}  from './utils/authUtils';
 import angular from 'angular';
 
+import { ConfigsStore} from '@/stores/configs';
 import { DashboardsStore } from '@/stores/dashboards';
 import { DevicesStore } from '@/stores/devices';
 import { RulesStore } from '@/stores/rules';
@@ -104,7 +103,6 @@ const module = angular
     'pascalprecht.translate',
     'angular-spinkit',
     routingModule,
-    dumbTemplateModule,
     'ngToast',
     'ui.scroll',
     'tmh.dynamicLocale',
@@ -148,7 +146,6 @@ module
   .value('AlertDelayMs', 5000)
   .controller('AlertCtrl', AlertCtrl)
   .controller('HomeCtrl', HomeCtrl)
-  .controller('MQTTCtrl', MQTTCtrl)
   .controller('DateTimePickerModalCtrl', DateTimePickerModalCtrl)
   .controller('DiagnosticCtrl', DiagnosticCtrl)
   .controller('BackupCtrl', BackupCtrl)
@@ -186,7 +183,6 @@ module
         'help',
         'system',
         'logs',
-        'configurations',
         'history',
       ].forEach(el => $translatePartialLoaderProvider.addPart(el));
       $translateProvider.useSanitizeValueStrategy('sceParameters');
@@ -302,6 +298,7 @@ const realApp = angular
       $rootScope.dashboardsStore = new DashboardsStore(ConfigEditorProxy);
       $rootScope.devicesStore = new DevicesStore(mqttClient);
       $rootScope.rulesStore = new RulesStore(mqttClient, whenMqttReady, EditorProxy);
+      $rootScope.configsStore = new ConfigsStore(whenMqttReady, ConfigEditorProxy);
 
       // Expose services for plugins
       if (window.__HOMEUI__) {

--- a/frontend/app/scripts/app.routes.js
+++ b/frontend/app/scripts/app.routes.js
@@ -270,8 +270,7 @@ function routing($stateProvider, $locationProvider, $urlRouterProvider) {
     //...........................................................................
     .state('configEdit', {
       url: '/configs/edit/{path:.*}',
-      controller: 'ConfigCtrl as $ctrl',
-      template: require('../views/config.html'),
+      template: '<config-page />',
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -377,7 +376,7 @@ function routing($stateProvider, $locationProvider, $urlRouterProvider) {
     })
     //...........................................................................
     .state('plugin', {
-      url: '/plugins/{pluginId}/{componentName}',
+      url: '/plugins/:pluginId/:componentName',
       template: '<plugin-page />',
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {

--- a/frontend/app/scripts/app.routes.js
+++ b/frontend/app/scripts/app.routes.js
@@ -270,7 +270,8 @@ function routing($stateProvider, $locationProvider, $urlRouterProvider) {
     //...........................................................................
     .state('configEdit', {
       url: '/configs/edit/{path:.*}',
-      template: '<config-page />',
+      controller: 'ConfigCtrl as $ctrl',
+      template: require('../views/config.html'),
       resolve: {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
@@ -369,6 +370,19 @@ function routing($stateProvider, $locationProvider, $urlRouterProvider) {
         ctrl: ($q, $ocLazyLoad) => {
           'ngInject';
           return import(/* webpackChunkName: 'alice' */ './controllers/aliceController').then(
+            module => $ocLazyLoad.load({ name: module.default.name })
+          );
+        },
+      },
+    })
+    //...........................................................................
+    .state('plugin', {
+      url: '/plugins/{pluginId}/{componentName}',
+      template: '<plugin-page />',
+      resolve: {
+        ctrl: ($q, $ocLazyLoad) => {
+          'ngInject';
+          return import(/* webpackChunkName: 'plugin' */ './controllers/pluginController').then(
             module => $ocLazyLoad.load({ name: module.default.name })
           );
         },

--- a/frontend/app/scripts/controllers/pluginController.js
+++ b/frontend/app/scripts/controllers/pluginController.js
@@ -1,0 +1,5 @@
+import pluginDirective from '~/react-directives/plugin/pluginDirective';
+
+export default angular
+  .module('homeuiApp.plugin', [])
+  .directive('pluginPage', pluginDirective);

--- a/frontend/app/scripts/plugin-api.js
+++ b/frontend/app/scripts/plugin-api.js
@@ -1,0 +1,62 @@
+// Plugin API - exposes shared dependencies for plugins
+// Plugins use window.__HOMEUI__ instead of bundling their own React/MobX
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+// UI Components
+import { Button } from '@/components/button/button';
+import { Card } from '@/components/card/card';
+import { Table, TableRow, TableCell } from '@/components/table/table';
+import { Input } from '@/components/input/input';
+import { Range } from '@/components/range/range';
+import { Dialog } from '@/components/dialog/dialog';
+import { Confirm } from '@/components/confirm/confirm';
+import { Alert } from '@/components/alert/alert';
+import { Tabs, TabContent } from '@/components/tabs/tabs';
+import { Tag } from '@/components/tag/tag';
+import { Checkbox } from '@/components/checkbox/checkbox';
+import { Switch } from '@/components/switch/switch';
+import { Dropdown } from '@/components/dropdown/dropdown';
+import { Loader } from '@/components/loader/loader';
+import { PageLayout } from '@/layouts/page/page';
+
+const pluginRegistry = {
+  _plugins: {},
+  register(pluginDef) {
+    this._plugins[pluginDef.id] = pluginDef;
+    window.dispatchEvent(new CustomEvent('homeui-plugin-registered', { detail: pluginDef }));
+  },
+  get(id) {
+    return this._plugins[id] || null;
+  },
+  getAll() {
+    return Object.values(this._plugins);
+  },
+};
+
+window.__HOMEUI__ = {
+  version: 1,
+  pluginRegistry,
+  React,
+  ReactDOM,
+  // services (mqttClient, ConfigEditorProxy, EditorProxy) are injected at runtime by app.js
+  services: null,
+  components: {
+    Button,
+    Card,
+    Table, TableRow, TableCell,
+    Input,
+    Range,
+    Dialog,
+    Confirm,
+    Alert,
+    Tabs, TabContent,
+    Tag,
+    Checkbox,
+    Switch,
+    Dropdown,
+    Loader,
+    PageLayout,
+  },
+};

--- a/frontend/app/scripts/react-directives/plugin/pluginDirective.jsx
+++ b/frontend/app/scripts/react-directives/plugin/pluginDirective.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { PluginHost } from '@/components/plugin-host/plugin-host';
+
+export default function pluginDirective($stateParams) {
+  'ngInject';
+  return {
+    restrict: 'E',
+    scope: {},
+    link: function (scope, element) {
+      const pluginId = $stateParams.pluginId;
+      const componentName = $stateParams.componentName;
+
+      const root = ReactDOM.createRoot(element[0]);
+      root.render(
+        React.createElement(PluginHost, {
+          pluginId: pluginId,
+          componentName: componentName,
+        })
+      );
+
+      element.on('$destroy', () => {
+        root.unmount();
+      });
+    },
+  };
+}

--- a/frontend/src/components/plugin-host/plugin-host.tsx
+++ b/frontend/src/components/plugin-host/plugin-host.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from 'react';
+
+interface PluginHostProps {
+  pluginId: string;
+  componentName: string;
+}
+
+class PluginErrorBoundary extends React.Component<
+  { pluginId: string; children: React.ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: '20px', color: '#d9534f' }}>
+          Plugin "{this.props.pluginId}" crashed: {this.state.error.message}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const loadedScripts = new Set<string>();
+
+export const PluginHost: React.FC<PluginHostProps> = ({ pluginId, componentName }) => {
+  const [Component, setComponent] = useState<React.ComponentType | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const registry = (window as any).__HOMEUI__?.pluginRegistry;
+    if (!registry) {
+      setError('Plugin system not initialized');
+      setLoading(false);
+      return;
+    }
+
+    const existing = registry.get(pluginId);
+    if (existing?.components?.[componentName]) {
+      setComponent(() => existing.components[componentName]);
+      setLoading(false);
+      return;
+    }
+
+    const manifests: any[] = (window as any).__HOMEUI_PLUGIN_MANIFESTS__ || [];
+    const manifest = manifests.find((m: any) => m.id === pluginId);
+    if (!manifest) {
+      setError(`Plugin manifest not found: ${pluginId}`);
+      setLoading(false);
+      return;
+    }
+
+    const scriptUrl = `/plugins/${pluginId}/${manifest.entrypoint}`;
+
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const onRegistered = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.id === pluginId) {
+        clearTimeout(timeoutId);
+        const plugin = registry.get(pluginId);
+        if (plugin?.components?.[componentName]) {
+          setComponent(() => plugin.components[componentName]);
+        } else {
+          setError(`Component "${componentName}" not found in plugin "${pluginId}"`);
+        }
+        setLoading(false);
+        window.removeEventListener('homeui-plugin-registered', onRegistered);
+      }
+    };
+
+    window.addEventListener('homeui-plugin-registered', onRegistered);
+
+    if (!loadedScripts.has(scriptUrl)) {
+      loadedScripts.add(scriptUrl);
+      const script = document.createElement('script');
+      script.src = scriptUrl;
+      script.async = true;
+      script.onerror = () => {
+        clearTimeout(timeoutId);
+        setError(`Failed to load plugin: ${scriptUrl}`);
+        setLoading(false);
+        loadedScripts.delete(scriptUrl);
+      };
+      document.head.appendChild(script);
+    }
+
+    timeoutId = setTimeout(() => {
+      setError(`Plugin "${pluginId}" load timeout`);
+      setLoading(false);
+    }, 10000);
+
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener('homeui-plugin-registered', onRegistered);
+    };
+  }, [pluginId, componentName]);
+
+  if (loading) {
+    return <div style={{ padding: '20px', textAlign: 'center' }}>Loading plugin...</div>;
+  }
+
+  if (error) {
+    return <div style={{ padding: '20px', color: '#d9534f' }}>{error}</div>;
+  }
+
+  if (!Component) {
+    return null;
+  }
+
+  return (
+    <PluginErrorBoundary pluginId={pluginId}>
+      <Component />
+    </PluginErrorBoundary>
+  );
+};

--- a/frontend/src/stores/ui/ui-store.ts
+++ b/frontend/src/stores/ui/ui-store.ts
@@ -6,6 +6,31 @@ import { getMenu } from './api';
 import { getMenuItems, mergeMenuItems, normalizeMenuResponse, toMenuItemInstance } from './menu-items';
 import type { CustomMenuItem, MenuItemInstance } from './types';
 
+interface PluginManifest {
+  id: string;
+  version: string;
+  title: { ru: string; en: string };
+  entrypoint: string;
+  menu?: {
+    parentId: string;
+    item: {
+      id: string;
+      url: string;
+      title?: { ru?: string; en?: string };
+    };
+  };
+}
+
+const getPlugins = async (): Promise<PluginManifest[]> => {
+  try {
+    const response = await fetch('/api/plugins');
+    if (!response.ok) return [];
+    return await response.json();
+  } catch {
+    return [];
+  }
+};
+
 export default class UiStore {
   public isConnected = false;
   public menuItems: MenuItemInstance[] = [];
@@ -33,8 +58,28 @@ export default class UiStore {
 
   async #getCustomMenuItems() {
     if (!this.#additionalItems) {
-      const additionalItems = await getMenu();
+      const [additionalItems, pluginManifests] = await Promise.all([getMenu(), getPlugins()]);
       this.#additionalItems = normalizeMenuResponse(additionalItems);
+
+      // Store manifests for plugin directive to access
+      (window as any).__HOMEUI_PLUGIN_MANIFESTS__ = pluginManifests;
+
+      // Convert plugin menus to custom menu items
+      for (const manifest of pluginManifests) {
+        if (manifest.menu) {
+          const pluginMenuItem: CustomMenuItem = {
+            id: manifest.menu.parentId,
+            children: [
+              {
+                id: manifest.menu.item.id,
+                url: manifest.menu.item.url,
+                title: manifest.menu.item.title || manifest.title,
+              },
+            ],
+          };
+          this.#additionalItems.push(pluginMenuItem);
+        }
+      }
     }
     runInAction(() => {
       this.modules = this.#collectModuleIds(this.#additionalItems);

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -305,7 +305,7 @@ module.exports = (function makeWebpackConfig() {
 
       // Output path from the view of the page
       // Uses dev-server in development
-      publicPath: '/',
+      publicPath: 'http://localhost:8080/',
 
       // Filename for entry points
       filename: '[name].bundle.js',
@@ -358,7 +358,9 @@ module.exports = (function makeWebpackConfig() {
           '/api/https',
           '/api/check',
           '/api/integrations/alice',
-          '/ui/menu'
+          '/ui/menu',
+          '/api/plugins',
+          '/plugins/'
         ],
         target: process.env.MQTT_BROKER_URI,
         ws: true,


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Добавлена система плагинов для homeui. Внешние Debian-пакеты (например, [Пример поставки плагинов в PR wb-scenarios](https://github.com/wirenboard/wb-scenarios/pull/73)) теперь могут поставлять собственные React-страницы в веб-интерфейс без необходимости пересобирать homeui.

Пример работы при установке двух пакетов homeui и пакета wb-scenarios:

Страница буззера
<img width="1225" height="991" alt="2026-03-27_10-47-09" src="https://github.com/user-attachments/assets/a5c8780e-d24c-4e55-b000-88a97d67c704" />

Страница сценариев
<img width="1917" height="989" alt="2026-03-27_10-47-47" src="https://github.com/user-attachments/assets/d451d9ec-f73c-4eed-8414-0bc8640769ed" />

Плагин — это `manifest.json` + `index.js`, которые пакет устанавливает в `/usr/share/wb-mqtt-homeui/plugins/<plugin-id>/`. При загрузке homeui:
1. Backend сканирует директорию плагинов (`GET /api/plugins`)
2. Frontend читает манифесты и добавляет пункты меню в навигацию
3. При переходе на страницу плагина `PluginHost` загружает JS-скрипт плагина
4. Плагин получает React, UI-компоненты и сервисы (MQTT, ConfigEditorProxy) через `window.__HOMEUI__`

Изменения:
- **Backend** (`main.py`): новый endpoint `GET /api/plugins`, сканирует `manifest.json` файлы
- **Nginx** (`default.conf`): проксирование `/api/plugins`
- **Frontend**:
  - `plugin-api.js` — экспорт `window.__HOMEUI__` (React, 18 UI-компонентов, registry)
  - `plugin-host.tsx` — React-компонент загрузки плагинов с ErrorBoundary и таймаутом 10с
  - `pluginDirective.jsx` + `pluginController.js` — мост AngularJS → React
  - `app.js` — инжекция сервисов (mqttClient, ConfigEditorProxy) в `window.__HOMEUI__.services`
  - `app.routes.js` — роут `/plugins/:pluginId/:componentName`
  - `ui-store.ts` — загрузка манифестов, регистрация пунктов меню
  - `webpack.config.js` — dev proxy для `/api/plugins` и `/plugins/`

___________________________________
**Что поменялось для пользователей:**

Для пользователей homeui ничего не меняется — плагины появляются в меню только если соответствующий пакет установил файлы в `/usr/share/wb-mqtt-homeui/plugins/`. Без плагинов интерфейс работает как раньше.

При установке пакета с плагинами (например, wb-scenarios) в боковом меню появляются новые пункты, ведущие на страницы плагина.

___________________________________
**Как проверял/а:**

1. Установил два пакета wb-mqtt-homeui и wb-homeui-backend на контроллере WB
2. Установил пакет [wb-scenarios](https://github.com/wirenboard/wb-scenarios/pull/73)  с двумя плагинами:
   - **wb-buzzer** Упрощенный пример (Настройки > Пищалка) — управление зуммером: вкл/выкл, громкость (0-100), частота (0-7000 Гц), длительность, пресеты. Значения подтягиваются из MQTT в реальном времени
   - **wb-scenarios-v2** Сложный пример (Правила > Сценарии V2) — CRUD сценариев (devicesControl, schedule, astronomicalTimer) через ConfigEditorProxy
3. Проверено:
   - Оба плагина загружаются и отображаются в меню
   - Навигация между плагинами и встроенными страницами работает
   - MQTT подписки работают (чтение текущих значений buzzer)
   - CRUD сценариев: создание, редактирование, удаление — данные сохраняются через confed
   - Существующие сценарии неподдерживаемых типов (thermostat) не затрагиваются
   - Без плагинов интерфейс работает как раньше (пункты меню не появляются)
   - Перезагрузка страницы — плагины загружаются корректно

Документация: [PLUGINS.md](PLUGINS.md)