### PR TITLE
Авторизация HomeUI для сторонних сервисов: nginx-сниппеты + лимит /auth/check → 1000 (INT-1147)

### DIFF
--- a/backend/wb/homeui_backend/main.py
+++ b/backend/wb/homeui_backend/main.py
@@ -580,7 +580,7 @@ class WebRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # pylint: disable=invalid-name
         self.process_request(
             {
-                "/auth/check": RequestHandler(fn=auth_check_handler, rate_per_minute_limit=100),
+                "/auth/check": RequestHandler(fn=auth_check_handler, rate_per_minute_limit=1000),
                 "/auth/who_am_i": RequestHandler(fn=auth_who_am_i_handler),
                 "/users": RequestHandler(fn=get_users_handler),
                 "/device/info": RequestHandler(fn=device_info_handler),

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.235.4) stable; urgency=medium
+
+  * Raise /auth/check rate limit to 1000 req/min
+
+ -- smintank <assbestmail@gmail.com>  Fri, 26 Jun 2026 18:03:34 +0200
+
 wb-mqtt-homeui (2.235.3) stable; urgency=medium
 
   * Encode special characters in rule editor URLs


### PR DESCRIPTION
Позволяет закрыть любой loopback-сервис на контроллере авторизацией HomeUI: пользователь пишет один маленький per-service nginx-файл (внешний/внутренний порт, роль, путь возврата) и подключает готовые сниппеты.

**Изменения:**

1. Лимит `/auth/check` `100 → 1000` req/min (`backend/wb/homeui_backend/main.py`) — лимит глобальный на путь; повышение убирает класс 429→500 при всплеске `auth_request`-подзапросов на открытии интерактивных сабаппов, отдельный кэш auth-check на каждый сабапп не нужен.
2. Переиспользуемые nginx-сниппеты в `/etc/nginx/snippets/` (едут через `backend/configs/`):
   - `wb-gate-tls.inc` — TLS на выделенном порту (sslip-сертификат);
   - `wb-gate-authcheck.inc` — `auth_request` к `/auth/check` (нужен `$wb_role`);
   - `wb-gate-unauth.inc` — фоллоу-ап для неавторизованных: браузер → форма логина HomeUI, остальные → 401 (нужен `$wb_return`); вынесен отдельно от check, чтобы кэширующие гейты (напр. Node-RED) несли свой check, но переиспользовали этот фоллоу-ап как есть;
   - `wb-gate-proxy.inc` — заголовки проксирования (сброс клиентских `X-WB-*`, websocket).
3. Дока `docs/wb-service-gate-howto.md` — пользовательская инструкция + контракт со стороны HomeUI.

Per-service файлы (сам gate, редирект `/open-<svc>`, пункт меню) пишет пользователь — в пакет не идут. Скрипт `wb-gate-add.sh` пока остаётся в репозитории `wb-node-red`.

**Проверка:** backend-пайплайн ✓ (pylint 10.00/10, pytest 36 passed); на контроллере A5FQ6ODF — `nginx -t` ✓ и deny-пути (XHR → 401, переход в браузере → 302 на логин) ✓; авторизованный проход — ручная проверка (HITL), pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)