### PR TITLE
DALI: keep renamed device names on page load

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.235.2) stable; urgency=medium
+
+  * DALI: keep renamed device names on page load instead of overwriting them with a retained scan result
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 26 Jun 2026 12:00:00 +0500
+
 wb-mqtt-homeui (2.235.1) stable; urgency=medium
 
   * Fix the rule's opening with slashes

--- a/frontend/src/stores/dali/bus-store.test.ts
+++ b/frontend/src/stores/dali/bus-store.test.ts
@@ -351,12 +351,14 @@ describe('BusStore', () => {
       expect(store.scanStopRequested).toBe(false);
     });
 
-    test('rebuilds children on completed', async () => {
+    test('rebuilds children on completed when a scan was active', async () => {
       daliProxyMock.GetBus.mockResolvedValue({
         config: {},
         schema: {},
         name: 'Bus 1',
       });
+      // simulate an in-flight scan so completion is treated as a fresh scan result
+      store.scanStartRequested = true;
 
       await store.applyCommissioningState({
         status: 'completed',
@@ -374,6 +376,31 @@ describe('BusStore', () => {
         .filter((c) => c.type === ItemType.Device)
         .map((c) => c.id);
       expect(deviceIds).toEqual(['dev1', 'dev2']);
+    });
+
+    test('does not rebuild children from a retained completed state on load (no active scan)', async () => {
+      // children already loaded from GetList with the up-to-date (renamed) name
+      const persisted = new DeviceStore('dev1', 'Renamed', [], store);
+      store.children = [persisted];
+
+      // retained commissioning message replayed on (re)subscribe carries the stale
+      // scan-time name; no scan is running in this session
+      await store.applyCommissioningState({
+        status: 'completed',
+        progress: 100,
+        error: null,
+        device_count: 1,
+        devices: [{ id: 'dev1', name: 'Old scan name', groups: [] }],
+        finished_at: '2026-01-01',
+      });
+
+      // children are not rebuilt, so the renamed label survives...
+      const devices = store.children.filter((c) => c.type === ItemType.Device);
+      expect(devices).toHaveLength(1);
+      expect(devices[0]).toBe(persisted);
+      expect(devices[0].label).toBe('Renamed');
+      // ...but the commissioning state itself is still updated
+      expect(store.commissioningState.status).toBe('completed');
     });
   });
 

--- a/frontend/src/stores/dali/bus-store.ts
+++ b/frontend/src/stores/dali/bus-store.ts
@@ -241,10 +241,15 @@ export class BusStore extends BaseItemStore {
   }
 
   async applyCommissioningState(newState: CommissioningState) {
+    // A retained "completed" message is redelivered on every (re)subscribe at page
+    // load. Rebuilding children from it would clobber the authoritative, possibly
+    // renamed device list from GetList with the scan-time snapshot. Only rebuild
+    // when a scan was actually running in this session.
+    const wasScanning = this.isScanning;
     this.commissioningState = newState;
     this.scanStartRequested = false;
     this.scanStopRequested = false;
-    if ('completed' === newState.status) {
+    if ('completed' === newState.status && wasScanning) {
       this.children = newState.devices.map((device: { id: string; name: string; groups: number[] }) =>
         new DeviceStore(device.id, device.name, device.groups, this),
       );


### PR DESCRIPTION
## Problem

When a DALI bus is (re)subscribed at page load, the broker redelivers the retained `completed` commissioning message. `applyCommissioningState` rebuilt the bus children from that message's `devices` array — overwriting the authoritative device list loaded via `GetList`, including any names the user had since renamed. The scan-time snapshot would clobber the up-to-date labels.

## Fix

Only rebuild children from a `completed` state when a scan was actually running in this session (`isScanning`). A retained completion replayed on load no longer touches the existing children, so renamed labels survive. The commissioning state itself is still updated either way.

## Tests

- Updated `rebuilds children on completed` → now simulates an in-flight scan so the existing behavior (rebuild after a real scan) is still covered.
- Added `does not rebuild children from a retained completed state on load (no active scan)` — asserts renamed labels are preserved while the commissioning state is still updated.

Verification: `vitest` (37 passed), `eslint`, and `tsc --noEmit` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)