### PR TITLE
Hide dropdown arrow for readonly fields on DALI page

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.216.3) stable; urgency=medium
+
+  * Hide dropdown arrow for readonly fields on DALI settings page
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Mon, 01 Jun 2026 12:00:00 +0500
+
 wb-mqtt-homeui (2.216.2) stable; urgency=medium
 
   * Fix pylint

--- a/frontend/src/pages/settings/configs/dali/styles.css
+++ b/frontend/src/pages/settings/configs/dali/styles.css
@@ -52,3 +52,7 @@
 .dali-resetWarning {
     margin-top: 12px;
 }
+
+.dali .dropdown__control--is-disabled .dropdown__indicator {
+    display: none;
+}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Убрал треугольник выпадающего списка, если элемент недоступен для редактирования.
Пользователи тупили

<img width="2751" height="146" alt="Screenshot_20260601_152700" src="https://github.com/user-attachments/assets/c1425a3a-8d26-4963-b141-12cfc37d9e3e" />


___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


