### PR TITLE
fix history dropdown width

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.208.1-wb101) stable; urgency=medium
+
+  * Fix history dropdown width
+
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Wed, 01 Jul 2026 10:28:00 +0300
+
 wb-mqtt-homeui (2.208.1-wb100) stable; urgency=medium
 
   * Fix json-editor's layout overflow

--- a/frontend/src/components/dropdown/dropdown.tsx
+++ b/frontend/src/components/dropdown/dropdown.tsx
@@ -90,7 +90,7 @@ export const Dropdown = ({
   };
 
   return (
-    <div style={{ display: 'contents' }} onTouchEndCapture={(ev) => ev.stopPropagation()}>
+    <div className="dropdown-wrapper" onTouchEndCapture={(ev) => ev.stopPropagation()}>
       <Select
         ref={select}
         inputId={inputId}

--- a/frontend/src/components/dropdown/dropdown.tsx
+++ b/frontend/src/components/dropdown/dropdown.tsx
@@ -90,7 +90,7 @@ export const Dropdown = ({
   };
 
   return (
-    <div onTouchEndCapture={(ev) => ev.stopPropagation()}>
+    <div style={{ display: 'contents' }} onTouchEndCapture={(ev) => ev.stopPropagation()}>
       <Select
         ref={select}
         inputId={inputId}

--- a/frontend/src/components/dropdown/styles.css
+++ b/frontend/src/components/dropdown/styles.css
@@ -1,3 +1,7 @@
+.dropdown-wrapper {
+  display: contents;
+}
+
 .dropdown__control {
   border: 1px solid var(--input-border-color);
   background: var(--input-background);

--- a/frontend/src/pages/history/styles.css
+++ b/frontend/src/pages/history/styles.css
@@ -8,7 +8,7 @@
 .history-channel {
   width: 100%;
   max-width: 440px;
-  flex-shrink: 0;
+  flex-shrink: 1;
 }
 
 .history-addChannel {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Исправил ширину дропдауна в истории

___________________________________
**Что поменялось для пользователей:**
<img width="1587" height="563" alt="image" src="https://github.com/user-attachments/assets/4b29fcd0-0597-4f6f-b0e4-7054664517ea" />


___________________________________
**Как проверял/а:**
локально

