### PR TITLE
Fix DALI scenes editor rendering

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.216.3) stable; urgency=medium
+
+  * Fix DALI device scenes settings editor scroll bug
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 01 Jun 2026 11:01:44 +0500
+
 wb-mqtt-homeui (2.216.2) stable; urgency=medium
 
   * Fix pylint

--- a/frontend/src/pages/settings/configs/dali/styles.css
+++ b/frontend/src/pages/settings/configs/dali/styles.css
@@ -42,7 +42,7 @@
 .dali-deviceToolbar {
     position: sticky;
     top: -12px;
-    z-index: 1;
+    z-index: 101;
     margin: -12px -12px 0;
     padding: 12px;
     background: var(--background-accent-color-hover);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Было так

<img width="2950" height="659" alt="Screenshot_20260601_110130" src="https://github.com/user-attachments/assets/eddcb5c8-c594-49b9-8f08-7775c037bbc6" />


Стало
<img width="2907" height="701" alt="Screenshot_20260601_110457" src="https://github.com/user-attachments/assets/27e4ed41-e671-40f3-8002-9bb04616445c" />


___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


