### PR TITLE
Fix storing dependent parameters in wb-mqtt-serial config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.206.2) stable; urgency=medium
+
+  * Store dependent parameters in wb-mqtt-serial if the main parameter has not default value
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 04 May 2026 10:45:05 +0500
+
 wb-mqtt-homeui (2.206.1) stable; urgency=medium
 
   * Fix DALI devices list update after scanning

--- a/frontend/src/stores/device-manager/device-tab/device-settings-editor/parameter-editor-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-settings-editor/parameter-editor-store.ts
@@ -29,6 +29,7 @@ export class WbDeviceParameterEditorVariant {
 
     makeObservable(this, {
       isEnabledByCondition: computed,
+      hasDirtyDependency: computed,
     });
   }
 
@@ -45,6 +46,16 @@ export class WbDeviceParameterEditorVariant {
       return undefined;
     }));
     return res;
+  }
+
+  get hasDirtyDependency() {
+    if (!this._conditionFn) {
+      return false;
+    }
+    return this._dependencies?.some((dep) => {
+      const param = this._otherParameters.get(dep);
+      return param?.isEnabledByCondition && param.isDirty;
+    }) ?? false;
   }
 }
 
@@ -80,6 +91,7 @@ export class WbDeviceParameterEditor {
       hasErrors: computed,
       hasBadValueFromRegisters: computed,
       hasSeveralVariants: computed,
+      hasDirtyDependency: computed,
       shouldStoreInConfig: computed,
       addVariant: action,
       setFromDeviceRegister: action,
@@ -135,6 +147,10 @@ export class WbDeviceParameterEditor {
     return this.variants.filter((variant) => variant.isEnabledByCondition).length > 1;
   }
 
+  get hasDirtyDependency() {
+    return this.variants.some((variant) => variant.hasDirtyDependency);
+  }
+
   get shouldStoreInConfig() {
     if (!this.isEnabledByCondition || !this.isSupportedByFirmware) {
       return false;
@@ -145,7 +161,7 @@ export class WbDeviceParameterEditor {
     if (this.isSetInDeviceRegisters) {
       return !this.hasBadValueFromRegisters;
     }
-    return (this.required || this.isDirty) && !this.hasErrors;
+    return (this.required || this.isDirty || this.hasDirtyDependency) && !this.hasErrors;
   }
 
   addVariant(
@@ -225,7 +241,7 @@ export class WbDeviceParameterEditor {
     if (this.hasErrors || this.hasBadValueFromRegisters) {
       return;
     }
-    if (this.isDirty || this.isSetInDeviceRegisters) {
+    if (this.shouldStoreInConfig) {
       this.isSetInUserDefinedConfig = true;
     }
     this.isSetInDeviceRegisters = false;


### PR DESCRIPTION
If a main parameter has not default value all dependent parameters, selected by conditions, will be stored in config

___________________________________
**Что происходит; кому и зачем нужно:**
В шаблонах, есть параметры, которые появляются только, если выбрано конкретное значение какого-то другого параметра. Раньше такие зависимые параметры сохранялись, если имели значение отличное от значения по умолчанию. Теперь они сохраняются всегда 

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


