### PR TITLE
fix: correct grouping zigbee devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.240.1) stable; urgency=medium
+
+  * Fix Zigbee devices being grouped under Modbus in the devices filter
+
+ -- Victor Fedorov <victor.fedorov@wirenboard.com>  Wed, 15 Jul 2026 11:56:45 +0300
+
 wb-mqtt-homeui (2.240.0) stable; urgency=medium
 
   * Serve the main UI over TLS whenever the certificate file loads, even

--- a/frontend/src/stores/devices/device.ts
+++ b/frontend/src/stores/devices/device.ts
@@ -45,7 +45,7 @@ export default class Device {
       } else if (parsedMeta.driver === 'wb-modbus') {
         this.type = DeviceType.Modbus;
       } else if (parsedMeta.driver === 'wb-mqtt-zigbee') {
-        this.type = DeviceType.Modbus;
+        this.type = DeviceType.Zigbee;
       }
     } catch (error) {
       console.error('Invalid meta format:', error);


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Не было группироваки для Zigbee устройств

___________________________________
**Что поменялось для пользователей:**
Появился пункт с `Zigbee`, устройства фильтруются.
<img height="300" alt="image" src="https://github.com/user-attachments/assets/67880a84-f4b2-48d5-93f3-025648a5abbc" />


___________________________________
**Как проверял/а:**


