### PR TITLE
fix: wb-dynamic-type reset on open INT-1062

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.236.1) stable; urgency=medium
+
+  * Fix wb-dynamic-type field resetting saved color and text on scenario reopen
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Mon, 29 Jun 2026 18:45:00 +0300
+
 wb-mqtt-homeui (2.236.0) stable; urgency=medium
 
   * Add wb-dynamic-type json-editor widget for scenario output value

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-homeui (2.236.1) stable; urgency=medium
 
   * Fix wb-dynamic-type field resetting saved color and text on scenario reopen
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Mon, 29 Jun 2026 18:45:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Mon, 29 Jun 2026 18:55:00 +0300
 
 wb-mqtt-homeui (2.236.0) stable; urgency=medium
 

--- a/frontend/src/components/json-editor/extensions/dynamic-type-editor.js
+++ b/frontend/src/components/json-editor/extensions/dynamic-type-editor.js
@@ -104,11 +104,12 @@ export function makeDynamicTypeEditor() {
     }
 
     currentType() {
+      // Before the driver resolves (watch is deferred), keep the input as text — a
+      // number input would silently drop a color/text value assigned meanwhile.
+      if (!this.driverWatchPath) return 'text';
       // Look up the driver live by path — a cached editor ref goes stale when
       // json-editor rebuilds object-level fields.
-      const driver = this.driverWatchPath
-        ? this.jsoneditor.getEditor(this.driverWatchPath)
-        : null;
+      const driver = this.jsoneditor.getEditor(this.driverWatchPath);
       const value = driver ? driver.getValue() : undefined;
       if (this.valueToType && this.valueToType[value]) return this.valueToType[value];
       return 'number';


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

При открытии сохранённого сценария значения «Установить цвет» и «Установить текст» сбрасывались на дефолт (белый цвет, пустая строка), число сохранялось — пользователь терял настроенные цвет и текст при каждом переоткрытии конфигуратора. 

Причина: драйвер (поле действия) резолвится отложенно через requestAnimationFrame, поэтому сохранённое значение присваивается раньше, чем известен тип поля. До резолва `currentType()` отдавал дефолт `number`, виджет морфил инпут в `type="number"`, а такой инпут молча отбрасывает нечисловую строку при присваивании, и значение терялось ещё до морфинга в color/text.

___________________________________
**Что поменялось для пользователей:**

Сохранённые цвет и текст теперь корректно отображаются при открытии сценария. Пока тип поля ещё не определён, инпут остаётся текстовым и удерживает любое значение, а в реальный тип (палитра/текст/число) морфится после резолва драйвера.

___________________________________
**Как проверял/а:**

Воспроизвёл на контроллере: сценарий с действиями «Установить цвет» и «Установить текст», сохранил, переоткрыл конфигуратор — до фикса поля становились белым и пустым. После фикса значения полей в DOM совпадают с сохранёнными в /etc/wb-scenarios.conf (цвет, текст и число грузятся верно). Дополнительно проверил, что переключение типа поля на лету по выбранному действию работает как прежде.

Проверил установку пакетом.
