### PR TITLE
Drop support for old WB-DALI template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.201.0) stable; urgency=medium
+
+  * Drop support for old WB-DALI template. Only WB-MDALI is supported now.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 22 Apr 2026 13:47:57 +0500
+
 wb-mqtt-homeui (2.200.1) stable; urgency=medium
 
   * Fix devices without cells

--- a/frontend/src/stores/dali/monitor-store.ts
+++ b/frontend/src/stores/dali/monitor-store.ts
@@ -17,7 +17,7 @@ export class MonitorStore {
 
   enableMonitoring(bus_mqtt_id: string) {
     this.logs = [];
-    this.topic = `/wb-dali/${bus_mqtt_id}/bus_monitor`;
+    this.topic = `/wb-mdali/${bus_mqtt_id}/bus_monitor`;
     this._subscribeToTopic();
     this.isEnabled = true;
     this.isOnPause = false;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В старом шаблоне публиковалось в wb-dali. Поменяли в рамках перехода на единообразное название wb-**m**dali
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


