### PR TITLE
Require nodejs>=22

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.218.1) stable; urgency=medium
+
+  * Require nodejs>=22
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 03 Jun 2026 18:30:00 +0400
+
 wb-mqtt-homeui (2.218.0) stable; urgency=medium
 
   * Port for Debian 13

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Priority: optional
 Standards-Version: 4.5.1
 X-Python3-Version: >= 3.9
 Build-Depends: debhelper-compat (= 13),
-               nodejs (>= 18),
+               nodejs (>= 22),
                j2cli,
                minify,
                rsync,


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
использовать более свежий nodejs из dev-tools репы вместо из дебиана, в нем npm включен в nodejs пакет, в дебиане это отдельный пакет. В булзае подтягивался nodejs из dev-tools так как в апстриме был более старый чем 18.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


