### PR TITLE
Fix polling settings editing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.197.4) stable; urgency=medium
+
+  * Allow disabling poll of channels not supported by firmware in device settings editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 13 Apr 2026 19:12:25 +0500
+
 wb-mqtt-homeui (2.197.3) stable; urgency=medium
 
   * Error handling for invalid data from MQTT

--- a/frontend/src/pages/settings/device-manager/components/device-settings-editor/device-settings-editor-desktop.tsx
+++ b/frontend/src/pages/settings/device-manager/components/device-settings-editor/device-settings-editor-desktop.tsx
@@ -79,15 +79,13 @@ const ChannelsTableRow = observer(({
         {description && <ParamDescription description={description} />}
       </TableCell>
       <TableCell>
-        {channel.isSupportedByFirmware && (
-          <StringEditor
-            store={channel.mode}
-            translator={translator}
-          />
-        )}
+        <StringEditor
+          store={channel.mode}
+          translator={translator}
+        />
       </TableCell>
       <TableCell>
-        {channel.isSupportedByFirmware && channel.hasCustomPeriod && (
+        {channel.hasCustomPeriod && (
           <CustomPeriodEditor
             store={channel.period}
             translator={translator}

--- a/frontend/src/pages/settings/device-manager/components/device-settings-editor/device-settings-editor-mobile.tsx
+++ b/frontend/src/pages/settings/device-manager/components/device-settings-editor/device-settings-editor-mobile.tsx
@@ -77,10 +77,8 @@ const ChannelCard = observer((
     >
       <div className="deviceSettingsEditor-channel">
         {description && <ParamDescription description={description} />}
-        {channel.isSupportedByFirmware && (
-          <StringEditor store={channel.mode} translator={translator} />
-        )}
-        {channel.isSupportedByFirmware && channel.hasCustomPeriod && (
+        <StringEditor store={channel.mode} translator={translator} />
+        {channel.hasCustomPeriod && (
           <CustomPeriodEditor store={channel.period} translator={translator} />
         )}
       </div>


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Если канал не поддерживается прошивкой, ему нельзя настроить опрос. В некоторых шаблонах опрос включен по умолчанию, в результате у пользователей отображаются каналы с ошибкой, и отключить их нельзя.
Вернул редактирование опроса

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


