### PR TITLE
fix: keep device name and MQTT id when switching template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.237.8) stable; urgency=medium
+
+  * Keep device name and MQTT id when switching device template
+
+ -- KraPete <86825564+KraPete@users.noreply.github.com>  Tue, 07 Jul 2026 12:55:41 +0000
+
 wb-mqtt-homeui (2.237.7) stable; urgency=medium
 
   * Fix HTML in json-editor schema descriptions

--- a/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.ts
@@ -276,6 +276,16 @@ export class DeviceSettingsObjectStore {
     store?.setValue(id);
   }
 
+  // When switching to another template the params store is rebuilt from scratch, so the
+  // device identity (name, MQTT id, slave_id) must be re-applied from the previous config —
+  // otherwise these fields are reset to the new template's defaults.
+  restoreIdentity(previousConfig: JsonObject) {
+    const slaveId = previousConfig?.slave_id;
+    this.setSlaveId(slaveId === undefined || slaveId === '' ? undefined : (slaveId as string));
+    this._restoreOptionalParam('name', previousConfig?.name as string);
+    this._restoreOptionalParam('id', previousConfig?.id as string);
+  }
+
   setDefault() {
     this.commonParams.setDefault();
     this.topLevelGroup.setDefault();
@@ -303,5 +313,18 @@ export class DeviceSettingsObjectStore {
         channel.setFirmwareInDevice(fw);
       });
     });
+  }
+
+  _restoreOptionalParam(key: string, value: string | undefined) {
+    if (value === undefined) {
+      return;
+    }
+    const param = this.commonParams.getParamByKey(key);
+    if (param) {
+      // May be an opt-in param (e.g. id), disabled in a freshly built store; enable it
+      // so the restored value is kept and shown in the editor.
+      param.enable();
+      (param.store as StringStore).setValue(value);
+    }
   }
 }

--- a/frontend/src/stores/device-manager/device-tab/device-tab-store.test.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-tab-store.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import type { JsonSchema } from '@/stores/json-schema-editor';
+import type { DeviceTypesStore } from '../device-types-store';
+import { DeviceTabStore } from './device-tab-store';
+
+// Minimal top-level device schema: the common (template-independent) identity params.
+const commonParamsSchema = (): JsonSchema =>
+  ({
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      id: { type: 'string' },
+      slave_id: { type: 'string' },
+    },
+    device: {},
+  } as unknown as JsonSchema);
+
+// Non-WB device type keeps ReadRegistersState at Unsupported, so setDeviceType does not
+// try to read registers from a (non-existent) serial proxy.
+const makeDeviceTypesStore = (schema: JsonSchema): DeviceTypesStore =>
+  ({
+    isUnknown: () => false,
+    isDeprecated: () => false,
+    withSubdevices: () => false,
+    isModbusDevice: () => false,
+    isWbDevice: () => false,
+    getName: () => 'Device',
+    getDefaultId: (type: string, slaveId: string) => `${type}_${slaveId}`,
+    getSchema: async () => schema,
+  } as unknown as DeviceTypesStore);
+
+describe('DeviceTabStore.setDeviceType', () => {
+  it('keeps the user-set device name and MQTT id when switching to another template', async () => {
+    const deviceTypesStore = makeDeviceTypesStore(commonParamsSchema());
+    const tab = new DeviceTabStore(
+      { name: 'Kitchen light', id: 'kitchen_light', slave_id: '10' },
+      'wb-old-template',
+      deviceTypesStore,
+    );
+    await tab.loadContent();
+
+    await tab.setDeviceType('wb-new-template', undefined);
+
+    expect(tab.deviceType).toBe('wb-new-template');
+    expect(tab.editedData.name).toBe('Kitchen light');
+    expect(tab.mqttId).toBe('kitchen_light');
+    expect(tab.slaveId).toBe('10');
+  });
+
+  it('falls back to the new template default MQTT id when none was set by the user', async () => {
+    const deviceTypesStore = makeDeviceTypesStore(commonParamsSchema());
+    const tab = new DeviceTabStore(
+      { slave_id: '7' },
+      'wb-old-template',
+      deviceTypesStore,
+    );
+    await tab.loadContent();
+
+    await tab.setDeviceType('wb-new-template', undefined);
+
+    // No explicit id was preserved, so the id derives from the new device type.
+    expect(tab.editedData.id).toBeUndefined();
+    expect(tab.mqttId).toBe('wb-new-template_7');
+    expect(tab.slaveId).toBe('7');
+  });
+});

--- a/frontend/src/stores/device-manager/device-tab/device-tab-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-tab-store.ts
@@ -167,7 +167,7 @@ export class DeviceTabStore {
       return;
     }
     this._setLoading(i18n.t('device-manager.labels.loading-template'));
-    const oldSlaveId = this.slaveId;
+    const previousConfig = this.editedData;
     try {
       const schema = await this.deviceTypesStore.getSchema(type);
       runInAction(() => {
@@ -183,7 +183,7 @@ export class DeviceTabStore {
       return this._clearLoading();
     }
     this._initFromDeviceType(type);
-    this.schemaStore?.setSlaveId(oldSlaveId);
+    this.schemaStore?.restoreIdentity(previousConfig);
     this.readRegistersState.deviceTypeChanged(type, this.slaveId ?? '', !!(this.editedData?.enabled ?? true));
     this._clearError();
     await this._loadConfigFromDevice(portConfig);


### PR DESCRIPTION
## Проблема (SOFT-7113)

Когда для устройства предлагается перейти на более свежий шаблон (плашка «Для этого устройства доступен новый шаблон…» / кнопка «Переключить шаблон» после чтения регистров), при переключении **терялись** пользовательские настройки:

- **Имя устройства** (`name`)
- **Идентификатор устройства в MQTT** (`id`)

## Причина

`DeviceTabStore.setDeviceType()` пересобирал `DeviceSettingsObjectStore` с пустым конфигом `{}` и переносил в новый шаблон **только** `slave_id`. Поля `name` и `id` сбрасывались в дефолты нового шаблона.

## Исправление

- Перед пересборкой стора захватываю предыдущий конфиг и восстанавливаю идентичность устройства (`name`, `id`, `slave_id`) новым методом `DeviceSettingsObjectStore.restoreIdentity()`.
- Параметр `id` — opt-in и в свежесобранном сторе disabled, поэтому перед записью значения он включается (`enable()`).
- Если `id` пользователь не задавал явно — он корректно вычисляется из нового типа устройства (поведение по умолчанию сохранено).

## Тесты

Добавлен `device-tab-store.test.ts`:
- переключение шаблона сохраняет `name` / `id` / `slave_id`;
- при незаданном `id` он выводится из нового типа (`wb-new-template_7`).

## Проверка

- `npm run check:types` — чисто
- `npm run lint` — чисто (без новых warning'ов)
- `npm test` — все тесты зелёные (включая 2 новых)

🤖 Generated with [Claude Code](https://claude.com/claude-code)