### PR TITLE
Fix mosquitto override config

### DIFF
--- a/backend/configs/usr/lib/systemd/system/mosquitto.service.d/20-fix-homeui-acl-perms.conf
+++ b/backend/configs/usr/lib/systemd/system/mosquitto.service.d/20-fix-homeui-acl-perms.conf
@@ -1,5 +1,5 @@
 [Service]
-ExecStartPre=/bin/chmod 0700 /usr/share/wb-mqtt-homeui/mosquitto/acl/user.conf
-ExecStartPre=/bin/chmod 0700 /usr/share/wb-mqtt-homeui/mosquitto/acl/operator.conf
-ExecStartPre=/bin/chown mosquitto:mosquitto /usr/share/wb-mqtt-homeui/mosquitto/acl/user.conf
-ExecStartPre=/bin/chown mosquitto:mosquitto /usr/share/wb-mqtt-homeui/mosquitto/acl/operator.conf
+ExecStartPre=+/bin/chmod 0700 /usr/share/wb-mqtt-homeui/mosquitto/acl/user.conf
+ExecStartPre=+/bin/chmod 0700 /usr/share/wb-mqtt-homeui/mosquitto/acl/operator.conf
+ExecStartPre=+/bin/chown mosquitto:mosquitto /usr/share/wb-mqtt-homeui/mosquitto/acl/user.conf
+ExecStartPre=+/bin/chown mosquitto:mosquitto /usr/share/wb-mqtt-homeui/mosquitto/acl/operator.conf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.237.2) stable; urgency=medium
+
+  * Fix mosquitto override config
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 03 Jul 2026 10:10:00 +0400
+
 wb-mqtt-homeui (2.237.1) stable; urgency=medium
 
   * Show the firmware-update banner when only a newer bootloader is available


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
сервис mosquitto запущен от mosquitto юзера, поэтому chmod надо делать от рута:
```sh
chmod: changing permissions of '/usr/share/wb-mqtt-homeui/mosquitto/acl/user.conf': Operation not permitted
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


