### PR TITLE
fix: add missing title description for autocomplete fields

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.209.2) stable; urgency=medium
+
+  * Fix missing title and description for autocomplete fields
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 19 May 2026 12:07:00 +0300
+
 wb-mqtt-homeui (2.209.1) stable; urgency=medium
 
   * Return tests for fw-utils

--- a/frontend/app/scripts/json-editor/autocomplete.js
+++ b/frontend/app/scripts/json-editor/autocomplete.js
@@ -15,7 +15,7 @@ export function makeAutocompleteEditor(topics) {
 
       this.control = document.createElement('div');
       this.control.style.minWidth = '180px';
-      
+
       const formControl = this.theme.getFormControl(this.label, this.control);
       this.container.appendChild(formControl);
 
@@ -25,7 +25,21 @@ export function makeAutocompleteEditor(topics) {
         );
       }
 
+      this.control.controlgroup = formControl;
+
       this.render();
+    }
+
+    showValidationErrors(errors) {
+      const messages = errors
+        .filter((error) => error.path === this.path)
+        .map((error) => error.message);
+
+      if (messages.length) {
+        this.theme.addInputError(this.control, `${messages.join('. ')}.`);
+      } else {
+        this.theme.removeInputError(this.control);
+      }
     }
 
     render() {

--- a/frontend/app/scripts/json-editor/autocomplete.js
+++ b/frontend/app/scripts/json-editor/autocomplete.js
@@ -6,9 +6,24 @@ import { Dropdown } from '@/components/dropdown';
 export function makeAutocompleteEditor(topics) {
   return class extends JSONEditor.AbstractEditor {
     build() {
+      // AbstractEditor doesn't render label/description by default, so reproduce
+      // the pattern used by the built-in string editor — otherwise schema title
+      // and description are silently dropped for every wb-autocomplete field.
+      if (!this.options.compact) {
+        this.label = this.theme.getFormInputLabel(this.getTitle(), this.isRequired());
+      }
+
       this.control = document.createElement('div');
       this.control.style.minWidth = '180px';
-      this.container.appendChild(this.control);
+      
+      const formControl = this.theme.getFormControl(this.label, this.control);
+      this.container.appendChild(formControl);
+
+      if (this.schema.description) {
+        this.container.appendChild(
+          this.theme.getFormInputDescription(this.translateProperty(this.schema.description))
+        );
+      }
 
       this.render();
     }

--- a/frontend/app/styles/main.css
+++ b/frontend/app/styles/main.css
@@ -597,11 +597,6 @@ button.dashboard-back:active {
   border-color: var(--danger-color);
 }
 
-.has-error .dropdown__control,
-.has-error .dropdown__control:hover {
-  border-color: var(--danger-color);
-}
-
 .wb-react-select .wb-react-select__indicator-separator {
   display: none,
 }

--- a/frontend/app/styles/main.css
+++ b/frontend/app/styles/main.css
@@ -597,6 +597,11 @@ button.dashboard-back:active {
   border-color: var(--danger-color);
 }
 
+.has-error .dropdown__control,
+.has-error .dropdown__control:hover {
+  border-color: var(--danger-color);
+}
+
 .wb-react-select .wb-react-select__indicator-separator {
   display: none,
 }

--- a/frontend/src/components/dropdown/styles.css
+++ b/frontend/src/components/dropdown/styles.css
@@ -125,6 +125,14 @@
   border-color: var(--danger-color);
 }
 
+/* Picked up by json-editor's has-error class on the surrounding form-group so
+   the dropdown shows the same red border as native form-controls on validation
+   failure. */
+.has-error .dropdown__control,
+.has-error .dropdown__control:hover {
+  border-color: var(--danger-color);
+}
+
 .dropdown__control--is-disabled {
   background-color: var(--border-color);
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Кастомный редактор `wb-autocomplete` был переписан на React-компонентом `Dropdown`. У `AbstractEditor` `build()` ничего не делает по умолчанию — поэтому из всех `wb-autocomplete`-полей пропали заголовки (`title`) и подсказки (`description`) из схемы, независимо от того, что в ней прописано.

Регрессия затрагивает все формы, где используется `_format: "wb-autocomplete"` — в частности, поля выбора датчика в сценариях термостата и ПИД-регулятора, где без подписи поле выглядит непонятно для пользователя.

В PR теперь `build()` воспроизводит ту же логику, что и стандартный `string`-редактор: создаёт label через `theme.getFormInputLabel`, оборачивает label + React-контрол в `theme.getFormControl` и если в схеме задано `description`, добавляет его через `theme.getFormInputDescription`.

Дополнительно у `AbstractEditor` пустой `showValidationErrors`, из-за чего у `wb-autocomplete`-полей не показывалась индикация ошибок валидации. Добавлена реализация `showValidationErrors` по образцу `edit-with-dropdown.js`: фильтрует ошибки и вызывает `theme.addInputError/removeInputError`. Контролу заранее проставляется `controlgroup`, чтобы тема корректно находила form-group. В `main.css` добавлено правило `.has-error .dropdown__control { border-color: var(--danger-color) }` — зеркально к уже существующему для устаревшего `.wb-react-select__control`.

___________________________________
**Что поменялось для пользователей:**

- У `wb-autocomplete`-полей снова показываются `title` и `description` из схемы.
- Для обязательных полей рисуется отметка required, как у обычных строковых редакторов.
- Между `wb-autocomplete`-полем и следующим элементом формы появляется естественный визуальный отступ (за счёт стандартного form-group + help-block).
- При ошибке валидации (пустое required-поле, несоответствие паттерну) у поля становится красной граница, label и текст ошибки окрашиваются в красный — как было до перехода на React-Dropdown.
- Для полей без `description` поведение не меняется — отображается только label.
- Поля с `options.compact: true` ведут себя как раньше (label не рисуется).

Пример старого отображения title и required:
<img width="519" height="222" alt="image" src="https://github.com/user-attachments/assets/735f9d62-4617-478b-87ff-e601b37307c6" />

Пример нового отображения title и required:
<img width="659" height="271" alt="image" src="https://github.com/user-attachments/assets/22cf2540-3063-4182-a296-31a48746ebdf" />

___________________________________
**Как проверял/а:**

Локально собрал фронт и залил на контроллер. Установка пакета проверена.
