### PR TITLE
Fix options.wb.show_editor handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.197.5) stable; urgency=medium
+
+  * Fix options.wb.show_editor flag handling in json-editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 14 Apr 2026 16:23:41 +0500
+
 wb-mqtt-homeui (2.197.4) stable; urgency=medium
 
   * Allow disabling poll of channels not supported by firmware in device settings editor

--- a/frontend/src/stores/json-schema-editor/object-store.ts
+++ b/frontend/src/stores/json-schema-editor/object-store.ts
@@ -93,7 +93,11 @@ export class ObjectStore implements PropertyStore {
     }
 
     if (initialValue === undefined) {
-      this.isUndefined = true;
+      if (required || (schema.options?.wb?.show_editor && !schema.options?.wb?.allow_undefined)) {
+        this.setDefault();
+      } else {
+        this.isUndefined = true;
+      }
     }
 
     makeObservable(this, {


### PR DESCRIPTION
Objects with options.wb.show_editor must render all sub editors and must not be marked as undefined

___________________________________
**Что происходит; кому и зачем нужно:**

options.wb.show_editor говорит, что надо рисовать редактор для параметра, даже если в исходном json этого параметра нет. Оно не работало для параметров типа object

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


