### PR TITLE
refactor: decompose alice device-capabilities.tsx INT-1069

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
+# This configuration resolves Git warnings related to line endings:
+#   This diff contains a change in line endings from 'LF' to 'CRLF'.
+#
+# After creating the config, the above error is hidden but may show
+# this one for some files:
+#   This diff contains a change in line endings from 'CRLF' to 'LF'.
+#
+# Refer to the following link for more information about this
+# configuration file:
+#   https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+
+# Use LF for all files as this project runs on a Linux-driven controller
+*.tsx text=auto eol=lf
+
 * text=auto

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Change listen settings in `/etc/nginx/includes/default.wb.d/listen.conf`.
 3. Create `.env` file and set `MQTT_BROKER_URI` if your controller is running on different IP (default is 10.200.200.1)
 4. Start the development server: `npm run start`
 
+## Before committing
+
+Run these checks in `./frontend` before opening a PR:
+
+```sh
+cd frontend
+npm install
+npx tsc --noemit  # TypeScript type check
+npm run lint  # ESLint static analysis
+```
+
 ## Custom menu
 One can put a JSON-file with custom menu description in `/usr/share/wb-mqtt-homeui/custom-menu`.
 Items, defined in the file, will be added to left navigation panel.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.215.0) stable; urgency=medium
+
+  * Refactor Alice device-capabilities by splitting it by capability type
+  * Make Alice capability labels clickable
+
+ -- Vitalii Gaponov <vitalii.gaponov@wirenboard.com>  Fri, 22 May 2026 21:00:00 +0300
+
 wb-mqtt-homeui (2.214.0) stable; urgency=medium
 
   * Update config editor page

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/color-setting.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/color-setting.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dropdown, type Option } from '@/components/dropdown';
+import { Input } from '@/components/input';
+import {
+  Capability,
+  Color,
+  ColorModel,
+  type CapabilityParameters,
+  type SmartDeviceCapability,
+  // colorSceneOptions, // TODO: <DISABLED_COLOR> - need uncomment for Color Scenes activation in WEBUI
+  defaultColorModelParameters,
+  defaultTemperatureParameters,
+  defaultColorSceneParameters,
+} from '@/stores/alice';
+
+export const getAvailableColorModels = (
+  capabilities: SmartDeviceCapability[],
+  excludeIndex?: number,
+): Color[] => {
+  // Collect already used Color models among color-setting capabilities
+  const usedColorModels = capabilities
+    .filter((cap, index) => cap.type === Capability['Color setting'] && index !== excludeIndex)
+    .map((cap) => {
+      if (cap.parameters?.color_model) return Color.ColorModel;
+      if (cap.parameters?.temperature_k) return Color.TemperatureK;
+      if (cap.parameters?.color_scene) return Color.ColorScene;
+      return null;
+    })
+    .filter(Boolean);
+
+  return Object.values(Color)
+    .filter((m) => m !== Color.ColorScene) // TODO: <DISABLED_COLOR> Its disable Color scene, need remove for enable
+    .filter((colorModel) => !usedColorModels.includes(colorModel));
+};
+
+const getCurrentColorModel = (capability: SmartDeviceCapability) => {
+  if (capability.parameters?.color_model) return Color.ColorModel;
+  if (capability.parameters?.temperature_k) return Color.TemperatureK;
+  if (capability.parameters?.color_scene) return Color.ColorScene;
+  return Color.ColorModel; // Default value
+};
+
+const getColorModelLabel = (colorKey: string, t: (k: string) => string) => {
+  switch (colorKey) {
+    case 'ColorModel': return t('alice.labels.color-model');
+    case 'TemperatureK': return t('alice.labels.color-temperature');
+    case 'ColorScene': return t('alice.labels.color-scenes');
+    default: return colorKey;
+  }
+};
+
+interface ColorSettingCapabilityProps {
+  capability: SmartDeviceCapability;
+  index: number;
+  capabilities: SmartDeviceCapability[];
+  onCapabilityChange: (capabilities: SmartDeviceCapability[]) => void;
+}
+
+export const ColorSettingCapability = ({
+  capability, index, capabilities, onCapabilityChange,
+}: ColorSettingCapabilityProps) => {
+  const { t } = useTranslation();
+
+  const handleColorSettingTypeChange = useCallback((
+    value: Color,
+    key: number,
+  ) => {
+    let newParameters: CapabilityParameters = {};
+
+    if (value === Color.ColorModel) {
+      Object.assign(newParameters, defaultColorModelParameters[ColorModel.RGB]);
+    } else if (value === Color.TemperatureK) {
+      Object.assign(newParameters, defaultTemperatureParameters);
+    } else if (value === Color.ColorScene) {
+      Object.assign(newParameters, defaultColorSceneParameters);
+    }
+
+    const updatedCapabilities = capabilities.map((item, i) => i === key
+      ? { ...item, parameters: newParameters }
+      : item);
+    onCapabilityChange(updatedCapabilities);
+  }, [capabilities]);
+
+  const handleColorModelInstanceChange = useCallback((
+    value: ColorModel,
+    key: number,
+  ) => {
+    const newParameters = defaultColorModelParameters[value];
+
+    const updatedCapabilities = capabilities.map((item, i) => i === key
+      ? { ...item, parameters: newParameters }
+      : item);
+    onCapabilityChange(updatedCapabilities);
+  }, [capabilities]);
+
+  const handleTemperatureParameterChange = useCallback((
+    paramType: 'min' | 'max',
+    value: number,
+    key: number,
+  ) => {
+    const updatedCapabilities = capabilities.map((item, i) => i === key
+      ? {
+        ...item,
+        parameters: {
+          ...item.parameters,
+          temperature_k: {
+            ...item.parameters.temperature_k,
+            [paramType]: value,
+          },
+        },
+      }
+      : item);
+    onCapabilityChange(updatedCapabilities);
+  }, [capabilities]);
+
+  const handleColorScenesChange = useCallback((
+    scenes: string,
+    key: number,
+  ) => {
+    const sceneList = scenes.split(',').map((s) => s.trim()).filter(Boolean);
+    const updatedCapabilities = capabilities.map((item, i) => i === key
+      ? {
+        ...item,
+        parameters: {
+          ...item.parameters,
+          color_scene: {
+            ...item.parameters.color_scene,
+            scenes: sceneList,
+          },
+        },
+      }
+      : item);
+    onCapabilityChange(updatedCapabilities);
+  }, [capabilities]);
+
+  const getColorModelOptions = useMemo(() => {
+    return (currentCapability: SmartDeviceCapability, currentCapabilityIndex: number) => {
+      const availableModels = getAvailableColorModels(capabilities, currentCapabilityIndex);
+      const currentlySelectedModel = getCurrentColorModel(currentCapability);
+
+      return Object.keys(Color)
+        // TODO: <DISABLED_COLOR> This line disable Color scene, need remove for enable
+        .filter((colorKey) => colorKey !== 'ColorScene')
+        .map((colorKey) => {
+          const modelValue = Color[colorKey];
+          const isCurrentlySelected = currentlySelectedModel === modelValue;
+          const isAvailableForUse = availableModels.includes(modelValue);
+
+          return {
+            label: getColorModelLabel(colorKey, t),
+            value: modelValue,
+            isDisabled: !isCurrentlySelected && !isAvailableForUse,
+          };
+        });
+    };
+  }, [capabilities]);
+
+  return (
+    <>
+      <div>
+        <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.type')}</div>
+        <Dropdown
+          value={getCurrentColorModel(capability)}
+          options={getColorModelOptions(capability, index)}
+          onChange={({ value }: Option<Color>) => {
+            handleColorSettingTypeChange(value, index);
+          }}
+        />
+      </div>
+
+      {getCurrentColorModel(capability) === Color.ColorModel && (
+        <div>
+          <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.color-model')}</div>
+          <Dropdown
+            value={capability.parameters?.color_model ?? null}
+            options={Object.keys(ColorModel)
+              // TODO: <DISABLED_COLOR> This line disable Color HSV, need remove for enable
+              .filter((m) => m !== 'HSV' || capability.parameters?.color_model === ColorModel.HSV)
+              .map((model) => ({
+                label: model,
+                value: ColorModel[model as keyof typeof ColorModel],
+              }))}
+            onChange={({ value }: Option<ColorModel>) => {
+              handleColorModelInstanceChange(value, index);
+            }}
+          />
+        </div>
+      )}
+
+      {capability.parameters?.temperature_k && (
+        <div className="aliceDeviceSkills-gridRange">
+          <div>
+            <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.min')}</div>
+            <Input
+              value={capability.parameters?.temperature_k?.min}
+              type="number"
+              isFullWidth
+              onChangeEvent={(event) => {
+                const min = event.currentTarget.valueAsNumber || 0;
+                handleTemperatureParameterChange('min', min, index);
+              }}
+            />
+          </div>
+          <div>
+            <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.max')}</div>
+            <Input
+              value={capability.parameters?.temperature_k?.max}
+              type="number"
+              isFullWidth
+              onChangeEvent={(event) => {
+                const max = event.currentTarget.valueAsNumber || 0;
+                handleTemperatureParameterChange('max', max, index);
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {getCurrentColorModel(capability) === Color.ColorScene && (
+        <div>
+          <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.scenes-input')}</div>
+          <Input
+            value={capability.parameters?.color_scene?.scenes?.join(', ') || ''}
+            placeholder="ocean, sunset, party"
+            isFullWidth
+            onChange={(scenes: string) => {
+              handleColorScenesChange(scenes, index);
+            }}
+          />
+        </div>
+      )}
+    </>
+  );
+};

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/color-setting.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/color-setting.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useId, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown, type Option } from '@/components/dropdown';
 import { Input } from '@/components/input';
@@ -55,6 +55,12 @@ export const ColorSettingCapability = ({
   capability, index, capabilities, onCapabilityChange,
 }: CapabilitySubProps) => {
   const { t } = useTranslation();
+  const idPrefix = useId();
+  const typeId = `${idPrefix}-type`;
+  const colorModelId = `${idPrefix}-color-model`;
+  const minId = `${idPrefix}-min`;
+  const maxId = `${idPrefix}-max`;
+  const scenesId = `${idPrefix}-scenes`;
 
   const handleColorSettingTypeChange = useCallback((
     value: Color,
@@ -153,8 +159,9 @@ export const ColorSettingCapability = ({
   return (
     <>
       <div>
-        <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.type')}</div>
+        <label className="aliceDeviceSkills-gridLabel" htmlFor={typeId}>{t('alice.labels.type')}</label>
         <Dropdown
+          id={typeId}
           value={getCurrentColorModel(capability)}
           options={getColorModelOptions(capability, index)}
           onChange={({ value }: Option<Color>) => {
@@ -165,8 +172,9 @@ export const ColorSettingCapability = ({
 
       {getCurrentColorModel(capability) === Color.ColorModel && (
         <div>
-          <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.color-model')}</div>
+          <label className="aliceDeviceSkills-gridLabel" htmlFor={colorModelId}>{t('alice.labels.color-model')}</label>
           <Dropdown
+            id={colorModelId}
             value={capability.parameters?.color_model ?? null}
             options={Object.keys(ColorModel)
               // TODO: <DISABLED_COLOR> This line disable Color HSV, need remove for enable
@@ -185,8 +193,9 @@ export const ColorSettingCapability = ({
       {capability.parameters?.temperature_k && (
         <div className="aliceDeviceSkills-gridRange">
           <div>
-            <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.min')}</div>
+            <label className="aliceDeviceSkills-gridLabel" htmlFor={minId}>{t('alice.labels.min')}</label>
             <Input
+              id={minId}
               value={capability.parameters?.temperature_k?.min}
               type="number"
               isFullWidth
@@ -197,8 +206,9 @@ export const ColorSettingCapability = ({
             />
           </div>
           <div>
-            <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.max')}</div>
+            <label className="aliceDeviceSkills-gridLabel" htmlFor={maxId}>{t('alice.labels.max')}</label>
             <Input
+              id={maxId}
               value={capability.parameters?.temperature_k?.max}
               type="number"
               isFullWidth
@@ -213,8 +223,9 @@ export const ColorSettingCapability = ({
 
       {getCurrentColorModel(capability) === Color.ColorScene && (
         <div>
-          <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.scenes-input')}</div>
+          <label className="aliceDeviceSkills-gridLabel" htmlFor={scenesId}>{t('alice.labels.scenes-input')}</label>
           <Input
+            id={scenesId}
             value={capability.parameters?.color_scene?.scenes?.join(', ') || ''}
             placeholder="ocean, sunset, party"
             isFullWidth

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/color-setting.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/color-setting.tsx
@@ -13,6 +13,7 @@ import {
   defaultTemperatureParameters,
   defaultColorSceneParameters,
 } from '@/stores/alice';
+import { type CapabilitySubProps } from '../types';
 
 export const getAvailableColorModels = (
   capabilities: SmartDeviceCapability[],
@@ -50,16 +51,9 @@ const getColorModelLabel = (colorKey: string, t: (k: string) => string) => {
   }
 };
 
-interface ColorSettingCapabilityProps {
-  capability: SmartDeviceCapability;
-  index: number;
-  capabilities: SmartDeviceCapability[];
-  onCapabilityChange: (capabilities: SmartDeviceCapability[]) => void;
-}
-
 export const ColorSettingCapability = ({
   capability, index, capabilities, onCapabilityChange,
-}: ColorSettingCapabilityProps) => {
+}: CapabilitySubProps) => {
   const { t } = useTranslation();
 
   const handleColorSettingTypeChange = useCallback((

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/mode.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/mode.tsx
@@ -1,0 +1,36 @@
+// TODO: <DISABLED_MODE> - need uncomment for Mode activation in WEBUI
+
+// import { modes } from '@/stores/alice';
+//
+// {capability.type === Capability.Mode && (
+//   <>
+//     <div>
+//       <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode-type')}</div>
+//       <Dropdown
+//         value={capability.parameters?.instance}
+//         options={modes.map((mode) => ({ label: mode, value: mode }))}
+//         onChange={({ value: instance }: Option<string>) => {
+//           const val = capabilities.map((item, i) => i === key
+//             ? { ...item, parameters: { ...item.parameters, instance } }
+//             : item);
+//           onCapabilityChange(val);
+//         }}
+//       />
+//     </div>
+//     <div>
+//       <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
+//       <Input
+//         value={capability.parameters?.modes}
+//         isFullWidth
+//         onChange={(modes: string) => {
+//           const val = capabilities.map((item, i) => i === key
+//             ? { ...item, parameters: { ...item.parameters, modes } }
+//             : item);
+//           onCapabilityChange(val);
+//         }}
+//       />
+//     </div>
+//   </>
+// )}
+
+export {};

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/mode.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/mode.tsx
@@ -1,6 +1,7 @@
 // TODO: <DISABLED_MODE> - need uncomment for Mode activation in WEBUI
 
 // import { modes } from '@/stores/alice';
+// import { type CapabilitySubProps } from '../types';
 //
 // {capability.type === Capability.Mode && (
 //   <>

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/mode.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/mode.tsx
@@ -6,8 +6,9 @@
 // {capability.type === Capability.Mode && (
 //   <>
 //     <div>
-//       <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode-type')}</div>
+//       <label className="aliceDeviceSkills-gridLabel" htmlFor={modeTypeId}>{t('alice.labels.mode-type')}</label>
 //       <Dropdown
+//         id={modeTypeId}
 //         value={capability.parameters?.instance}
 //         options={modes.map((mode) => ({ label: mode, value: mode }))}
 //         onChange={({ value: instance }: Option<string>) => {
@@ -19,8 +20,9 @@
 //       />
 //     </div>
 //     <div>
-//       <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
+//       <label className="aliceDeviceSkills-gridLabel" htmlFor={modeId}>{t('alice.labels.mode')}</label>
 //       <Input
+//         id={modeId}
 //         value={capability.parameters?.modes}
 //         isFullWidth
 //         onChange={(modes: string) => {

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/on-off.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/on-off.tsx
@@ -1,0 +1,3 @@
+export const OnOffCapability = () => (
+  <div className="aliceDeviceSkills-colspan2"></div>
+);

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/range.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/range.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown, type Option } from '@/components/dropdown';
 import { Input } from '@/components/input';
@@ -39,6 +39,11 @@ export const RangeCapability = ({
   capability, index, capabilities, onCapabilityChange,
 }: CapabilitySubProps) => {
   const { t } = useTranslation();
+  const idPrefix = useId();
+  const modeId = `${idPrefix}-mode`;
+  const minId = `${idPrefix}-min`;
+  const maxId = `${idPrefix}-max`;
+  const precisionId = `${idPrefix}-precision`;
 
   const getRangeInstanceOptions = useCallback((
     currentCapability: SmartDeviceCapability,
@@ -62,8 +67,9 @@ export const RangeCapability = ({
   return (
     <>
       <div>
-        <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
+        <label className="aliceDeviceSkills-gridLabel" htmlFor={modeId}>{t('alice.labels.mode')}</label>
         <Dropdown
+          id={modeId}
           value={capability.parameters?.instance}
           options={getRangeInstanceOptions(capability, index)}
           onChange={({ value: instance }: Option<string>) => {
@@ -99,8 +105,9 @@ export const RangeCapability = ({
           return (
             <>
               <div>
-                <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.min')}</div>
+                <label className="aliceDeviceSkills-gridLabel" htmlFor={minId}>{t('alice.labels.min')}</label>
                 <Input
+                  id={minId}
                   value={lockedMin}
                   type="number"
                   isDisabled={isRangeLocked}
@@ -118,8 +125,9 @@ export const RangeCapability = ({
                 />
               </div>
               <div>
-                <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.max')}</div>
+                <label className="aliceDeviceSkills-gridLabel" htmlFor={maxId}>{t('alice.labels.max')}</label>
                 <Input
+                  id={maxId}
                   value={lockedMax}
                   type="number"
                   isDisabled={isRangeLocked}
@@ -137,8 +145,11 @@ export const RangeCapability = ({
                 />
               </div>
               <div>
-                <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.precision')}</div>
+                <label className="aliceDeviceSkills-gridLabel" htmlFor={precisionId}>
+                  {t('alice.labels.precision')}
+                </label>
                 <Input
+                  id={precisionId}
                   value={capability.parameters?.range.precision}
                   type="number"
                   isFullWidth

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/range.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/range.tsx
@@ -1,0 +1,169 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dropdown, type Option } from '@/components/dropdown';
+import { Input } from '@/components/input';
+import { Capability, ranges, rangeUnitByInstance, type SmartDeviceCapability } from '@/stores/alice';
+
+// Default range values for unlocked instances
+export const RANGE_LIMITS_DEFAULT = { min: 0, max: 100, precision: 1 };
+
+// Instances with fixed ranges that cannot be changed in UI
+export const RANGE_LIMITS_LOCKED: Record<string, { min: number; max: number; precision?: number }> = {
+  brightness: { min: 0, max: 100, precision: 1 },
+  // channel: No lock applied
+  humidity:   { min: 0, max: 100, precision: 1 },
+  open:       { min: 0, max: 100, precision: 1 },
+  // temperature: No lock applied
+  // volume: No lock applied
+};
+
+export const getAvailableRangeInstances = (
+  capabilities: SmartDeviceCapability[],
+  excludeIndex?: number,
+): string[] => {
+  const usedInstances = capabilities
+    .filter((cap, index) =>
+      cap.type === Capability.Range &&
+      index !== excludeIndex &&
+      cap.parameters?.instance,
+    )
+    .map((cap) => cap.parameters.instance);
+
+  return ranges.filter(
+    (rangeInstance) => !usedInstances.includes(rangeInstance),
+  );
+};
+
+interface RangeCapabilityProps {
+  capability: SmartDeviceCapability;
+  index: number;
+  capabilities: SmartDeviceCapability[];
+  onCapabilityChange: (capabilities: SmartDeviceCapability[]) => void;
+}
+
+export const RangeCapability = ({
+  capability, index, capabilities, onCapabilityChange,
+}: RangeCapabilityProps) => {
+  const { t } = useTranslation();
+
+  const getRangeInstanceOptions = useCallback((
+    currentCapability: SmartDeviceCapability,
+    currentCapabilityIndex: number,
+  ) => {
+    const availableInstances = getAvailableRangeInstances(capabilities, currentCapabilityIndex);
+    const currentlySelectedInstance = currentCapability.parameters?.instance;
+
+    return ranges.map((rangeInstance) => {
+      const isCurrentlySelected = currentlySelectedInstance === rangeInstance;
+      const isAvailableForUse = availableInstances.includes(rangeInstance);
+
+      return {
+        label: rangeInstance,
+        value: rangeInstance,
+        isDisabled: !isCurrentlySelected && !isAvailableForUse,
+      };
+    });
+  }, [capabilities]);
+
+  return (
+    <>
+      <div>
+        <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
+        <Dropdown
+          value={capability.parameters?.instance}
+          options={getRangeInstanceOptions(capability, index)}
+          onChange={({ value: instance }: Option<string>) => {
+            const unit = rangeUnitByInstance[instance];
+
+            // If instance has a fixed range - apply it
+            const rangeConfig = RANGE_LIMITS_LOCKED[instance] ?? RANGE_LIMITS_DEFAULT;
+            const nextParams = {
+              ...capability.parameters,
+              instance,
+              unit,
+              range: {
+                min: rangeConfig.min,
+                max: rangeConfig.max,
+                precision: rangeConfig.precision ?? capability.parameters?.range?.precision ?? 1,
+              },
+            };
+
+            const val = capabilities.map((item, i) =>
+              i === index ? { ...item, parameters: nextParams } : item,
+            );
+            onCapabilityChange(val);
+          }}
+        />
+      </div>
+      <div className="aliceDeviceSkills-gridRange">
+        {(() => {
+          const curInstance = capability.parameters?.instance as string;
+          const fixedRange = RANGE_LIMITS_LOCKED[curInstance];
+          const isRangeLocked = !!fixedRange;
+          const lockedMin = fixedRange?.min ?? capability.parameters?.range?.min ?? 0;
+          const lockedMax = fixedRange?.max ?? capability.parameters?.range?.max ?? 100;
+          return (
+            <>
+              <div>
+                <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.min')}</div>
+                <Input
+                  value={lockedMin}
+                  type="number"
+                  isDisabled={isRangeLocked}
+                  isFullWidth
+                  onChangeEvent={(event) => {
+                    const min = event.currentTarget.valueAsNumber || 0;
+                    const val = capabilities.map((item, i) => i === index
+                      ? {
+                        ...item,
+                        parameters: { ...item.parameters, range: { ...item.parameters.range, min } },
+                      }
+                      : item);
+                    onCapabilityChange(val);
+                  }}
+                />
+              </div>
+              <div>
+                <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.max')}</div>
+                <Input
+                  value={lockedMax}
+                  type="number"
+                  isDisabled={isRangeLocked}
+                  isFullWidth
+                  onChangeEvent={(event) => {
+                    const max = event.currentTarget.valueAsNumber || 0;
+                    const val = capabilities.map((item, i) => i === index
+                      ? {
+                        ...item,
+                        parameters: { ...item.parameters, range: { ...item.parameters.range, max } },
+                      }
+                      : item);
+                    onCapabilityChange(val);
+                  }}
+                />
+              </div>
+              <div>
+                <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.precision')}</div>
+                <Input
+                  value={capability.parameters?.range.precision}
+                  type="number"
+                  isFullWidth
+                  onChangeEvent={(event) => {
+                    const precision = event.currentTarget.valueAsNumber || 0;
+                    const val = capabilities.map((item, i) => i === index
+                      ? {
+                        ...item,
+                        parameters: { ...item.parameters, range: { ...item.parameters.range, precision } },
+                      }
+                      : item);
+                    onCapabilityChange(val);
+                  }}
+                />
+              </div>
+            </>
+          );
+        })()}
+      </div>
+    </>
+  );
+};

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/range.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/range.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Dropdown, type Option } from '@/components/dropdown';
 import { Input } from '@/components/input';
 import { Capability, ranges, rangeUnitByInstance, type SmartDeviceCapability } from '@/stores/alice';
+import { type CapabilitySubProps } from '../types';
 
 // Default range values for unlocked instances
 export const RANGE_LIMITS_DEFAULT = { min: 0, max: 100, precision: 1 };
@@ -34,16 +35,9 @@ export const getAvailableRangeInstances = (
   );
 };
 
-interface RangeCapabilityProps {
-  capability: SmartDeviceCapability;
-  index: number;
-  capabilities: SmartDeviceCapability[];
-  onCapabilityChange: (capabilities: SmartDeviceCapability[]) => void;
-}
-
 export const RangeCapability = ({
   capability, index, capabilities, onCapabilityChange,
-}: RangeCapabilityProps) => {
+}: CapabilitySubProps) => {
   const { t } = useTranslation();
 
   const getRangeInstanceOptions = useCallback((

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/toggle.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/toggle.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown, type Option } from '@/components/dropdown';
 import { Capability, toggles, type SmartDeviceCapability } from '@/stores/alice';
@@ -25,6 +25,7 @@ export const ToggleCapability = ({
   capability, index, capabilities, onCapabilityChange,
 }: CapabilitySubProps) => {
   const { t } = useTranslation();
+  const instanceId = useId();
 
   const getToggleInstanceOptions = useCallback((
     currentCapability: SmartDeviceCapability,
@@ -47,8 +48,9 @@ export const ToggleCapability = ({
 
   return (
     <div className="aliceDeviceSkills-colspan2">
-      <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
+      <label className="aliceDeviceSkills-gridLabel" htmlFor={instanceId}>{t('alice.labels.mode')}</label>
       <Dropdown
+        id={instanceId}
         value={capability.parameters?.instance}
         options={getToggleInstanceOptions(capability, index)}
         onChange={({ value: instance }: Option<string>) => {

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/toggle.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/toggle.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dropdown, type Option } from '@/components/dropdown';
 import { Capability, toggles, type SmartDeviceCapability } from '@/stores/alice';
+import { type CapabilitySubProps } from '../types';
 
 export const getAvailableToggleInstances = (
   capabilities: SmartDeviceCapability[],
@@ -20,16 +21,9 @@ export const getAvailableToggleInstances = (
   );
 };
 
-interface ToggleCapabilityProps {
-  capability: SmartDeviceCapability;
-  index: number;
-  capabilities: SmartDeviceCapability[];
-  onCapabilityChange: (capabilities: SmartDeviceCapability[]) => void;
-}
-
 export const ToggleCapability = ({
   capability, index, capabilities, onCapabilityChange,
-}: ToggleCapabilityProps) => {
+}: CapabilitySubProps) => {
   const { t } = useTranslation();
 
   const getToggleInstanceOptions = useCallback((

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/toggle.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/capabilities/toggle.tsx
@@ -1,0 +1,69 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dropdown, type Option } from '@/components/dropdown';
+import { Capability, toggles, type SmartDeviceCapability } from '@/stores/alice';
+
+export const getAvailableToggleInstances = (
+  capabilities: SmartDeviceCapability[],
+  excludeIndex?: number,
+): string[] => {
+  const usedInstances = capabilities
+    .filter((cap, index) =>
+      cap.type === Capability.Toggle &&
+      index !== excludeIndex &&
+      cap.parameters?.instance,
+    )
+    .map((cap) => cap.parameters.instance);
+
+  return toggles.filter(
+    (toggleInstance) => !usedInstances.includes(toggleInstance),
+  );
+};
+
+interface ToggleCapabilityProps {
+  capability: SmartDeviceCapability;
+  index: number;
+  capabilities: SmartDeviceCapability[];
+  onCapabilityChange: (capabilities: SmartDeviceCapability[]) => void;
+}
+
+export const ToggleCapability = ({
+  capability, index, capabilities, onCapabilityChange,
+}: ToggleCapabilityProps) => {
+  const { t } = useTranslation();
+
+  const getToggleInstanceOptions = useCallback((
+    currentCapability: SmartDeviceCapability,
+    currentCapabilityIndex: number,
+  ) => {
+    const availableInstances = getAvailableToggleInstances(capabilities, currentCapabilityIndex);
+    const currentlySelectedInstance = currentCapability.parameters?.instance;
+
+    return toggles.map((toggleInstance) => {
+      const isCurrentlySelected = currentlySelectedInstance === toggleInstance;
+      const isAvailableForUse = availableInstances.includes(toggleInstance);
+
+      return {
+        label: toggleInstance,
+        value: toggleInstance,
+        isDisabled: !isCurrentlySelected && !isAvailableForUse,
+      };
+    });
+  }, [capabilities]);
+
+  return (
+    <div className="aliceDeviceSkills-colspan2">
+      <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
+      <Dropdown
+        value={capability.parameters?.instance}
+        options={getToggleInstanceOptions(capability, index)}
+        onChange={({ value: instance }: Option<string>) => {
+          const val = capabilities.map((item, i) => i === index
+            ? { ...item, parameters: { ...item.parameters, instance } }
+            : item);
+          onCapabilityChange(val);
+        }}
+      />
+    </div>
+  );
+};

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/device-capabilities.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/device-capabilities.tsx
@@ -30,7 +30,7 @@ import {
   ToggleCapability,
   getAvailableToggleInstances,
 } from './capabilities/toggle';
-import { type DeviceCapabilitiesProps } from './types';
+import { type CapabilitySubProps, type DeviceCapabilitiesProps } from './types';
 
 export const DeviceCapabilities = observer(({
   capabilities, devicesStore, onCapabilityChange,
@@ -131,7 +131,7 @@ export const DeviceCapabilities = observer(({
   };
 
   const renderCapabilityFields = (capability: SmartDeviceCapability, key: number) => {
-    const subProps = { capability, index: key, capabilities, onCapabilityChange };
+    const subProps: CapabilitySubProps = { capability, index: key, capabilities, onCapabilityChange };
     switch (capability.type) {
       case Capability['On/Off']: return <OnOffCapability />;
       case Capability['Color setting']: return <ColorSettingCapability {...subProps} />;

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/device-capabilities.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/device-capabilities.tsx
@@ -1,5 +1,5 @@
 import { observer } from 'mobx-react-lite';
-import { Fragment } from 'react';
+import { Fragment, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import TrashIcon from '@/assets/icons/trash.svg';
 import { Button } from '@/components/button';
@@ -36,6 +36,7 @@ export const DeviceCapabilities = observer(({
   capabilities, devicesStore, onCapabilityChange,
 }: DeviceCapabilitiesProps) => {
   const { t } = useTranslation();
+  const idPrefix = useId();
 
   const isCapabilityDisabled = (
     capabilityType: Capability,
@@ -142,55 +143,61 @@ export const DeviceCapabilities = observer(({
     }
   };
 
-  const renderCapabilityRow = (capability: SmartDeviceCapability, key: number) => (
-    <Fragment key={key}>
-      <div>
-        <div className="aliceDeviceSkills-gridLabel aliceDeviceSkills-gridHiddenLabel">
-          {t('alice.labels.capability')}
+  const renderCapabilityRow = (capability: SmartDeviceCapability, key: number) => {
+    const capabilityId = `${idPrefix}-capability-${key}`;
+    const topicId = `${idPrefix}-topic-${key}`;
+    return (
+      <Fragment key={key}>
+        <div>
+          <label className="aliceDeviceSkills-gridLabel" htmlFor={capabilityId}>
+            {t('alice.labels.capability')}
+          </label>
+          <Dropdown
+            id={capabilityId}
+            value={capability.type}
+            options={Object.keys(Capability).map((cap) => ({
+              label: cap,
+              value: Capability[cap],
+              isDisabled: isCapabilityDisabled(Capability[cap], capabilities),
+            }))}
+            onChange={(option: Option<Capability>) => onCapabilityTypeChange(option.value, key)}
+          />
         </div>
-        <Dropdown
-          value={capability.type}
-          options={Object.keys(Capability).map((cap) => ({
-            label: cap,
-            value: Capability[cap],
-            isDisabled: isCapabilityDisabled(Capability[cap], capabilities),
-          }))}
-          onChange={(option: Option<Capability>) => onCapabilityTypeChange(option.value, key)}
-        />
-      </div>
-      <div>
-        <div className="aliceDeviceSkills-gridLabel aliceDeviceSkills-gridHiddenLabel">
-          {t('alice.labels.topic')}
+        <div>
+          <label className="aliceDeviceSkills-gridLabel" htmlFor={topicId}>
+            {t('alice.labels.topic')}
+          </label>
+          <Dropdown
+            id={topicId}
+            className="aliceDeviceSkills-dropdown"
+            value={capability.mqtt}
+            placeholder={devicesStore.topics.flatMap((g) => g.options)
+              .find((o) => o.value === capability.mqtt)?.label}
+            options={devicesStore.topics as any[]}
+            isSearchable
+            onChange={({ value }: Option<string>) => {
+              onCapabilityChange(capabilities.map((item, i) => (
+                i === key ? { ...item, mqtt: value } : item
+              )));
+            }}
+          />
         </div>
-        <Dropdown
-          className="aliceDeviceSkills-dropdown"
-          value={capability.mqtt}
-          placeholder={devicesStore.topics.flatMap((g) => g.options)
-            .find((o) => o.value === capability.mqtt)?.label}
-          options={devicesStore.topics as any[]}
-          isSearchable
-          onChange={({ value }: Option<string>) => {
-            onCapabilityChange(capabilities.map((item, i) => (
-              i === key ? { ...item, mqtt: value } : item
-            )));
-          }}
-        />
-      </div>
 
-      {renderCapabilityFields(capability, key)}
+        {renderCapabilityFields(capability, key)}
 
-      <div className="aliceDeviceSkills-deleteButton">
-        <Button
-          size="small"
-          type="button"
-          icon={<TrashIcon />}
-          variant="secondary"
-          isOutlined
-          onClick={() => onCapabilityChange(capabilities.filter((_item, i) => i !== key))}
-        />
-      </div>
-    </Fragment>
-  );
+        <div className="aliceDeviceSkills-deleteButton">
+          <Button
+            size="small"
+            type="button"
+            icon={<TrashIcon />}
+            variant="secondary"
+            isOutlined
+            onClick={() => onCapabilityChange(capabilities.filter((_item, i) => i !== key))}
+          />
+        </div>
+      </Fragment>
+    );
+  };
 
   return (
     <>

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/device-capabilities.tsx
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/device-capabilities.tsx
@@ -1,269 +1,64 @@
 import { observer } from 'mobx-react-lite';
-import { Fragment, useCallback, useMemo } from 'react';
+import { Fragment } from 'react';
 import { useTranslation } from 'react-i18next';
 import TrashIcon from '@/assets/icons/trash.svg';
 import { Button } from '@/components/button';
 import { Dropdown, type Option } from '@/components/dropdown';
-import { Input } from '@/components/input';
 import {
   Capability,
   Color,
   ColorModel,
-  // modes, // TODO: <DISABLED_MODE> - need uncomment for Mode activation in WEBUI
-  ranges,
-  toggles,
   type CapabilityParameters,
   type SmartDeviceCapability,
-  // colorSceneOptions, // TODO: <DISABLED_COLOR> - need uncomment for Color Scenes activation in WEBUI
   rangeUnitByInstance,
   defaultColorModelParameters,
   defaultTemperatureParameters,
   defaultColorSceneParameters,
 } from '@/stores/alice';
+import {
+  ColorSettingCapability,
+  getAvailableColorModels,
+} from './capabilities/color-setting';
+import { OnOffCapability } from './capabilities/on-off';
+import {
+  RangeCapability,
+  RANGE_LIMITS_DEFAULT,
+  RANGE_LIMITS_LOCKED,
+  getAvailableRangeInstances,
+} from './capabilities/range';
+import {
+  ToggleCapability,
+  getAvailableToggleInstances,
+} from './capabilities/toggle';
 import { type DeviceCapabilitiesProps } from './types';
-
-// Default range values for unlocked instances
-const RANGE_LIMITS_DEFAULT = { min: 0, max: 100, precision: 1 };
-
-// Instances with fixed ranges that cannot be changed in UI
-const RANGE_LIMITS_LOCKED: Record<string, { min: number; max: number; precision?: number }> = {
-  brightness: { min: 0, max: 100, precision: 1 },
-  // channel: No lock applied
-  humidity:   { min: 0, max: 100, precision: 1 },
-  open:       { min: 0, max: 100, precision: 1 },
-  // temperature: No lock applied
-  // volume: No lock applied
-};
-
-const getAvailableColorModels = (
-  capabilities: SmartDeviceCapability[],
-  excludeIndex?: number,
-): Color[] => {
-  // Collect already used Color models among color-setting capabilities
-  const usedColorModels = capabilities
-    .filter((cap, index) => cap.type === Capability['Color setting'] && index !== excludeIndex)
-    .map((cap) => {
-      if (cap.parameters?.color_model) return Color.ColorModel;
-      if (cap.parameters?.temperature_k) return Color.TemperatureK;
-      if (cap.parameters?.color_scene) return Color.ColorScene;
-      return null;
-    })
-    .filter(Boolean);
-
-  return Object.values(Color)
-    .filter((m) => m !== Color.ColorScene) // TODO: <DISABLED_COLOR> Its disable Color scene, need remove for enable
-    .filter((colorModel) => !usedColorModels.includes(colorModel));
-};
-
-const getCurrentColorModel = (capability: SmartDeviceCapability) => {
-  if (capability.parameters?.color_model) return Color.ColorModel;
-  if (capability.parameters?.temperature_k) return Color.TemperatureK;
-  if (capability.parameters?.color_scene) return Color.ColorScene;
-  return Color.ColorModel; // Default value
-};
-
-const getAvailableRangeInstances = (
-  capabilities: SmartDeviceCapability[],
-  excludeIndex?: number,
-): string[] => {
-  const usedInstances = capabilities
-    .filter((cap, index) =>
-      cap.type === Capability.Range &&
-      index !== excludeIndex &&
-      cap.parameters?.instance,
-    )
-    .map((cap) => cap.parameters.instance);
-
-  return ranges.filter(
-    (rangeInstance) => !usedInstances.includes(rangeInstance),
-  );
-};
-
-const getAvailableToggleInstances = (
-  capabilities: SmartDeviceCapability[],
-  excludeIndex?: number,
-): string[] => {
-  const usedInstances = capabilities
-    .filter((cap, index) =>
-      cap.type === Capability.Toggle &&
-      index !== excludeIndex &&
-      cap.parameters?.instance,
-    )
-    .map((cap) => cap.parameters.instance);
-
-  return toggles.filter(
-    (toggleInstance) => !usedInstances.includes(toggleInstance),
-  );
-};
-
-const getColorModelLabel = (colorKey: string, t: (k: string) => string) => {
-  switch (colorKey) {
-    case 'ColorModel': return t('alice.labels.color-model');
-    case 'TemperatureK': return t('alice.labels.color-temperature');
-    case 'ColorScene': return t('alice.labels.color-scenes');
-    default: return colorKey;
-  }
-};
-
-const isCapabilityDisabled = (
-  capabilityType: Capability,
-  capabilities: SmartDeviceCapability[],
-) => {
-  if (capabilityType === Capability['Color setting']) {
-    // For color setting, disable only if all color models are used
-    return !getAvailableColorModels(capabilities).length;
-  }
-
-  if (capabilityType === Capability.Range) {
-    // For range, disable only if all range instances are used
-    return !getAvailableRangeInstances(capabilities).length;
-  }
-
-  if (capabilityType === Capability.Toggle) {
-    // For toggle, disable only if all toggle instances are used
-    return !getAvailableToggleInstances(capabilities).length;
-  }
-
-  // For other capabilities, use existing logic
-  return capabilities.find((item) => item.type === capabilityType);
-};
 
 export const DeviceCapabilities = observer(({
   capabilities, devicesStore, onCapabilityChange,
 }: DeviceCapabilitiesProps) => {
   const { t } = useTranslation();
 
-  const handleColorSettingTypeChange = useCallback((
-    value: Color,
-    key: number,
+  const isCapabilityDisabled = (
+    capabilityType: Capability,
+    capabilities: SmartDeviceCapability[],
   ) => {
-    let newParameters: CapabilityParameters = {};
-
-    if (value === Color.ColorModel) {
-      Object.assign(newParameters, defaultColorModelParameters[ColorModel.RGB]);
-    } else if (value === Color.TemperatureK) {
-      Object.assign(newParameters, defaultTemperatureParameters);
-    } else if (value === Color.ColorScene) {
-      Object.assign(newParameters, defaultColorSceneParameters);
+    if (capabilityType === Capability['Color setting']) {
+      // For color setting, disable only if all color models are used
+      return !getAvailableColorModels(capabilities).length;
     }
 
-    const updatedCapabilities = capabilities.map((item, i) => i === key
-      ? { ...item, parameters: newParameters }
-      : item);
-    onCapabilityChange(updatedCapabilities);
-  }, [capabilities]);
+    if (capabilityType === Capability.Range) {
+      // For range, disable only if all range instances are used
+      return !getAvailableRangeInstances(capabilities).length;
+    }
 
-  const handleColorModelInstanceChange = useCallback((
-    value: ColorModel,
-    key: number,
-  ) => {
-    const newParameters = defaultColorModelParameters[value];
+    if (capabilityType === Capability.Toggle) {
+      // For toggle, disable only if all toggle instances are used
+      return !getAvailableToggleInstances(capabilities).length;
+    }
 
-    const updatedCapabilities = capabilities.map((item, i) => i === key
-      ? { ...item, parameters: newParameters }
-      : item);
-    onCapabilityChange(updatedCapabilities);
-  }, [capabilities]);
-
-  const handleTemperatureParameterChange = useCallback((
-    paramType: 'min' | 'max',
-    value: number,
-    key: number,
-  ) => {
-    const updatedCapabilities = capabilities.map((item, i) => i === key
-      ? {
-        ...item,
-        parameters: {
-          ...item.parameters,
-          temperature_k: {
-            ...item.parameters.temperature_k,
-            [paramType]: value,
-          },
-        },
-      }
-      : item);
-    onCapabilityChange(updatedCapabilities);
-  }, [capabilities]);
-
-  const handleColorScenesChange = useCallback((
-    scenes: string,
-    key: number,
-  ) => {
-    const sceneList = scenes.split(',').map((s) => s.trim()).filter(Boolean);
-    const updatedCapabilities = capabilities.map((item, i) => i === key
-      ? {
-        ...item,
-        parameters: {
-          ...item.parameters,
-          color_scene: {
-            ...item.parameters.color_scene,
-            scenes: sceneList,
-          },
-        },
-      }
-      : item);
-    onCapabilityChange(updatedCapabilities);
-  }, [capabilities]);
-
-  const getColorModelOptions = useMemo(() => {
-    return (currentCapability: SmartDeviceCapability, currentCapabilityIndex: number) => {
-      const availableModels = getAvailableColorModels(capabilities, currentCapabilityIndex);
-      const currentlySelectedModel = getCurrentColorModel(currentCapability);
-
-      return Object.keys(Color)
-        // TODO: <DISABLED_COLOR> This line disable Color scene, need remove for enable
-        .filter((colorKey) => colorKey !== 'ColorScene')
-        .map((colorKey) => {
-          const modelValue = Color[colorKey];
-          const isCurrentlySelected = currentlySelectedModel === modelValue;
-          const isAvailableForUse = availableModels.includes(modelValue);
-
-          return {
-            label: getColorModelLabel(colorKey, t),
-            value: modelValue,
-            isDisabled: !isCurrentlySelected && !isAvailableForUse,
-          };
-        });
-    };
-  }, [capabilities]);
-
-  const getRangeInstanceOptions = useCallback((
-    currentCapability: SmartDeviceCapability,
-    currentCapabilityIndex: number,
-  ) => {
-    const availableInstances = getAvailableRangeInstances(capabilities, currentCapabilityIndex);
-    const currentlySelectedInstance = currentCapability.parameters?.instance;
-
-    return ranges.map((rangeInstance) => {
-      const isCurrentlySelected = currentlySelectedInstance === rangeInstance;
-      const isAvailableForUse = availableInstances.includes(rangeInstance);
-
-      return {
-        label: rangeInstance,
-        value: rangeInstance,
-        isDisabled: !isCurrentlySelected && !isAvailableForUse,
-      };
-    });
-  }, [capabilities]);
-
-  const getToggleInstanceOptions = useCallback((
-    currentCapability: SmartDeviceCapability,
-    currentCapabilityIndex: number,
-  ) => {
-    const availableInstances = getAvailableToggleInstances(capabilities, currentCapabilityIndex);
-    const currentlySelectedInstance = currentCapability.parameters?.instance;
-
-    return toggles.map((toggleInstance) => {
-      const isCurrentlySelected = currentlySelectedInstance === toggleInstance;
-      const isAvailableForUse = availableInstances.includes(toggleInstance);
-
-      return {
-        label: toggleInstance,
-        value: toggleInstance,
-        isDisabled: !isCurrentlySelected && !isAvailableForUse,
-      };
-    });
-  }, [capabilities]);
+    // For other capabilities, use existing logic
+    return capabilities.find((item) => item.type === capabilityType);
+  };
 
   const getAvailableCapabilities = () => {
     return Object.values(Capability).filter((capType) => {
@@ -334,291 +129,76 @@ export const DeviceCapabilities = observer(({
     )));
   };
 
+  const renderCapabilityFields = (capability: SmartDeviceCapability, key: number) => {
+    const subProps = { capability, index: key, capabilities, onCapabilityChange };
+    switch (capability.type) {
+      case Capability['On/Off']: return <OnOffCapability />;
+      case Capability['Color setting']: return <ColorSettingCapability {...subProps} />;
+      // TODO: <DISABLED_MODE> - need uncomment for Mode activation in WEBUI
+      // case Capability.Mode: return <ModeCapability {...subProps} />;
+      case Capability.Range: return <RangeCapability {...subProps} />;
+      case Capability.Toggle: return <ToggleCapability {...subProps} />;
+      default: return null;
+    }
+  };
+
+  const renderCapabilityRow = (capability: SmartDeviceCapability, key: number) => (
+    <Fragment key={key}>
+      <div>
+        <div className="aliceDeviceSkills-gridLabel aliceDeviceSkills-gridHiddenLabel">
+          {t('alice.labels.capability')}
+        </div>
+        <Dropdown
+          value={capability.type}
+          options={Object.keys(Capability).map((cap) => ({
+            label: cap,
+            value: Capability[cap],
+            isDisabled: isCapabilityDisabled(Capability[cap], capabilities),
+          }))}
+          onChange={(option: Option<Capability>) => onCapabilityTypeChange(option.value, key)}
+        />
+      </div>
+      <div>
+        <div className="aliceDeviceSkills-gridLabel aliceDeviceSkills-gridHiddenLabel">
+          {t('alice.labels.topic')}
+        </div>
+        <Dropdown
+          className="aliceDeviceSkills-dropdown"
+          value={capability.mqtt}
+          placeholder={devicesStore.topics.flatMap((g) => g.options)
+            .find((o) => o.value === capability.mqtt)?.label}
+          options={devicesStore.topics as any[]}
+          isSearchable
+          onChange={({ value }: Option<string>) => {
+            onCapabilityChange(capabilities.map((item, i) => (
+              i === key ? { ...item, mqtt: value } : item
+            )));
+          }}
+        />
+      </div>
+
+      {renderCapabilityFields(capability, key)}
+
+      <div className="aliceDeviceSkills-deleteButton">
+        <Button
+          size="small"
+          type="button"
+          icon={<TrashIcon />}
+          variant="secondary"
+          isOutlined
+          onClick={() => onCapabilityChange(capabilities.filter((_item, i) => i !== key))}
+        />
+      </div>
+    </Fragment>
+  );
+
   return (
     <>
       <h6>{t('alice.labels.device-capabilities')}</h6>
       <div className="aliceDeviceSkills">
         <p>{t('alice.labels.device-capabilities-description')}</p>
         <div className="aliceDeviceSkills-grid">
-          {capabilities.map((capability, key) => (
-            <Fragment key={key}>
-              <div>
-                <div className="aliceDeviceSkills-gridLabel aliceDeviceSkills-gridHiddenLabel">
-                  {t('alice.labels.capability')}
-                </div>
-                <Dropdown
-                  value={capability.type}
-                  options={Object.keys(Capability).map((cap) => ({
-                    label: cap,
-                    value: Capability[cap],
-                    isDisabled: isCapabilityDisabled(Capability[cap], capabilities),
-                  }))}
-                  onChange={(option: Option<Capability>) => onCapabilityTypeChange(option.value, key)}
-                />
-              </div>
-              <div>
-                <div className="aliceDeviceSkills-gridLabel aliceDeviceSkills-gridHiddenLabel">
-                  {t('alice.labels.topic')}
-                </div>
-                <Dropdown
-                  className="aliceDeviceSkills-dropdown"
-                  value={capability.mqtt}
-                  placeholder={devicesStore.topics.flatMap((g) => g.options)
-                    .find((o) => o.value === capability.mqtt)?.label}
-                  options={devicesStore.topics as any[]}
-                  isSearchable
-                  onChange={({ value }: Option<string>) => {
-                    onCapabilityChange(capabilities.map((item, i) => (
-                      i === key ? { ...item, mqtt: value } : item
-                    )));
-                  }}
-                />
-              </div>
-
-              {capability.type === Capability['On/Off'] && (
-                <div className="aliceDeviceSkills-colspan2"></div>
-              )}
-
-              {capability.type === Capability['Color setting'] && (
-                <>
-                  <div>
-                    <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.type')}</div>
-                    <Dropdown
-                      value={getCurrentColorModel(capability)}
-                      options={getColorModelOptions(capability, key)}
-                      onChange={({ value }: Option<Color>) => {
-                        handleColorSettingTypeChange(value, key);
-                      }}
-                    />
-                  </div>
-
-                  {getCurrentColorModel(capability) === Color.ColorModel && (
-                    <div>
-                      <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.color-model')}</div>
-                      <Dropdown
-                        value={capability.parameters?.color_model ?? null}
-                        options={Object.keys(ColorModel)
-                          // TODO: <DISABLED_COLOR> This line disable Color HSV, need remove for enable
-                          .filter((m) => m !== 'HSV' || capability.parameters?.color_model === ColorModel.HSV)
-                          .map((model) => ({
-                            label: model,
-                            value: ColorModel[model as keyof typeof ColorModel],
-                          }))}
-                        onChange={({ value }: Option<ColorModel>) => {
-                          handleColorModelInstanceChange(value, key);
-                        }}
-                      />
-                    </div>
-                  )}
-
-                  {capability.parameters?.temperature_k && (
-                    <div className="aliceDeviceSkills-gridRange">
-                      <div>
-                        <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.min')}</div>
-                        <Input
-                          value={capability.parameters?.temperature_k?.min}
-                          type="number"
-                          isFullWidth
-                          onChangeEvent={(event) => {
-                            const min = event.currentTarget.valueAsNumber || 0;
-                            handleTemperatureParameterChange('min', min, key);
-                          }}
-                        />
-                      </div>
-                      <div>
-                        <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.max')}</div>
-                        <Input
-                          value={capability.parameters?.temperature_k?.max}
-                          type="number"
-                          isFullWidth
-                          onChangeEvent={(event) => {
-                            const max = event.currentTarget.valueAsNumber || 0;
-                            handleTemperatureParameterChange('max', max, key);
-                          }}
-                        />
-                      </div>
-                    </div>
-                  )}
-
-                  {getCurrentColorModel(capability) === Color.ColorScene && (
-                    <div>
-                      <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.scenes-input')}</div>
-                      <Input
-                        value={capability.parameters?.color_scene?.scenes?.join(', ') || ''}
-                        placeholder="ocean, sunset, party"
-                        isFullWidth
-                        onChange={(scenes: string) => {
-                          handleColorScenesChange(scenes, key);
-                        }}
-                      />
-                    </div>
-                  )}
-                </>
-
-              )}
-
-              {/* TODO: <DISABLED_MODE> - need uncomment for Mode activation in WEBUI */}
-              {/* {capability.type === Capability.Mode && (
-                <>
-                  <div>
-                    <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode-type')}</div>
-                    <Dropdown
-                      value={capability.parameters?.instance}
-                      options={modes.map((mode) => ({ label: mode, value: mode }))}
-                      onChange={({ value: instance }: Option<string>) => {
-                        const val = capabilities.map((item, i) => i === key
-                          ? { ...item, parameters: { ...item.parameters, instance } }
-                          : item);
-                        onCapabilityChange(val);
-                      }}
-                    />
-                  </div>
-                  <div>
-                    <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
-                    <Input
-                      value={capability.parameters?.modes}
-                      isFullWidth
-                      onChange={(modes: string) => {
-                        const val = capabilities.map((item, i) => i === key
-                          ? { ...item, parameters: { ...item.parameters, modes } }
-                          : item);
-                        onCapabilityChange(val);
-                      }}
-                    />
-                  </div>
-                </>
-              )} */}
-
-              {capability.type === Capability.Range && (
-                <>
-                  <div>
-                    <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
-                    <Dropdown
-                      value={capability.parameters?.instance}
-                      options={getRangeInstanceOptions(capability, key)}
-                      onChange={({ value: instance }: Option<string>) => {
-                        const unit = rangeUnitByInstance[instance];
-
-                        // If instance has a fixed range - apply it
-                        const rangeConfig = RANGE_LIMITS_LOCKED[instance] ?? RANGE_LIMITS_DEFAULT;
-                        const nextParams = {
-                          ...capability.parameters,
-                          instance,
-                          unit,
-                          range: {
-                            min: rangeConfig.min,
-                            max: rangeConfig.max,
-                            precision: rangeConfig.precision ?? capability.parameters?.range?.precision ?? 1,
-                          },
-                        };
-
-                        const val = capabilities.map((item, i) =>
-                          i === key ? { ...item, parameters: nextParams } : item,
-                        );
-                        onCapabilityChange(val);
-                      }}
-                    />
-                  </div>
-                  <div className="aliceDeviceSkills-gridRange">
-                    {(() => {
-                      const curInstance = capability.parameters?.instance as string;
-                      const fixedRange = RANGE_LIMITS_LOCKED[curInstance];
-                      const isRangeLocked = !!fixedRange;
-                      const lockedMin = fixedRange?.min ?? capability.parameters?.range?.min ?? 0;
-                      const lockedMax = fixedRange?.max ?? capability.parameters?.range?.max ?? 100;
-                      return (
-                        <>
-                          <div>
-                            <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.min')}</div>
-                            <Input
-                              value={lockedMin}
-                              type="number"
-                              isDisabled={isRangeLocked}
-                              isFullWidth
-                              onChangeEvent={(event) => {
-                                const min = event.currentTarget.valueAsNumber || 0;
-                                const val = capabilities.map((item, i) => i === key
-                                  ? {
-                                    ...item,
-                                    parameters: { ...item.parameters, range: { ...item.parameters.range, min } },
-                                  }
-                                  : item);
-                                onCapabilityChange(val);
-                              }}
-                            />
-                          </div>
-                          <div>
-                            <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.max')}</div>
-                            <Input
-                              value={lockedMax}
-                              type="number"
-                              isDisabled={isRangeLocked}
-                              isFullWidth
-                              onChangeEvent={(event) => {
-                                const max = event.currentTarget.valueAsNumber || 0;
-                                const val = capabilities.map((item, i) => i === key
-                                  ? {
-                                    ...item,
-                                    parameters: { ...item.parameters, range: { ...item.parameters.range, max } },
-                                  }
-                                  : item);
-                                onCapabilityChange(val);
-                              }}
-                            />
-                          </div>
-                          <div>
-                            <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.precision')}</div>
-                            <Input
-                              value={capability.parameters?.range.precision}
-                              type="number"
-                              isFullWidth
-                              onChangeEvent={(event) => {
-                                const precision = event.currentTarget.valueAsNumber || 0;
-                                const val = capabilities.map((item, i) => i === key
-                                  ? {
-                                    ...item,
-                                    parameters: { ...item.parameters, range: { ...item.parameters.range, precision } },
-                                  }
-                                  : item);
-                                onCapabilityChange(val);
-                              }}
-                            />
-                          </div>
-                        </>
-                      );
-                    })()}
-                  </div>
-                </>
-              )}
-
-              {capability.type === Capability.Toggle && (
-                <div className="aliceDeviceSkills-colspan2">
-                  <div className="aliceDeviceSkills-gridLabel">{t('alice.labels.mode')}</div>
-                  <Dropdown
-                    value={capability.parameters?.instance}
-                    options={getToggleInstanceOptions(capability, key)}
-                    onChange={({ value: instance }: Option<string>) => {
-                      const val = capabilities.map((item, i) => i === key
-                        ? { ...item, parameters: { ...item.parameters, instance } }
-                        : item);
-                      onCapabilityChange(val);
-                    }}
-                  />
-                </div>
-              )}
-
-              <div className="aliceDeviceSkills-deleteButton">
-                <Button
-                  size="small"
-                  type="button"
-                  icon={<TrashIcon />}
-                  variant="secondary"
-                  isOutlined
-                  onClick={() => onCapabilityChange(capabilities.filter((_item, i) => i !== key))}
-                />
-              </div>
-            </Fragment>
-          ))}
+          {capabilities.map(renderCapabilityRow)}
         </div>
 
         <Button

--- a/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/types.ts
+++ b/frontend/src/pages/integrations/alice/components/smart-device/components/device-skills/types.ts
@@ -20,3 +20,10 @@ export interface DevicePropertiesProps {
   devicesStore: DevicesStore;
   onPropertyChange: (properties: any[]) => void;
 }
+
+export interface CapabilitySubProps {
+  capability: SmartDeviceCapability;
+  index: number;
+  capabilities: SmartDeviceCapability[];
+  onCapabilityChange: (capabilities: SmartDeviceCapability[]) => void;
+}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В прошлом PR коллеги попросили сделать не большой рефакторинг упростив чтение основного файла
https://github.com/wirenboard/homeui/pull/1082

В этом PR учел пожелания:
1) Отрефакторен код - разбиением одного большого файла на несколько мелких по умениям
В главном файле было 624 строк - стало 204
2) Добавлена строка *.tsx text=auto eol=lf в файл атрибутов чтобы не получать на винде такие сообщения о конвертации окончаний строк туда сюда.

<img width="550" height="106" alt="image" src="https://github.com/user-attachments/assets/25cfaa6e-c08a-4845-8a28-27dd43e3ac26" />

3) В процессе текущего PR еще сделал что дропдауны умений имеют надписи сверху не див а лейбл и лейбл если кликнуть то будет выделено дропдаун поле
<img width="1888" height="837" alt="image" src="https://github.com/user-attachments/assets/7b05f646-7e93-4e42-bef6-8c041a06a528" />


___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**

Локально запускал фронт


