### PR TITLE
Show update banner when only a newer bootloader is available

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.237.1) stable; urgency=medium
+
+  * Show the firmware-update banner when only a newer bootloader is available
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Thu, 02 Jul 2026 11:25:56 +0300
+
 wb-mqtt-homeui (2.237.0) stable; urgency=medium
 
   * Serve dashboards from the HTTP backend (wb.homeui_backend) instead of confed:

--- a/frontend/src/stores/device-manager/device-tab/embedded-software/embedded-software-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/embedded-software/embedded-software-store.ts
@@ -312,7 +312,7 @@ export class EmbeddedSoftware {
   }
 
   get hasUpdate() {
-    return this.firmware.hasUpdate || this.hasComponentsUpdates;
+    return this.bootloader.hasUpdate || this.firmware.hasUpdate || this.hasComponentsUpdates;
   }
 
   get hasComponentsUpdates() {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Баннер обновления и значок-индикатор в списке устройств показывались только при наличии обновления **прошивки или компонента**. Из-за этого, если прошивка уже актуальна, а для устройства доступна более новая релизная версия загрузчика, интерфейс не показывал ничего, и обновить загрузчик из веба было нельзя.

___________________________________
**Что поменялось для пользователей:**

- Баннер «Доступна новая версия загрузчика…» (со ссылкой на Bootloader Changelog) и кнопка «Обновить» теперь появляются и когда обновление доступно **только** у загрузчика.
- Кнопка запускает обновление загрузчика; следом автоматически до-заливается релизная прошивка — это неизбежно, т.к. прошивка загрузчика перезаписывает приложение (поведение бэкенда не меняется).
- Значок доступного обновления в списке устройств тоже зажигается в этом случае.
- Изменение **только фронтовое**: бэкенд (`wb-mqtt-serial`, RPC `fw-update`) уже поддерживал автономное обновление `type: "bootloader"`, правок там не потребовалось.

___________________________________
**Как проверял/а:**

- `npm run check:types` (tsc --noEmit) — чисто; `eslint` по изменённому файлу — чисто; `npm run build` (vite) — успешно.
- `vitest`: 54 падения из 2101, но **ровно те же 54 на чистом master** (проверил через `git stash` + повторный прогон). Это pre-existing проблема окружения тестов (мок `localStorage`: `getItem/removeItem` на `undefined`, похоже на несовместимость с Node 26); ни один из падающих файлов не относится к device-manager/embedded-software.
- Визуальная проверка на контроллере.
