### PR TITLE
feat: make the config editor tab list scroll on its own INT-1079

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.236.2) stable; urgency=medium
+
+  * Make the config editor tab list scroll on its own
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 30 Jun 2026 12:41:00 +0300
+
 wb-mqtt-homeui (2.236.1) stable; urgency=medium
 
   * Fix wb-dynamic-type field resetting saved color and text on scenario reopen

--- a/frontend/src/components/json-editor/json-editor.tsx
+++ b/frontend/src/components/json-editor/json-editor.tsx
@@ -1,11 +1,33 @@
 import classNames from 'classnames';
 import isEqual from 'lodash/isEqual';
 import { observer } from 'mobx-react-lite';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import i18n from '@/i18n/config';
 import { createJSONEditor } from './extensions/wb-json-editor';
 import { type JsonEditorProps } from './types';
 import './styles.css';
+
+// Cap each sticky vertical tab list to the distance from its current top to the bottom
+// of the viewport, so it scrolls on its own instead of running off-screen.
+const TAB_LIST_SELECTOR = 'ul.nav-stacked';
+const VIEWPORT_GAP = 12;
+const DESKTOP_QUERY = '(min-width: 992px)';
+
+const syncTabListMaxHeight = (root: HTMLElement | null) => {
+  if (!root) {
+    return;
+  }
+  const isDesktop = window.matchMedia(DESKTOP_QUERY).matches;
+  root.querySelectorAll<HTMLElement>(TAB_LIST_SELECTOR).forEach((list) => {
+    if (!isDesktop) {
+      list.style.maxHeight = '';
+      return;
+    }
+    const available = window.innerHeight - list.getBoundingClientRect().top - VIEWPORT_GAP;
+    // below the fold: drop the cap, let the CSS fallback hold until it scrolls into view
+    list.style.maxHeight = available > 0 ? `${available}px` : '';
+  });
+};
 
 export const JsonEditor = observer((props: JsonEditorProps) => {
   const container = useRef<HTMLDivElement>(null);
@@ -56,6 +78,31 @@ export const JsonEditor = observer((props: JsonEditorProps) => {
       }
     }
   });
+
+  useEffect(() => {
+    const root = container.current;
+    if (!root) {
+      return undefined;
+    }
+    let frame = 0;
+    const schedule = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => syncTabListMaxHeight(root));
+    };
+    schedule();
+    // capture phase to catch the inner page container scroll, not just window
+    window.addEventListener('scroll', schedule, true);
+    window.addEventListener('resize', schedule);
+    // recompute when tabs change or content resizes the layout
+    const resizeObserver = new ResizeObserver(schedule);
+    resizeObserver.observe(root);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', schedule, true);
+      window.removeEventListener('resize', schedule);
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   return <div ref={container} className={classNames('json-editor', props.className)} />;
 });

--- a/frontend/src/components/json-editor/json-editor.tsx
+++ b/frontend/src/components/json-editor/json-editor.tsx
@@ -23,7 +23,15 @@ const syncTabListMaxHeight = (root: HTMLElement | null) => {
       list.style.maxHeight = '';
       return;
     }
-    const available = window.innerHeight - list.getBoundingClientRect().top - VIEWPORT_GAP;
+    // clamp the top to the pinned position: a list scrolled above the fold has a
+    // negative rect.top, which would inflate the cap past the viewport and un-cap the list
+    const top = Math.max(list.getBoundingClientRect().top, VIEWPORT_GAP);
+    const viewportAvailable = window.innerHeight - top - VIEWPORT_GAP;
+    // keep the list roughly level with its content pane (the flex sibling) so a long list
+    // doesn't tower over a short form; still cap to the viewport for very tall forms
+    const sibling = Array.from(list.parentElement?.children ?? []).find((el) => el !== list);
+    const contentHeight = sibling ? sibling.getBoundingClientRect().height : viewportAvailable;
+    const available = Math.min(viewportAvailable, contentHeight);
     // below the fold: drop the cap, let the CSS fallback hold until it scrolls into view
     list.style.maxHeight = available > 0 ? `${available}px` : '';
   });

--- a/frontend/src/components/json-editor/styles.css
+++ b/frontend/src/components/json-editor/styles.css
@@ -184,6 +184,18 @@
   border: 1px solid var(--border-color) !important;
 }
 
+.json-editor ul.nav-tabs.nav-stacked,
+.json-editor ul.nav-pills.nav-stacked {
+  @media (min-width: 992px) {
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+    max-height: calc(100vh - 24px);
+    overflow-y: auto;
+    scrollbar-width: thin;
+  }
+}
+
 .json-editor .nav li {
   list-style: none;
   padding: 12px !important;

--- a/frontend/src/components/json-editor/styles.css
+++ b/frontend/src/components/json-editor/styles.css
@@ -158,10 +158,13 @@
 .json-editor div:has(> ul.nav-pills) {
   display: flex;
   gap: 12px;
+  /* don't stretch the content pane to the (taller) sticky tab list */
+  align-items: flex-start;
 
   @media (max-width: 991px) {
     flex-direction: column;
     gap: 0;
+    align-items: stretch;
   }
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Страницы редактора конфигов, которые рисуются вертикальными вкладками — Scenarios, MQTT History (db), IEC104, KNX и другие — при большом числе вкладок растягивают список на всю высоту. Чтобы добраться до нижних вкладок, приходится прокручивать всю страницу, и форма справа уезжает из виду. Особенно больно на сценариях и на шлюзах с десятками групп: список вкладок может вообще не помещаться на экран.

___________________________________
**Что поменялось для пользователей:**

Список вкладок теперь остаётся в пределах экрана и прокручивается сам по себе, а форма справа на месте. Высота списка подстраивается под его реальное положение на странице (над списком у разных схем разное количество полей) и не вылезает ниже формы справа — длинный список не возвышается над короткой формой и не растягивает страницу в пустоту. Если форма выше экрана, список ограничивается высотой экрана и залипает у верха при прокрутке. Работает на всех страницах редактора конфигов с вертикальными вкладками. На узких экранах (< 992px) поведение прежнее — вкладки сворачиваются в обычную колоночную раскладку.

Пример отображения до расширения:
<img width="1911" height="895" alt="image" src="https://github.com/user-attachments/assets/7b28206e-bd87-4e5e-9b70-ccb72b9d6124" />

Пример появления скролла:
<img width="1908" height="884" alt="image" src="https://github.com/user-attachments/assets/d4bf186c-0077-41d4-80f5-b61fb91c912b" />

Пример огромного списка и что скролл корректно работает по отношению к телу конфига:
<img width="1905" height="897" alt="image" src="https://github.com/user-attachments/assets/7245c71a-7ea4-4296-ab86-8856fb26e821" />

___________________________________
**Как проверял/а:**

Контроллер, ширина экрана ≥ 992px. Открывал Scenarios, MQTT History (db) и IEC104 с большим числом вкладок:
- список вкладок прокручивается своим скроллбаром, нижние вкладки доступны без прокрутки всей страницы;
- список не вылезает ниже формы справа, страница не прокручивается в пустоту под списком;
- при высокой форме список ограничивается высотой экрана и залипает у верха, виден целиком;
- на ширине < 992px вкладки штатно сворачиваются в колонку.
