### PR TITLE
feat: show min/max range band on history charts for switch channels INT-1039

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.209.0) stable; urgency=medium
+
+  * Show min/max range band on history charts for switch channels
+
+ -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Tue, 14 May 2026 12:15:00 +0300
+
 wb-mqtt-homeui (2.208.0) stable; urgency=medium
 
   * Update scan page

--- a/frontend/src/stores/history/chart-traits.ts
+++ b/frontend/src/stores/history/chart-traits.ts
@@ -25,7 +25,7 @@ export class ChartTraits {
   }
 
   get hasErrors() {
-    return this.type === ChartType.Number;
+    return this.type === ChartType.Number || this.type === ChartType.Boolean;
   }
 
   get hasBooleanValues() {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

На графиках истории для switch-каналов (boolean) не рисовался диапазон min/max — даже если backend `wb-mqtt-db` отдавал тройку `(value, min, max)` для записи. Это приводило к тому, что для часто переключающегося switch-канала на больших окнах виден либо график с линией среднего по середине бул-оси (если бакет содержал смесь 0 и 1), либо "выпрямленная" линия по 1 после агрегации.

Корень: `chart-traits.ts:27` — геттер `hasErrors` возвращал `true` только для `ChartType.Number`. Логика `createErrorChart` (рендер band'а через `chart.maxErrors`/`chart.minErrors`) условно дёргается только при `chart.hasErrors`, поэтому для `ChartType.Boolean` band никогда не рисовался, даже если backend присылал min и max.

Затрагивает всех пользователей, которые смотрят историю switch/pushbutton каналов.

___________________________________
**Что поменялось для пользователей:**

- На графиках истории для switch-каналов теперь рисуется band между min и max, как для числовых каналов.
- Там, где канал стабилен (`всегда 0` или `всегда 1`), band нулевой ширины — визуально график выглядит как раньше, без лишних элементов.
- Там, где внутри write-окна или read-бакета были переключения, band показывает диапазон `[0, 1]` — сразу видно, на каких участках канал был активен.
- Полностью видимый эффект работает в паре с фиксом в `wb-mqtt-db` (корректное сохранение min/max для одиночных записей).

___________________________________
**Как проверял/а:**

Еще не проверял.