### PR TITLE
feat: unify autocomplete fields INT-1042

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-homeui (2.209.0) stable; urgency=medium
 
   * Unify autocomplete fields
 
- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Wed, 13 May 2026 16:59:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Wed, 13 May 2026 16:59:00 +0300
 
 wb-mqtt-homeui (2.208.0) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-homeui (2.208.2) stable; urgency=medium
 
   * Unify autocomplete fields
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Wed, 14 May 2026 14:47:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Wed, 14 May 2026 14:56:00 +0300
 
 wb-mqtt-homeui (2.208.1) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.209.0) stable; urgency=medium
+
+  * Unify autocomplete fields
+
+ Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Wed, 13 May 2026 16:59:00 +0300
+
 wb-mqtt-homeui (2.208.0) stable; urgency=medium
 
   * Update scan page

--- a/frontend/app/scripts/json-editor/autocomplete.js
+++ b/frontend/app/scripts/json-editor/autocomplete.js
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { createElement } from 'react';
 import { Dropdown } from '@/components/dropdown';
 
-export function makeAutocompleteEditor(devices) {
+export function makeAutocompleteEditor(topics) {
   return class extends JSONEditor.AbstractEditor {
     build() {
       this.control = document.createElement('div');
@@ -18,14 +18,9 @@ export function makeAutocompleteEditor(devices) {
         this.reactRoot = createRoot(this.control);
       }
 
-      const options = devices?.map(topic => ({
-        label: topic,
-        value: topic,
-      })) || [];
-
       this.reactRoot.render(
         createElement(Dropdown, {
-          options,
+          options: topics || [],
           value: this.value,
           isSearchable: true,
           isClearable: true,
@@ -38,7 +33,7 @@ export function makeAutocompleteEditor(devices) {
     }
 
     setValue(value) {
-      if (this.value === value){
+      if (this.value === value) {
         return;
       }
       this.value = value;

--- a/frontend/src/components/dropdown/dropdown.tsx
+++ b/frontend/src/components/dropdown/dropdown.tsx
@@ -90,7 +90,7 @@ export const Dropdown = ({
   };
 
   return (
-    <div onTouchEndCapture={(ev) => ev.stopPropagation()}>
+    <div style={{ display: 'contents' }} onTouchEndCapture={(ev) => ev.stopPropagation()}>
       <Select
         ref={select}
         inputId={inputId}

--- a/frontend/src/components/json-editor/types.ts
+++ b/frontend/src/components/json-editor/types.ts
@@ -1,8 +1,10 @@
+import { type TopicGroup } from '@/stores/devices/types';
+
 export interface JsonEditorProps {
   schema: any;
   data: any;
   root?: string;
   className?: string;
-  cells?: string[];
+  cells?: TopicGroup[];
   onChange: (_val: any, _errors: any[]) => void;
 }

--- a/frontend/src/components/json-editor/types.ts
+++ b/frontend/src/components/json-editor/types.ts
@@ -1,10 +1,10 @@
-import { type TopicGroup } from '@/stores/devices/types';
+import { type Option } from '@/components/dropdown';
 
 export interface JsonEditorProps {
   schema: any;
   data: any;
   root?: string;
   className?: string;
-  cells?: TopicGroup[];
+  cells?: Option<string>[];
   onChange: (_val: any, _errors: any[]) => void;
 }

--- a/frontend/src/pages/dashboards/[slug]/components/widget-add/types.ts
+++ b/frontend/src/pages/dashboards/[slug]/components/widget-add/types.ts
@@ -1,6 +1,7 @@
 import { type Dashboard, type Widget } from '@/stores/dashboards';
 import type DashboardsStore from '@/stores/dashboards/dashboards-store';
 import { type Cell } from '@/stores/devices';
+import { type TopicGroup } from '@/stores/devices/types';
 
 export interface WidgetAddProps {
   dashboard: Dashboard;
@@ -8,6 +9,6 @@ export interface WidgetAddProps {
   widgets: Map<string, Widget>;
   cells: Map<string, Cell>;
   isOpened: boolean;
-  controls: any;
+  topics: TopicGroup[];
   onClose: () => void;
 }

--- a/frontend/src/pages/dashboards/[slug]/components/widget-add/types.ts
+++ b/frontend/src/pages/dashboards/[slug]/components/widget-add/types.ts
@@ -1,7 +1,7 @@
+import { type Option } from '@/components/dropdown';
 import { type Dashboard, type Widget } from '@/stores/dashboards';
 import type DashboardsStore from '@/stores/dashboards/dashboards-store';
 import { type Cell } from '@/stores/devices';
-import { type TopicGroup } from '@/stores/devices/types';
 
 export interface WidgetAddProps {
   dashboard: Dashboard;
@@ -9,6 +9,6 @@ export interface WidgetAddProps {
   widgets: Map<string, Widget>;
   cells: Map<string, Cell>;
   isOpened: boolean;
-  topics: TopicGroup[];
+  topics: Option<string>[];
   onClose: () => void;
 }

--- a/frontend/src/pages/dashboards/[slug]/components/widget-add/widget-add.tsx
+++ b/frontend/src/pages/dashboards/[slug]/components/widget-add/widget-add.tsx
@@ -23,7 +23,7 @@ export const WidgetAdd = observer(({
   widgets,
   dashboard,
   cells,
-  controls,
+  topics,
   isOpened,
   onClose,
 }: WidgetAddProps) => {
@@ -191,7 +191,7 @@ export const WidgetAdd = observer(({
             ? { id: '', name: '', description: '', cells: [], compact: false } as any
             : widgets.get(widgetId)}
           cells={cells}
-          controls={controls}
+          topics={topics}
           isOpened={!!isEditing}
           onClose={() => {
             setIsEditing(false);

--- a/frontend/src/pages/dashboards/[slug]/components/widget-edit/types.ts
+++ b/frontend/src/pages/dashboards/[slug]/components/widget-edit/types.ts
@@ -1,6 +1,6 @@
+import { type Option } from '@/components/dropdown';
 import { type Widget } from '@/stores/dashboards/widget';
 import { type Cell } from '@/stores/devices';
-import { type TopicGroup } from '@/stores/devices/types';
 
 export interface CellSimple {
   id: string;
@@ -15,7 +15,7 @@ export interface WidgetEditProps {
   widget: Widget;
   cells: Map<string, Cell | CellSimple>;
   isOpened: boolean;
-  topics: TopicGroup[];
+  topics: Option<string>[];
   onClose: () => void;
   onSave: (data: any) => void;
 }

--- a/frontend/src/pages/dashboards/[slug]/components/widget-edit/types.ts
+++ b/frontend/src/pages/dashboards/[slug]/components/widget-edit/types.ts
@@ -1,5 +1,6 @@
 import { type Widget } from '@/stores/dashboards/widget';
 import { type Cell } from '@/stores/devices';
+import { type TopicGroup } from '@/stores/devices/types';
 
 export interface CellSimple {
   id: string;
@@ -14,7 +15,7 @@ export interface WidgetEditProps {
   widget: Widget;
   cells: Map<string, Cell | CellSimple>;
   isOpened: boolean;
-  controls: any;
+  topics: TopicGroup[];
   onClose: () => void;
   onSave: (data: any) => void;
 }

--- a/frontend/src/pages/dashboards/[slug]/components/widget-edit/widget-edit.tsx
+++ b/frontend/src/pages/dashboards/[slug]/components/widget-edit/widget-edit.tsx
@@ -19,7 +19,7 @@ import { generateNextId } from '@/utils/id';
 import type { CellSimple, WidgetEditProps } from './types';
 import './styles.css';
 
-export const WidgetEdit = ({ widget, cells, controls, isOpened, onSave, onClose }: WidgetEditProps) => {
+export const WidgetEdit = ({ widget, cells, topics, isOpened, onSave, onClose }: WidgetEditProps) => {
   const { t } = useTranslation();
   const [widgetCells, setWidgetCells] = useState<(CellSimple)[]>([]);
   const [isJsonView, setIsJsonView] = useState(false);
@@ -89,10 +89,22 @@ export const WidgetEdit = ({ widget, cells, controls, isOpened, onSave, onClose 
 
   const controlsOptions = useMemo(() => {
     const uniqueSeparatorId = generateNextId(widgetCells.map((item, i) => item.id || String(i)), 'separator');
-    return [{ name: t('widget.labels.separator'), id:uniqueSeparatorId }, ...controls]
-      .filter(({ id }) => !widgetCells.find((cell) => cell.id === id && !id?.startsWith('separator')))
-      .map(({ name, id }) => ({ label: name, value: id }));
-  }, [widgetCells]);
+    const addedIds = new Set(
+      widgetCells
+        .filter((c) => !c.id?.startsWith('separator'))
+        .map((c) => c.id),
+    );
+    const groups = (topics || [])
+      .map((group) => ({
+        label: group.label,
+        options: group.options.filter((opt) => !addedIds.has(opt.value)),
+      }))
+      .filter((group) => group.options.length > 0);
+    return [
+      { label: t('widget.labels.separator'), value: uniqueSeparatorId },
+      ...groups,
+    ];
+  }, [widgetCells, topics]);
 
   return (
     <Confirm

--- a/frontend/src/pages/dashboards/[slug]/dashboard.tsx
+++ b/frontend/src/pages/dashboards/[slug]/dashboard.tsx
@@ -156,7 +156,7 @@ const DashboardPage = observer(({ dashboardsStore, devicesStore }: DashboardPage
             dashboard={dashboards.get(dashboardId)}
             cells={cells}
             isOpened={isAddWidgetModalOpened}
-            controls={devicesStore.controls}
+            topics={devicesStore.topicsWithoutSystem}
             onClose={() => setIsAddWidgetModalOpened(false)}
           />
         )}
@@ -189,7 +189,7 @@ const DashboardPage = observer(({ dashboardsStore, devicesStore }: DashboardPage
         <WidgetEdit
           widget={widgets.get(editingWidgetId)}
           cells={cells}
-          controls={devicesStore.controls}
+          topics={devicesStore.topicsWithoutSystem}
           isOpened={!!editingWidgetId}
           onClose={() => setEditingWidgetId(null)}
           onSave={(data) => {

--- a/frontend/src/pages/dashboards/widgets/widgets.tsx
+++ b/frontend/src/pages/dashboards/widgets/widgets.tsx
@@ -227,7 +227,7 @@ const WidgetsPage = observer(({ store, devicesStore }: WidgetsPageProps) => {
         <WidgetEdit
           widget={store.widgets.get(widgetToEdit)}
           cells={cells}
-          controls={devicesStore.controls}
+          topics={devicesStore.topicsWithoutSystem}
           isOpened={!!widgetToEdit}
           onClose={() => {
             setWidgetToEdit(null);

--- a/frontend/src/pages/settings/configs/[path]/config.tsx
+++ b/frontend/src/pages/settings/configs/[path]/config.tsx
@@ -82,7 +82,7 @@ const ConfigPage = observer(({ store, rootScope, devicesStore }: ConfigPageProps
       <JsonEditor
         schema={store.config?.schema}
         data={store.config?.content}
-        cells={Array.from(devicesStore.cells.keys()).filter((t) => !t.startsWith('system__'))}
+        cells={devicesStore.topicsWithoutSystem}
         onChange={onChange}
       />
     </PageLayout>

--- a/frontend/src/stores/devices/devices-store.ts
+++ b/frontend/src/stores/devices/devices-store.ts
@@ -3,7 +3,7 @@ import type { MqttClient } from '@/common/types';
 import Cell from './cell';
 import Device from './device';
 import { isTopicsAreEqual, splitTopic } from './helpers';
-import type { ValueType } from './types';
+import type { TopicGroup, TopicOption, ValueType } from './types';
 
 export default class DevicesStore {
   public devices: Map<string, Device> = new Map();
@@ -46,7 +46,7 @@ export default class DevicesStore {
     return new Map(
       Array.from(this.devices.entries())
         .filter(([_, device]) => !device.isSystemDevice)
-        .sort(([_1, device1], [_2, device2]) => device1.name.localeCompare(device2.name))
+        .sort(([_1, device1], [_2, device2]) => device1.name.localeCompare(device2.name)),
     );
   }
 
@@ -110,11 +110,11 @@ export default class DevicesStore {
     this.#allDevicesTopics.delete(id);
   }
 
-  get topics(): any[] {
-    const result = [];
+  get topics(): TopicGroup[] {
+    const result: TopicGroup[] = [];
 
     for (const device of this.devices.values()) {
-      const options = [];
+      const options: TopicOption[] = [];
 
       for (const cellId of device.cells) {
         const cell = this.cells.get(cellId);
@@ -126,6 +126,8 @@ export default class DevicesStore {
         });
       }
 
+      if (options.length === 0) continue;
+
       result.push({
         label: device.name,
         options,
@@ -133,6 +135,17 @@ export default class DevicesStore {
     }
 
     return result;
+  }
+
+  // For end-user pickers (scenarios, widgets). Alice uses topics directly so
+  // that system controls remain exportable to the smart home.
+  get topicsWithoutSystem(): TopicGroup[] {
+    return this.topics
+      .map((group) => ({
+        label: group.label,
+        options: group.options.filter((opt) => !opt.value.startsWith('system__')),
+      }))
+      .filter((group) => group.options.length > 0);
   }
 
   toggleDevices() {
@@ -151,12 +164,6 @@ export default class DevicesStore {
 
   get hasOpenedDivices() {
     return Array.from(this.filteredDevices.values()).some((device) => device.isVisible);
-  }
-
-  get controls() {
-    return Array.from(this.cells.values())
-      .filter((cell) => !cell.id.startsWith('system__') && !cell.hidden)
-      .map((cell) => ({ id: cell.id, name: `${this.devices.get(cell.deviceId)?.name} / ${cell.name}` }));
   }
 
   async sendCellValueUpdate(deviceId: string, controlId: string, value: string) {

--- a/frontend/src/stores/devices/devices-store.ts
+++ b/frontend/src/stores/devices/devices-store.ts
@@ -1,9 +1,10 @@
 import { makeAutoObservable, runInAction } from 'mobx';
 import type { MqttClient } from '@/common/types';
+import { type Option } from '@/components/dropdown';
 import Cell from './cell';
 import Device from './device';
 import { isTopicsAreEqual, splitTopic } from './helpers';
-import type { TopicGroup, TopicOption, ValueType } from './types';
+import type { ValueType } from './types';
 
 export default class DevicesStore {
   public devices: Map<string, Device> = new Map();
@@ -110,11 +111,11 @@ export default class DevicesStore {
     this.#allDevicesTopics.delete(id);
   }
 
-  get topics(): TopicGroup[] {
-    const result: TopicGroup[] = [];
+  get topics(): Option<string>[] {
+    const result: Option<string>[] = [];
 
     for (const device of this.devices.values()) {
-      const options: TopicOption[] = [];
+      const options: Option<string>[] = [];
 
       for (const cellId of device.cells) {
         const cell = this.cells.get(cellId);
@@ -139,12 +140,15 @@ export default class DevicesStore {
 
   // For end-user pickers (scenarios, widgets). Alice uses topics directly so
   // that system controls remain exportable to the smart home.
-  get topicsWithoutSystem(): TopicGroup[] {
+  get topicsWithoutSystem(): Option<string>[] {
     return this.topics
-      .map((group) => ({
-        label: group.label,
-        options: group.options.filter((opt) => !opt.value.startsWith('system__')),
-      }))
+      .map((group) => {
+        const options = 'options' in group ? group.options ?? [] : [];
+        return {
+          label: group.label,
+          options: options.filter((opt) => !(opt.value as string).startsWith('system__')),
+        };
+      })
       .filter((group) => group.options.length > 0);
   }
 

--- a/frontend/src/stores/devices/types.ts
+++ b/frontend/src/stores/devices/types.ts
@@ -33,13 +33,3 @@ export type ValueType = string | number | boolean | null;
 export type SendValueUpdate = (_deviceId: string, _controlId: string, _value: string) => Promise<void>;
 
 export type DeviceOption = Option<string>;
-
-export interface TopicOption {
-  value: string;
-  label: string;
-}
-
-export interface TopicGroup {
-  label: string;
-  options: TopicOption[];
-}

--- a/frontend/src/stores/devices/types.ts
+++ b/frontend/src/stores/devices/types.ts
@@ -33,3 +33,13 @@ export type ValueType = string | number | boolean | null;
 export type SendValueUpdate = (_deviceId: string, _controlId: string, _value: string) => Promise<void>;
 
 export type DeviceOption = Option<string>;
+
+export interface TopicOption {
+  value: string;
+  label: string;
+}
+
+export interface TopicGroup {
+  label: string;
+  options: TopicOption[];
+}

--- a/frontend/src/stores/rules/autocomplete/enums.ts
+++ b/frontend/src/stores/rules/autocomplete/enums.ts
@@ -129,7 +129,7 @@ const makeTopicSource = (fnName: string, topics: string[]): CompletionSource => 
 
 export const getEnums = (devicesStore: DevicesStore) => {
   const devices = Array.from(devicesStore.devices.keys());
-  const topics = devicesStore.controls.map(({ id }) => id);
+  const topics = devicesStore.topicsWithoutSystem.flatMap((g) => g.options.map((o) => o.value));
 
   return [
     typeCompletionSource,


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В homeui исторически сложилось 4 разных способа отображать выпадающий список выбора MQTT-контрола — в каждом со своим форматом строки, своим источником данных и своей логикой фильтрации:

| Место | Формат строки | Источник | Группировка |
| --- | --- | --- | --- |
| Алиса | `Имя [device/control]` | `DevicesStore.topics` | по устройствам |
| Сценарии (confed-схемы) | `device/control` (сырой топик) | `DevicesStore.cells.keys()` | нет |
| Виджеты (дашборды + страница `/widgets`) | `DeviceName / CellName` | `DevicesStore.controls` | нет |
| Автокомплит wb-rules в редакторе скриптов | плоский список топиков | `DevicesStore.controls` | нет |

Это было неконсистентно для пользователя (одно и то же устройство выглядит по-разному в зависимости от того, где его выбираешь), и требовало править формат сразу в нескольких местах при любых изменениях.

Унифицируем на Алисовском подходе как на эталоне: единый источник `DevicesStore.topics`, формат `<имя> [<device/control>]`, группировка по устройствам. Для сценариев/виджетов/wb-rules — отдельный getter `topicsWithoutSystem`, который скрывает системные устройства. Алиса остаётся на `topics` без фильтра.

Примеры отображения в сценариях:
<img width="1203" height="739" alt="image" src="https://github.com/user-attachments/assets/996d024c-8119-42b6-91e5-1b9d80218d27" />
Примеры отображения в виджетах:
<img width="749" height="663" alt="image" src="https://github.com/user-attachments/assets/bdab6b5b-41b4-4b1f-af57-1c50a30a3022" />
Пример подсказки в wb-rules (Осталось по старому):
<img width="589" height="232" alt="image" src="https://github.com/user-attachments/assets/cf19481f-7928-4212-90c1-def6bda83772" />

___________________________________
**Что поменялось для пользователей:**

Во всех местах выбора MQTT-контрола теперь единый формат `<имя контрола> [<device/control>]`, элементы сгруппированы по устройствам. Список:

- **Сценарии** — в 5 confed-схемах (`wb-scenarios`, `alarms`, `wb-mqtt-db`, `wb-mqtt-iec104`, `wb-mqtt-opcua`) для полей с `_format: "wb-autocomplete"`. Например: группа «Реле выходное», в ней `K6 [wb-mr6cv3_127/K6]`. Системные устройства скрыты.
- **Редактор виджетов** — модалка добавления виджета на дашборд и страница `/widgets`. Сверху отдельным пунктом без группы — «Разделитель», ниже группы устройств. Контролы, уже добавленные в текущий виджет, отфильтровываются. Системные устройства скрыты.
- **Алиса** — поля выбора MQTT-топика для умений (capabilities) и свойств (properties). Системные устройства показываются.
- **Автокомплит wb-rules** в редакторе скриптов — плоский список топиков для `dev[...]`, `trackMqtt`, `publish` (UX без изменений, изменился только источник). Системные устройства скрыты.

Поиск в выпадающем списке работает по полной строке — можно искать как по человечному имени, так и по части топика.

___________________________________
**Как проверял/а:**

Проверял самостоятельной сборкой пакета и запуском его на контроллере. Проверил установку пакетов - все корректно установилось. Также проверил логику работы Сценариев, Виджетов, Алисы, Правила (подсказки).


