### PR TITLE
Fix displaying read errors for alarm controls

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.227.1) stable; urgency=medium
+
+  * Fix displaying read errors for alarm controls 
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 18 Jun 2026 17:10:10 +0500
+
 wb-mqtt-homeui (2.227.0) stable; urgency=medium
 
   * Add tests

--- a/frontend/src/components/alert/alert.tsx
+++ b/frontend/src/components/alert/alert.tsx
@@ -25,8 +25,10 @@ export const Alert = ({
       case 'warn':
         Component = WarnIcon;
         break;
-      case 'info':
       case 'gray':
+        Component = WarnIcon;
+        break;
+      case 'info':
       default:
         Component = InfoIcon;
     }

--- a/frontend/src/components/alert/styles.css
+++ b/frontend/src/components/alert/styles.css
@@ -45,7 +45,6 @@
 
 .alertMessage-gray {
     background: var(--light-gray-color);
-    color: var(--gray-color);
 }
 
 .alertMessage-success {

--- a/frontend/src/components/alert/styles.css
+++ b/frontend/src/components/alert/styles.css
@@ -45,7 +45,7 @@
 
 .alertMessage-gray {
     background: var(--light-gray-color);
-    border: 1px solid var(--gray-color);
+    color: var(--gray-color);
 }
 
 .alertMessage-success {

--- a/frontend/src/components/cell/cell-alert.tsx
+++ b/frontend/src/components/cell/cell-alert.tsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react-lite';
 import { useTranslation } from 'react-i18next';
 import { Alert } from '@/components/alert';
 import { Tooltip } from '@/components/tooltip';
+import { CellError } from '@/stores/devices/cell-type';
 import { copyToClipboard } from '@/utils/clipboard';
 import { CellHistory } from './cell-history';
 import { type CellAlertProps } from './types';
@@ -9,6 +10,10 @@ import './styles.css';
 
 export const CellAlert = observer(({ cell, name, hideHistory }: CellAlertProps) => {
   const { t } = useTranslation();
+
+  const variant = cell.error?.includes(CellError.Read)
+    ? 'gray'
+    : cell.value ? 'danger' : 'success';
 
   return (
     <>
@@ -19,7 +24,7 @@ export const CellAlert = observer(({ cell, name, hideHistory }: CellAlertProps) 
       >
         <Alert
           size="small"
-          variant={cell.value ? 'danger' : 'info'}
+          variant={variant}
           className="deviceCell-alert"
           onClick={() => copyToClipboard(cell.id)}
         >


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Поправил цвета. Если есть ошибка чтения, alarm теперь серый и с восклицательным знаком

<img width="1675" height="214" alt="Screenshot_20260618_172035" src="https://github.com/user-attachments/assets/6245d9f4-5af2-4452-af03-828f086112d4" />


___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


