### PR TITLE
Fix default channel poll policy for semi-sporadic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.202.2) stable; urgency=medium
+
+  * Fix default channel poll policy for WB-MSW v.3
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 28 Apr 2026 11:08:20 +0500
+
 wb-mqtt-homeui (2.202.1) stable; urgency=medium
 
   * Fix clearing channel settings on config reread in wb-mqtt-serial editor 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-homeui (2.202.2) stable; urgency=medium
 
-  * Fix default channel poll policy for WB-MSW v.3
+  * Fix default poll policy for semi-sporadic channels
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 28 Apr 2026 11:08:20 +0500
 

--- a/frontend/src/stores/device-manager/device-tab/device-settings-editor/channel-editor-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-settings-editor/channel-editor-store.ts
@@ -219,7 +219,7 @@ export class WbDeviceChannelEditor {
 
   setDefault() {
     const { mode, period } = getEditorValuesFromChannelData(this.channel);
-    if (this.channel['semi-sporadic'] === true || this.channel.sporadic === true) {
+    if (this.channel.sporadic === true) {
       this.mode.setValue(mode === WbDeviceChannelModes.Disabled ? mode : WbDeviceChannelModes.UsingFastModbus);
     } else {
       this.mode.setValue(mode);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
По умолчанию для semi-sporadic регистров выбирался вариант "опрашивать через быстрый модбас", а его в списке вариантов не было. Теперь выбирается "в порядке очереди"

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


