### PR TITLE
fix: floor config editor tab list height

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.242.2) stable; urgency=medium
+
+  * config editor: keep the vertical tab list readable when the form is short
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Thu, 16 Jul 2026 13:00:00 +0300
+
 wb-mqtt-homeui (2.242.1) stable; urgency=medium
 
   * json-schema-editor: add readme

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-homeui (2.242.3) stable; urgency=medium
 
   * config editor: keep the vertical tab list readable when the form is short
 
- -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Thu, 16 Jul 2026 13:00:00 +0300
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Thu, 16 Jul 2026 13:53:00 +0300
 
 wb-mqtt-homeui (2.242.2) stable; urgency=medium
 

--- a/frontend/src/components/json-editor/json-editor.tsx
+++ b/frontend/src/components/json-editor/json-editor.tsx
@@ -7,11 +7,12 @@ import { createJSONEditor } from './extensions/wb-json-editor';
 import { type JsonEditorProps } from './types';
 import './styles.css';
 
-// Cap each sticky vertical tab list to the distance from its current top to the bottom
-// of the viewport, so it scrolls on its own instead of running off-screen.
+// Cap the sticky vertical tab list so it scrolls on its own instead of running off-screen.
 const TAB_LIST_SELECTOR = 'ul.nav-stacked';
 const VIEWPORT_GAP = 12;
 const DESKTOP_QUERY = '(min-width: 992px)';
+// floor so a short form can't crush the list to a couple of rows
+const MIN_TAB_LIST_HEIGHT = 360;
 
 const syncTabListMaxHeight = (root: HTMLElement | null) => {
   if (!root) {
@@ -23,16 +24,13 @@ const syncTabListMaxHeight = (root: HTMLElement | null) => {
       list.style.maxHeight = '';
       return;
     }
-    // clamp the top to the pinned position: a list scrolled above the fold has a
-    // negative rect.top, which would inflate the cap past the viewport and un-cap the list
+    // clamp the top to the pinned position, else a list scrolled above the fold un-caps
     const top = Math.max(list.getBoundingClientRect().top, VIEWPORT_GAP);
     const viewportAvailable = window.innerHeight - top - VIEWPORT_GAP;
-    // keep the list roughly level with its content pane (the flex sibling) so a long list
-    // doesn't tower over a short form; still cap to the viewport for very tall forms
+    // follow the content pane (no towering over a short form), floored by MIN and capped by the viewport
     const sibling = Array.from(list.parentElement?.children ?? []).find((el) => el !== list);
     const contentHeight = sibling ? sibling.getBoundingClientRect().height : viewportAvailable;
-    const available = Math.min(viewportAvailable, contentHeight);
-    // below the fold: drop the cap, let the CSS fallback hold until it scrolls into view
+    const available = Math.min(viewportAvailable, Math.max(contentHeight, MIN_TAB_LIST_HEIGHT));
     list.style.maxHeight = available > 0 ? `${available}px` : '';
   });
 };


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

На странице конфигуратора «Модули расширения и порты» (wb-hardware) и на других confed-страницах с левым списком вкладок список слева схлопывался до пары строк, когда справа короткая форма (например «Тип модуля» в один выпадающий список). Листать неудобно, пожаловался пользователь на тестинге trixie. Причина в нашей прошлой правке скролла списка вкладок (INT-1079) — высота списка ограничивалась высотой правой формы, и при короткой форме список ужимался.

___________________________________
**Что поменялось для пользователей:**

Левый список вкладок больше не схлопывается под короткую форму — держит минимум ~360px (около 8 строк), а короткий список показывается целиком без пустого места под ним. Длинные списки по-прежнему скроллятся сами в пределах экрана и не убегают за него.

Пример скриншота как было:
<img width="1911" height="982" alt="2026-07-16_12-46-04" src="https://github.com/user-attachments/assets/018253b1-fdc3-49dc-981c-d9afc7a13ed4" />

Пример скриншота как стало:
<img width="1910" height="942" alt="2026-07-16_12-46-27" src="https://github.com/user-attachments/assets/bc536416-bdb9-4d3d-aa14-3a0f07dfb060" />

___________________________________
**Как проверял:**

- Собрал фронт и залил на контроллер, открыл «Модули расширения и порты» (wb-hardware) — список слотов слева больше не схлопывается, виден целиком.
- Прошёлся по нескольким confed-страницам с левым списком — короткий список виден целиком, при длинном списке и высокой форме сохраняется скролл в пределах вьюпорта, пустого места под коротким списком нет.
- Проверил через установку пакета.