### PR TITLE
Fix DALI colour temperature slider

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.225.6) stable; urgency=medium
+
+  * Fix DALI colour temperature slider to follow the device's current Coolest/Warmest limits live.
+    The slider steps in 100 K.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 15 Jun 2026 20:19:10 +0500
+
 wb-mqtt-homeui (2.225.5) stable; urgency=medium
 
   * Fix rule prevent leave on save

--- a/frontend/src/components/json-schema-editor/dali-color-temperature-slider-param-editor.tsx
+++ b/frontend/src/components/json-schema-editor/dali-color-temperature-slider-param-editor.tsx
@@ -1,44 +1,129 @@
 import classNames from 'classnames';
 import { observer } from 'mobx-react-lite';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/input';
 import { Range } from '@/components/range';
 import { Switch } from '@/components/switch';
-import { DALI_TC_MASK_VALUE } from '@/utils/dali-color-temperature';
+import { NumberStore, type ObjectStore, type PropertyStore } from '@/stores/json-schema-editor';
+import {
+  DALI_TC_MASK_VALUE,
+  TC_SLIDER_STEP_K,
+  UI_MAX_TC_MIREK,
+  UI_MIN_TC_MIREK,
+  kelvinToMirek,
+  mirekToKelvin,
+  snapKelvinTo100,
+} from '@/utils/dali-color-temperature';
 import type { DaliColorTemperatureSliderEditorProps } from './types';
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(Math.max(v, lo), hi);
+
+const usableMirek = (value: unknown): number | undefined =>
+  typeof value === 'number' && value !== DALI_TC_MASK_VALUE ? value : undefined;
+
+// Resolve a dotted path (e.g. 'tc_limits.tc_coolest') to a limit mirek, or undefined.
+const resolveLimitMirek = (rootStore: PropertyStore | undefined, path?: string): number | undefined => {
+  if (!path || !rootStore) {
+    return undefined;
+  }
+  let store: PropertyStore | undefined = rootStore;
+  for (const key of path.split('.')) {
+    if (store?.storeType !== 'object') {
+      return undefined;
+    }
+    store = (store as ObjectStore).getParamByKey(key)?.store;
+  }
+  return usableMirek(store instanceof NumberStore ? store.value : undefined);
+};
+
+// Bounds (mirek): live limit → static bound → UI range; ordered to never invert.
+const tcSliderBounds = (store: NumberStore, rootStore?: PropertyStore) => {
+  const dali = store.schema.options?.wb?.dali_tc;
+  const min = resolveLimitMirek(rootStore, dali?.min_limit)
+    ?? (typeof dali?.minimum === 'number' ? dali.minimum : undefined)
+    ?? UI_MIN_TC_MIREK;
+  const max = resolveLimitMirek(rootStore, dali?.max_limit)
+    ?? (typeof dali?.maximum === 'number' ? dali.maximum : undefined)
+    ?? UI_MAX_TC_MIREK;
+  return { min: Math.min(min, max), max: Math.max(min, max) };
+};
+
+// Kelvin grid bounds, rounded *outward* so any value's nearest-100 snap stays in
+// range (thumb and field agree); out-of-range is still clamped on commit.
+const kelvinSliderBounds = (minMirek: number, maxMirek: number) => {
+  const warmK = mirekToKelvin(maxMirek);
+  const coolK = mirekToKelvin(minMirek);
+  const kMin = Math.floor(warmK / TC_SLIDER_STEP_K) * TC_SLIDER_STEP_K;
+  const kMax = Math.ceil(coolK / TC_SLIDER_STEP_K) * TC_SLIDER_STEP_K;
+  return { kMin, kMax };
+};
 
 export const DaliColorTemperatureSliderEditor = observer(({
   store,
   inputId,
+  rootStore,
 }: DaliColorTemperatureSliderEditorProps) => {
   const { t } = useTranslation();
   const value = typeof store.value === 'number' ? store.value : 0;
-  const minValue = store.schema.options?.wb?.dali_tc?.minimum ?? 1;
-  const maxValue = store.schema.options?.wb?.dali_tc?.maximum ?? (DALI_TC_MASK_VALUE - 1);
+  const { min: minMirek, max: maxMirek } = tcSliderBounds(store, rootStore);
+  const { kMin, kMax } = kelvinSliderBounds(minMirek, maxMirek);
+  // Reflect the track (kSpan − K) so the cool end (high K) stays on the left.
+  const kSpan = kMin + kMax;
+  const displayKelvin = clamp(snapKelvinTo100(mirekToKelvin(value)), kMin, kMax);
+  const sliderPos = kSpan - displayKelvin;
+  // Live drag readout; null = not dragging (field shows editString).
+  const [dragKelvin, setDragKelvin] = useState<number | null>(null);
   const isMasked = value === DALI_TC_MASK_VALUE;
   const isDisabled = !!store.schema.options?.wb?.read_only;
   const hasErrors = !isMasked && store.hasErrors;
 
-  const onSwitchChange = useCallback((enabled: boolean) => {
-    store.setValue(enabled ? maxValue : DALI_TC_MASK_VALUE);
-  }, [maxValue]);
+  // Re-clamp when limits narrow; skip the first run so loading doesn't dirty the form.
+  const prevBounds = useRef<{ min: number; max: number } | null>(null);
+  useEffect(() => {
+    const isInitial = prevBounds.current === null;
+    prevBounds.current = { min: minMirek, max: maxMirek };
+    if (isInitial || typeof store.value !== 'number' || store.value === DALI_TC_MASK_VALUE) {
+      return;
+    }
+    const clamped = clamp(store.value, minMirek, maxMirek);
+    if (clamped !== store.value) {
+      store.setValue(clamped);
+    }
+  }, [minMirek, maxMirek, store]);
 
-  const onSliderChange = useCallback((val: number) => {
-    store.setValue(val);
-  }, []);
+  const onSwitchChange = useCallback((enabled: boolean) => {
+    store.setValue(enabled ? maxMirek : DALI_TC_MASK_VALUE);
+  }, [maxMirek, store]);
+
+  const onSliderLive = useCallback((pos: number) => {
+    const mirek = clamp(kelvinToMirek(kMin + kMax - pos), minMirek, maxMirek);
+    setDragKelvin(snapKelvinTo100(mirekToKelvin(mirek)));
+  }, [kMin, kMax, minMirek, maxMirek]);
+
+  const onSliderChange = useCallback((pos: number) => {
+    const kelvin = kMin + kMax - pos;
+    if (String(kelvin) !== store.editString) {
+      store.setValue(clamp(kelvinToMirek(kelvin), minMirek, maxMirek));
+    }
+    setDragKelvin(null);
+  }, [kMin, kMax, minMirek, maxMirek, store]);
 
   const onKelvinChange = useCallback((val: string | number) => {
     store.setEditString(String(val));
-  }, []);
+  }, [store]);
 
   const onKelvinCommit = useCallback(() => {
-    if (store.hasErrors || typeof store.value !== 'number') {
+    if (typeof store.value !== 'number') {
       return;
     }
-    // Re-derive editString from canonical K — gives the "snap" (4500 → 4505).
-    store.setValue(store.value);
-  }, []);
+    // Snap the typed K to the grid (4530 → 4500). Skip if the field already shows it,
+    // so focus+blur can't drift the mirek and dirty the form.
+    const snappedK = clamp(snapKelvinTo100(mirekToKelvin(store.value)), kMin, kMax);
+    if (String(snappedK) !== store.editString) {
+      store.setValue(clamp(kelvinToMirek(snappedK), minMirek, maxMirek));
+    }
+  }, [kMin, kMax, minMirek, maxMirek, store]);
 
   return (
     <div className="dali-color-temperature-slider">
@@ -57,20 +142,21 @@ export const DaliColorTemperatureSliderEditor = observer(({
         <>
           <Range
             id={inputId ?? ''}
-            value={value}
-            min={minValue}
-            max={maxValue}
-            step={1}
+            value={sliderPos}
+            min={kMin}
+            max={kMax}
+            step={TC_SLIDER_STEP_K}
             isDisabled={isDisabled}
             isInvalid={hasErrors}
             labelPosition="none"
             onChange={onSliderChange}
+            onLiveChange={onSliderLive}
           />
           <Input
             className={classNames('dali-color-temperature-slider-input', {
               'wb-jsonEditor-propertyInputError': hasErrors,
             })}
-            value={store.editString}
+            value={dragKelvin !== null ? String(dragKelvin) : store.editString}
             isDisabled={isDisabled}
             ariaLabel="Kelvin"
             ariaInvalid={hasErrors}

--- a/frontend/src/components/json-schema-editor/json-schema-editor.tsx
+++ b/frontend/src/components/json-schema-editor/json-schema-editor.tsx
@@ -129,6 +129,7 @@ const DefaultEditorBuilder = (props: EditorBuilderFunctionProps) => {
         <Suspense>
           <DaliColorTemperatureSliderEditor
             store={props.store as NumberStore}
+            rootStore={props.rootStore}
             inputId={props.inputId}
           />
         </Suspense>

--- a/frontend/src/components/json-schema-editor/types.ts
+++ b/frontend/src/components/json-schema-editor/types.ts
@@ -59,6 +59,7 @@ export interface DaliLevelSliderEditorProps {
 
 export interface DaliColorTemperatureSliderEditorProps {
   store: NumberStore;
+  rootStore?: PropertyStore;
   inputId?: string;
 }
 

--- a/frontend/src/components/range/range.tsx
+++ b/frontend/src/components/range/range.tsx
@@ -4,7 +4,7 @@ import { type RangeProps } from './types';
 import './styles.css';
 
 export const Range = ({
-  value, id, isDisabled, min, max, step, units, formatLabel, isInvalid, onChange, ariaLabel,
+  value, id, isDisabled, min, max, step, units, formatLabel, isInvalid, onChange, onLiveChange, ariaLabel,
   labelPosition = 'bottom',
 }: RangeProps) => {
   const [proxyValue, setProxyValue] = useState(0);
@@ -65,7 +65,9 @@ export const Range = ({
         aria-label={ariaLabel}
         onKeyUp={() => onChange(proxyValue)}
         onInput={(ev: InputEvent<HTMLInputElement>) => {
-          setProxyValue(ev.currentTarget.valueAsNumber);
+          const next = ev.currentTarget.valueAsNumber;
+          setProxyValue(next);
+          onLiveChange?.(next);
         }}
         onTouchEnd={() => {
           input.current.focus();

--- a/frontend/src/components/range/types.ts
+++ b/frontend/src/components/range/types.ts
@@ -13,4 +13,8 @@ export interface RangeProps {
   ariaLabel?: string;
   labelPosition?: RangeLabelPosition;
   onChange: (_val: number) => void;
+  // Fires continuously while the thumb is being dragged (on every `input` event),
+  // unlike `onChange` which only fires on release. Use it for live readouts that
+  // should track the thumb without committing the value on every pixel.
+  onLiveChange?: (_val: number) => void;
 }

--- a/frontend/src/stores/json-schema-editor/json-schema-loader.ts
+++ b/frontend/src/stores/json-schema-editor/json-schema-loader.ts
@@ -152,6 +152,14 @@ const sanitizeOptions = (source: JsonEditorOptions, dest: JsonEditorOptions) => 
       dest.wb.dali_tc = dest.wb.dali_tc || {};
       dest.wb.dali_tc.mode = source.wb.dali_tc.mode;
     }
+    if (typeof source.wb.dali_tc?.min_limit === 'string') {
+      dest.wb.dali_tc = dest.wb.dali_tc || {};
+      dest.wb.dali_tc.min_limit = source.wb.dali_tc.min_limit;
+    }
+    if (typeof source.wb.dali_tc?.max_limit === 'string') {
+      dest.wb.dali_tc = dest.wb.dali_tc || {};
+      dest.wb.dali_tc.max_limit = source.wb.dali_tc.max_limit;
+    }
   }
   if (Array.isArray(source.enum_titles)) {
     dest.enum_titles = source.enum_titles;

--- a/frontend/src/stores/json-schema-editor/types.ts
+++ b/frontend/src/stores/json-schema-editor/types.ts
@@ -9,6 +9,13 @@ export interface WbDaliTcEditorOptions {
   minimum?: number;
   maximum?: number;
 
+  // Dotted paths (from the device root store) to the parameters that bound this
+  // slider live, e.g. 'tc_limits.tc_coolest'. When set and resolving to a usable
+  // value, that value overrides the static minimum/maximum; otherwise the static
+  // bound is used.
+  min_limit?: string;
+  max_limit?: string;
+
   // Affects MASK label.
   // In 'value' mode, MASK means "do not change", in 'limit' mode, MASK means "no limit"
   // Default is 'value'

--- a/frontend/src/utils/dali-color-temperature.ts
+++ b/frontend/src/utils/dali-color-temperature.ts
@@ -10,19 +10,19 @@ const reciprocalMillion = (n: number): number => (n <= 0 ? 0 : Math.round(1_000_
 export const mirekToKelvin = reciprocalMillion;
 export const kelvinToMirek = reciprocalMillion;
 
-// Default to 10 K granularity, but the mirek that lies closest to each
-// multiple of 100 is promoted to show that 100-multiple exactly. This keeps
-// every multiple of 100 in [1000, 10000] reachable while letting every other
-// slider position keep its natural 10 K rounding.
-const roundKelvinForDisplay = (k: number): number => {
-  if (k < 1000) return k;
-  const hundred = Math.round(k / 100) * 100;
-  if (kelvinToMirek(hundred) === kelvinToMirek(k)) return hundred;
-  return Math.round(k / 10) * 10;
-};
+// Fallback colour-temperature span when a device has no usable physical limit.
+export const UI_MIN_TC_K = 1000;
+export const UI_MAX_TC_K = 10000;
+export const UI_MIN_TC_MIREK = kelvinToMirek(UI_MAX_TC_K);
+export const UI_MAX_TC_MIREK = kelvinToMirek(UI_MIN_TC_K);
+
+// 100 K grid — the finest step where every position round-trips to a distinct mirek
+export const TC_SLIDER_STEP_K = 100;
+export const snapKelvinTo100 = (k: number): number =>
+  Math.round(k / TC_SLIDER_STEP_K) * TC_SLIDER_STEP_K;
 
 export const formatKelvinEditString = (mirek: number): string =>
-  mirek === DALI_TC_MASK_VALUE ? '' : String(roundKelvinForDisplay(mirekToKelvin(mirek)));
+  mirek === DALI_TC_MASK_VALUE ? '' : String(snapKelvinTo100(mirekToKelvin(mirek)));
 
 // Validates a user-entered K text against [minMirek, maxMirek] mirek bounds.
 // Validation happens in mirek-space so the device-side range is respected even
@@ -42,8 +42,8 @@ export const validateKelvinEditString = (
     return {
       key: 'json-editor.errors.minmax',
       data: {
-        min: roundKelvinForDisplay(mirekToKelvin(maxMirek)),
-        max: roundKelvinForDisplay(mirekToKelvin(minMirek)),
+        min: snapKelvinTo100(mirekToKelvin(maxMirek)),
+        max: snapKelvinTo100(mirekToKelvin(minMirek)),
       },
     };
   }


### PR DESCRIPTION
The slider follow the device's current Coolest/Warmest limits live. The slider steps in 100 K.

___________________________________
**Что происходит; кому и зачем нужно:**
Редакторы настроек цыетовой температуры теперь смотрят в текущие щначения границ цветовой температуры и учитывают их.
Ещё они стали монотонно линейными с шагом в 100К.

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


