### PR TITLE
Fix clearing channel settings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.202.1) stable; urgency=medium
+
+  * Fix clearing channel settings on config reread in wb-mqtt-serial editor 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 27 Apr 2026 16:44:47 +0500
+
 wb-mqtt-homeui (2.202.0) stable; urgency=medium
 
   * Rename WB-MDALI to WB-DALI

--- a/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.ts
@@ -124,9 +124,8 @@ export class DeviceSettingsObjectStore {
       });
     }
 
-    delete userDefinedConfig.channels;
-    userDefinedConfig.channels = customChannels;
-    this.commonParams = new ObjectStore(jsonSchema, userDefinedConfig, false, new StoreBuilder());
+    const configForCommonParams = { ...userDefinedConfig, channels: customChannels };
+    this.commonParams = new ObjectStore(jsonSchema, configForCommonParams, false, new StoreBuilder());
     this.customChannels = this.commonParams.getParamByKey('channels')?.store as ArrayStore;
     this.commonParams.removeParamByKey('channels');
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Поправил баг со сбросом настроек каналов, при перечитывании настроек. Объект с исходными настройками мутировали в процессе работы. а потом считали, что он не изменился. Теперь делаем копию

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


