### PR TITLE
Sync pre-baseline default dashboards instead of freezing them as user-edited

### DIFF
--- a/backend/tests/dashboards_test.py
+++ b/backend/tests/dashboards_test.py
@@ -636,8 +636,9 @@ class MigrationReconcileTest(DashboardsStoreFixture):
     """No-baseline-yet path: a controller upgrading from a pre-baseline version.
 
     The live /etc/wb-webui.conf already exists but no baseline-state file does, so
-    state.hashes is empty. Reconcile must adopt the default hash as the baseline without
-    duplicating or clobbering already-present dashboards.
+    state.hashes is empty. Reconcile tells an untouched (but possibly stale) default from a
+    user edit by name: same id and name -> synced silently to the current default; a
+    different name -> treated as user-modified and left alone.
     """
 
     def test_present_default_is_not_duplicated_and_unchanged(self):
@@ -654,6 +655,30 @@ class MigrationReconcileTest(DashboardsStoreFixture):
         self.assertEqual(sorted(ids), ["dashboard1", "dashboard2"])
         self.assertEqual(self.read_config(), make_config())
         self.assertEqual(set(self.read_state()["hashes"].keys()), {"dashboard1", "dashboard2"})
+
+    def test_present_default_same_name_stale_content_is_synced(self):
+        """Same id and name but stale content (default evolved before baseline existed) is synced.
+
+        This is the actual bug fix: previously the no-baseline path adopted the new default's
+        hash without ever writing it, so a pre-baseline default that fell behind a later
+        release stayed stale forever (permanently misread as user-modified on every future
+        reconcile). Matching id+name now proves it was never renamed, so it's safe to sync.
+        """
+        stale = make_config()
+        self.write_config(stale)
+        upgraded = make_config()
+        upgraded["dashboards"][0]["widgets"] = ["widget1", "widget2"]
+        upgraded["widgets"].append({"id": "widget2", "name": "W2", "cells": []})
+        self.write_board_config("wb6", upgraded)
+
+        self.store.seed_and_reconcile("wb6")
+
+        on_disk = {d["id"]: d for d in self.read_config()["dashboards"]}
+        self.assertEqual(on_disk["dashboard1"]["widgets"], ["widget1", "widget2"])
+        self.assertEqual(
+            self.read_state()["hashes"]["dashboard1"],
+            dashboard_content_hash(upgraded["dashboards"][0]),
+        )
 
     def test_user_modified_present_default_survives_two_runs(self):
         """A user edit predating the baseline is preserved across two consecutive reconciles.

--- a/backend/wb/homeui_backend/dashboards.py
+++ b/backend/wb/homeui_backend/dashboards.py
@@ -399,10 +399,17 @@ class DashboardsStore:
             live_dashboard = self._find_dashboard(live_config, dashboard_id)
 
             if dashboard_id not in state.hashes:
-                # No baseline memory: add it if absent from live; if already present (pre-baseline
-                # migration), just adopt the hash so we neither duplicate nor clobber a user edit.
+                # No baseline memory: add it if absent from live. If already present (e.g. a
+                # pre-baseline install), the id alone doesn't tell us whether it was ever edited,
+                # so also check the name: unchanged name -> still the shipped default, safe to
+                # sync silently; a renamed dashboard is treated as user-modified and left alone.
                 if live_dashboard is None:
                     live_dashboards.append(copy.deepcopy(default_dashboard))
+                    self._add_missing_widgets(board_config, live_config, default_dashboard)
+                    config_changed = True
+                elif live_dashboard.get("name") == default_dashboard.get("name"):
+                    live_dashboard.clear()
+                    live_dashboard.update(copy.deepcopy(default_dashboard))
                     self._add_missing_widgets(board_config, live_config, default_dashboard)
                     config_changed = True
                 state.hashes[dashboard_id] = default_hash

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-homeui (2.238.1) stable; urgency=medium
+
+  * Reconcile default dashboards seeded before baseline hashing existed:
+    sync unrenamed ones to the current default instead of permanently
+    treating them as user-edited
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 14 Jul 2026 11:10:00 +0500
+
 wb-mqtt-homeui (2.238.0) stable; urgency=medium
 
   * Custom menu: read drop-ins from three per-origin dirs (package


### PR DESCRIPTION
## Summary
- Controllers upgrading from a version without hash-based dashboard reconciliation (pre-`da80e7f4`) had their existing default dashboards permanently misread as user-modified: the no-baseline migration path adopted the *new* default's hash as the baseline without ever checking it against the actual on-disk content, so any drift accumulated before hashing existed got frozen forever and never received later default updates.
- Fix: in `DashboardsStore._reconcile`, the no-baseline path now also checks `name` (in addition to the `id` join key). Same id+name -> still recognizably the shipped default -> synced silently to the current default. Different name -> treated as a user edit and left untouched, exactly as before.
- Bumped `debian/changelog` to `2.238.1`.

## Test plan
- [x] `backend/`: `isort --src .. wb tests`, `black wb tests`, `pylint wb tests` (10.00/10), `pytest` — 137 passed, no existing test assertions changed
- [x] Added `MigrationReconcileTest.test_present_default_same_name_stale_content_is_synced` covering the actual bug (same id+name, stale content -> synced, baseline hash recorded correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)