### PR TITLE
Request HTTPS certificate on enable and fix stale status banner

### DIFF
--- a/backend/wb/homeui_backend/main.py
+++ b/backend/wb/homeui_backend/main.py
@@ -444,6 +444,7 @@ def update_https_handler(request: BaseHTTPRequestHandler, context: WebRequestHan
         WebRequestHandler.config.set_https_enabled(https_enabled)
         if https_enabled:
             context.certificate_thread.enable_certificate_update()
+            context.certificate_thread.request_certificate()
         else:
             context.certificate_thread.disable_certificate_update()
     return response_200()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-homeui (2.239.1) stable; urgency=medium
+
+  * Request an HTTPS certificate immediately when enabling HTTPS in
+    settings, and fix the certificate status banner getting stuck on a
+    stale status
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 14 Jul 2026 13:05:00 +0000
+
 wb-mqtt-homeui (2.239.0) stable; urgency=medium
 
   * Add themes

--- a/frontend/src/pages/settings/web-ui/components/https-settings.tsx
+++ b/frontend/src/pages/settings/web-ui/components/https-settings.tsx
@@ -86,7 +86,7 @@ const HttpsSettings = ({ onError }: HttpsSettingsProps) => {
         description={t('web-ui-settings.labels.enable-https-description')}
         onChange={setSwitchStateHandler}
       />
-      {switchState && <CertStatusBanner />}
+      {switchState && !disabled && <CertStatusBanner />}
     </FormFieldGroup>
   );
 };


### PR DESCRIPTION
## Что изменилось
- Backend: `update_https_handler` теперь вызывает `certificate_thread.request_certificate()` при включении HTTPS, в дополнение к `enable_certificate_update()` — включение HTTPS сразу инициирует запрос сертификата, а не ждёт молча до следующей 24-часовой фоновой проверки.
- Frontend: `CertStatusBanner` теперь рендерится по условию `switchState && !disabled` вместо просто `switchState` — первый опрос статуса происходит только после того, как бэкенд подтвердит включение (и, соответственно, уже начал запрос), что убирает гонку, из-за которой баннер мог навсегда зависнуть на устаревшем статусе.

## Почему
Включение тумблера "Auto configuration" (HTTPS) в настройках фактически не запрашивало сертификат — это делал только флоу авто-редиректа (`switchToHttps()` при загрузке по HTTP). Баннер статуса также мог зависнуть на неверном статусе сразу после включения, поскольку переставал опрашивать после первого (возможно устаревшего) значения.

## Как тестировалось
Проверено вживую на dev-контроллере (10.200.200.1): задеплоен патченный backend, удалён существующий `/etc/ssl/sslip.pem`, затем в Настройках → Web UI тумблер HTTPS выключен и снова включён. По `journalctl` подтверждено, что включение сразу вызвало `Certificate updated successfully` (реальный ACME-запрос), на диск записан новый сертификат, а баннер в UI прошёл путь от "Getting HTTPS certificate status..." прямо до "HTTPS certificate is valid", не зависнув на промежуточном устаревшем статусе.

Автотесты не добавлялись и не менялись (явное указание автора для этого изменения).

## Риски
Риск низкий — `request_certificate()` идемпотентен (no-op, если уже идёт запрос) и дёшев, если сертификат уже валиден (быстрая проверка без нового ACME-запроса). Тестового покрытия на это изменение поведения не добавлено (см. "Как тестировалось").

🤖 Generated with [Claude Code](https://claude.com/claude-code)