### PR TITLE
Add new_row parameter in json-editor

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.196.0) stable; urgency=medium
+
+  * Add new_row parameter to wb options in json-editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 08 Apr 2026 15:12:32 +0500
+
 wb-mqtt-homeui (2.195.0) stable; urgency=medium
 
   * Add new units - var, VA, kvarh

--- a/frontend/src/components/json-schema-editor/object-param-editor.tsx
+++ b/frontend/src/components/json-schema-editor/object-param-editor.tsx
@@ -89,7 +89,8 @@ const makeLayout = (params: ObjectParamStore[], rootStore: PropertyStore, transl
   for (const param of params) {
     if (shouldRenderObjectParamEditor(param)) {
       const gridColumns = param.store.schema.options?.grid_columns ?? MAX_SLOTS + 1;
-      if (slotsInRow === 0 || slotsInRow + gridColumns <= MAX_SLOTS) {
+      const newRow = param.store.schema.options?.wb?.new_row ?? false;
+      if (slotsInRow === 0 || (!newRow && slotsInRow + gridColumns <= MAX_SLOTS)) {
         slotsInRow += gridColumns;
         elements.push(param);
       } else {

--- a/frontend/src/stores/json-schema-editor/json-schema-loader.ts
+++ b/frontend/src/stores/json-schema-editor/json-schema-loader.ts
@@ -139,6 +139,7 @@ const sanitizeOptions = (source: JsonEditorOptions, dest: JsonEditorOptions) => 
     dest.wb.allow_undefined = !!source.wb.allow_undefined;
     dest.wb.read_only = !!source.wb.read_only;
     dest.wb.disable_title = !!source.wb.disable_title;
+    dest.wb.new_row = !!source.wb.new_row;
     if (typeof source.wb.dali_tc?.minimum === 'number') {
       dest.wb.dali_tc = dest.wb.dali_tc || {};
       dest.wb.dali_tc.minimum = source.wb.dali_tc.minimum;

--- a/frontend/src/stores/json-schema-editor/types.ts
+++ b/frontend/src/stores/json-schema-editor/types.ts
@@ -32,6 +32,9 @@ export interface WbOptions {
   // If true, the property will be shown as read-only in the editor
   read_only?: boolean;
 
+  // If true, the property will start a new row in the flex layout
+  new_row?: boolean;
+
   dali_tc?: WbDaliTcEditorOptions;
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил параметр new_row в опции для редактора на базе JSONSchema. Он указывает, что редактор параметра надо отображать с новой строки. 

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


