### PR TITLE
Repair default dashboards poisoned by the 2.237-2.238 migration bug

### DIFF
--- a/backend/tests/dashboards_test.py
+++ b/backend/tests/dashboards_test.py
@@ -92,6 +92,11 @@ class DashboardsStoreFixture(unittest.TestCase):
         with open(self.state_path, "r", encoding="utf-8") as f:
             return json.load(f)
 
+    def write_state(self, hashes: dict) -> None:
+        os.makedirs(os.path.dirname(self.state_path), exist_ok=True)
+        with open(self.state_path, "w", encoding="utf-8") as f:
+            json.dump({"hashes": hashes}, f)
+
 
 class GetIndexTest(DashboardsStoreFixture):
     def test_index_strips_svg_current_keeps_rest(self):
@@ -591,6 +596,111 @@ class ReconciliationTest(DashboardsStoreFixture):
 
         on_disk = {d["id"]: d for d in self.read_config()["dashboards"]}
         self.assertEqual(on_disk["dashboard1"]["name"], "User edited")
+
+    def test_poisoned_baseline_is_synced_regardless_of_live_content(self):
+        """A baseline pinned to a known-poisoned hash is synced even though live content differs.
+
+        Reproduces the migration-window bug: a stale live default's hash got recorded as the
+        baseline without the content ever being synced, so reconcile read it as "user-modified"
+        forever after. The widened condition must sync it forward regardless of live content.
+        """
+        self._seed_baseline(make_config())
+        poisoned_hash = "a" * 64
+
+        state = self.read_state()
+        state["hashes"]["dashboard1"] = poisoned_hash
+        self.write_state(state["hashes"])
+
+        live = self.read_config()
+        live["dashboards"][0]["name"] = "Some arbitrary stale content"
+        self.write_config(live)
+
+        upgraded = make_config()
+        upgraded["dashboards"][0]["name"] = "New default name"
+        self.write_board_config("wb6", upgraded)
+
+        with patch.dict(
+            "wb.homeui_backend.dashboards.KNOWN_POISONED_BASELINE_HASHES",
+            {("wb6", "dashboard1"): poisoned_hash},
+            clear=True,
+        ):
+            self.store.seed_and_reconcile("wb6")
+
+        on_disk = {d["id"]: d for d in self.read_config()["dashboards"]}
+        self.assertEqual(on_disk["dashboard1"]["name"], "New default name")
+        # Baseline advanced to the new content, same as the normal sync path.
+        self.assertEqual(
+            self.read_state()["hashes"]["dashboard1"],
+            dashboard_content_hash(upgraded["dashboards"][0]),
+        )
+
+    def test_normal_baseline_with_genuine_edit_stays_protected(self):
+        """A genuine edit stays protected when the stored baseline isn't the poisoned value.
+
+        Proves the widened OR condition didn't loosen protection for the normal case.
+        """
+        self._seed_baseline(make_config())
+
+        live = self.read_config()
+        live["dashboards"][0]["name"] = "User edited"
+        self.write_config(live)
+
+        upgraded = make_config()
+        upgraded["dashboards"][0]["name"] = "New default name"
+        self.write_board_config("wb6", upgraded)
+
+        with patch.dict(
+            "wb.homeui_backend.dashboards.KNOWN_POISONED_BASELINE_HASHES",
+            {("wb6", "dashboard1"): "b" * 64},
+            clear=True,
+        ):
+            self.store.seed_and_reconcile("wb6")
+
+        on_disk = {d["id"]: d for d in self.read_config()["dashboards"]}
+        self.assertEqual(on_disk["dashboard1"]["name"], "User edited")
+
+    def test_no_known_poisoned_entry_behaves_as_before(self):
+        """No entry in the poisoned map: behaves as before, no KeyError from the lookup."""
+        self._seed_baseline(make_config())
+
+        upgraded = make_config()
+        upgraded["dashboards"][0]["name"] = "New default name"
+        self.write_board_config("wb6", upgraded)
+
+        with patch.dict("wb.homeui_backend.dashboards.KNOWN_POISONED_BASELINE_HASHES", {}, clear=True):
+            self.store.seed_and_reconcile("wb6")
+
+        on_disk = {d["id"]: d for d in self.read_config()["dashboards"]}
+        self.assertEqual(on_disk["dashboard1"]["name"], "New default name")
+        self.assertEqual(
+            self.read_state()["hashes"]["dashboard1"],
+            dashboard_content_hash(upgraded["dashboards"][0]),
+        )
+
+    def test_poisoned_baseline_already_current_leaves_files_untouched(self):
+        """A poisoned baseline that's already current triggers no writes at all.
+
+        The baseline matches both the poisoned-hash check and the live-content check, but it
+        already equals today's default hash, so the "already current" skip should still block
+        the write. Checked via inode, not content: _atomic_write_json replaces the file on
+        every write, so even a same-content rewrite bumps the inode, while content equality
+        wouldn't catch that.
+        """
+        self._seed_baseline(make_config())
+        current_hash = self.read_state()["hashes"]["dashboard1"]
+
+        with patch.dict(
+            "wb.homeui_backend.dashboards.KNOWN_POISONED_BASELINE_HASHES",
+            {("wb6", "dashboard1"): current_hash},
+            clear=True,
+        ):
+            config_ino_before = os.stat(self.config_path).st_ino
+            state_ino_before = os.stat(self.state_path).st_ino
+
+            self.store.seed_and_reconcile("wb6")
+
+            self.assertEqual(os.stat(self.config_path).st_ino, config_ino_before)
+            self.assertEqual(os.stat(self.state_path).st_ino, state_ino_before)
 
     def test_does_not_readd_user_deleted_default(self):
         """A default the user deleted (id in baseline, absent from config) is not re-added."""

--- a/backend/wb/homeui_backend/dashboards.py
+++ b/backend/wb/homeui_backend/dashboards.py
@@ -64,6 +64,22 @@ def dashboard_content_hash(dashboard: dict) -> str:
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
+# In 2.237.0-2.238.0, for an id with no recorded baseline yet, a live default whose name
+# differed from the shipped one was wrongly assumed user-edited: the code stored the *new*
+# default's hash as the baseline without ever syncing it to the live content. That stored hash
+# then never matched anything real, so reconcile refused forever to update the (actually
+# unmodified) default. Keyed by (board_suffix, dashboard_id) -> the exact poisoned hash, so
+# reconcile can recognize it and force a sync. The shipped defaults were bumped alongside this
+# fix, so these exact values won't be produced again.
+KNOWN_POISONED_BASELINE_HASHES: dict[tuple[str, str], str] = {
+    ("wb6", "dashboard2"): "64da1ef77c1937e56286a8c203e0dcfb6a9102b637245e6dd37e3ec5c0599cbe",
+    ("wb7", "dashboard2"): "2d33d3b92a1ebf23f740e2a3d356d6a16156d2a62c0d11ff680032c522cbef9e",
+    ("wb74", "dashboard2"): "eb66ca52be3b905972454649e312205c57db489087c4f9d4787bc840435628b8",
+    ("wb8", "dashboard2"): "4d47af937147a394907092b4af282d3c4a0b5b412d9b548006052e93e5ade820",
+    ("wb85", "dashboard2"): "fa239835590829b7ef5382b5b4d8f0b0f4a3b77884f18db881d7db08c6685232",
+}
+
+
 @dataclass
 class BaselineState:
     # dashboard id -> content hash recorded when the default was last installed/updated
@@ -321,7 +337,7 @@ class DashboardsStore:
                 self._seed(board_config)
                 return
 
-            self._reconcile(board_config)
+            self._reconcile(board_suffix, board_config)
 
     # --- Private ---
 
@@ -379,7 +395,7 @@ class DashboardsStore:
                 state.hashes[dashboard["id"]] = dashboard_content_hash(dashboard)
         self._write_baseline_state(state)
 
-    def _reconcile(self, board_config: dict) -> None:
+    def _reconcile(self, board_suffix: str, board_config: dict) -> None:
         try:
             live_config = self._read_config()
         except Exception as e:  # pylint: disable=broad-exception-caught
@@ -420,7 +436,9 @@ class DashboardsStore:
                 # User-deleted: keep the baseline so it never resurrects.
                 continue
 
-            if dashboard_content_hash(live_dashboard) == state.hashes[dashboard_id]:
+            if dashboard_content_hash(live_dashboard) == state.hashes[dashboard_id] or state.hashes[
+                dashboard_id
+            ] == KNOWN_POISONED_BASELINE_HASHES.get((board_suffix, dashboard_id)):
                 # Unmodified default -> update to the new default (skip if already current).
                 if state.hashes[dashboard_id] != default_hash:
                     live_dashboard.clear()

--- a/backend/webui-configs/wb6.svg
+++ b/backend/webui-configs/wb6.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" width="auto" height="80vh" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard.svg" inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)" style="">
+<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" width="auto" height="80vh" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard_2.svg" inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)" style="">
   <style id="style3612">
 #g2564 {
     height:80vh;

--- a/backend/webui-configs/wb7.svg
+++ b/backend/webui-configs/wb7.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard.svg" inkscape:version="1.2.2 (b0a8486541, 2022-12-01)" style="">
+<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard_2.svg" inkscape:version="1.2.2 (b0a8486541, 2022-12-01)" style="">
   <defs id="defs6">
     <clipPath clipPathUnits="userSpaceOnUse" id="clipPath26">
       <path d="M 0,0 H 301.0408 V 266.849 H 0 Z" id="path24"/>

--- a/backend/webui-configs/wb74.svg
+++ b/backend/webui-configs/wb74.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard.svg" inkscape:version="1.2.2 (b0a8486541, 2022-12-01)" style="">
+<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard_2.svg" inkscape:version="1.2.2 (b0a8486541, 2022-12-01)" style="">
   <defs id="defs6">
     <clipPath clipPathUnits="userSpaceOnUse" id="clipPath26">
       <path d="M 0,0 H 301.0408 V 266.849 H 0 Z" id="path24"/>

--- a/backend/webui-configs/wb8.svg
+++ b/backend/webui-configs/wb8.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard.svg" inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)" style="">
+<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" id="svg2" xml:space="preserve" viewBox="0 0 580 550" sodipodi:docname="Demo SVG Dashboard_2.svg" inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)" style="">
   <defs id="defs6">
     <clipPath clipPathUnits="userSpaceOnUse" id="clipPath26">
       <path d="M 0,0 H 301.0408 V 266.849 H 0 Z" id="path24"/>

--- a/backend/webui-configs/wb85.svg
+++ b/backend/webui-configs/wb85.svg
@@ -4,7 +4,7 @@
    id="svg2"
    xml:space="preserve"
    viewBox="0 0 580 550"
-   sodipodi:docname="wb85_1.svg"
+   sodipodi:docname="wb85_1_2.svg"
    inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
    style=""
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-homeui (2.242.3) stable; urgency=medium
+
+  * Repair default dashboards poisoned by the 2.237.0-2.238.0 baseline
+    migration bug: force-sync a known-poisoned baseline hash to the
+    current default regardless of live content
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 16 Jul 2026 19:20:00 +0500
+
 wb-mqtt-homeui (2.242.2) stable; urgency=medium
 
   * fix device name translations


### PR DESCRIPTION
## Что изменилось

Во время миграционного окна версий 2.237.0–2.238.0 функция `_reconcile()` могла
записать в состояние baseline-хэш дашборда, совпадающий с хэшем актуального на тот
момент дефолта, ни разу не сверив его с реальным содержимым дашборда и не обновив
это содержимое. В результате на части контроллеров дефолтный дашборд, который
пользователь не трогал, навсегда стал восприниматься системой как изменённый
пользователем — и переставал получать последующие обновления дефолтного контента.
Для новых случаев эта ошибка исправлена в коммите e5816846 (вышел в версии 2.238.1),
но контроллеры, уже пострадавшие за указанное окно, остались в испорченном
состоянии.

Этот PR исправляет именно уже пострадавшие контроллеры:

- Добавлен список подтверждённых испорченных baseline-хэшей для каждой платы
  (wb6, wb7, wb74, wb8, wb85) применительно к дашборду `dashboard2`; значения
  получены с реального контроллера (wb85).
- Функция `_reconcile()` теперь при совпадении сохранённого baseline-хэша с одним
  из значений этого списка безусловно заменяет содержимое дашборда актуальным
  дефолтом, независимо от того, что в нём находится сейчас. Существующая защита
  подлинных пользовательских правок (когда сохранённый хэш не входит в список)
  не изменилась.
- В пяти дефолтных SVG-файлах изменено значение атрибута `sodipodi:docname`, чтобы
  хэш актуального дефолта отличался от значений из списка испорченных. Без этого
  изменения то же правило впоследствии начало бы отменять и настоящие
  пользовательские правки на исправно работающих контроллерах.
- Версия пакета повышена до 2.242.3.

## Тесты

В `ReconciliationTest` добавлены четыре теста: восстановление испорченного baseline
независимо от текущего содержимого дашборда; сохранение подлинной пользовательской
правки при обычном (не испорченном) baseline; корректное поведение для платы или
идентификатора дашборда, отсутствующих в списке испорченных хэшей; и отсутствие
каких-либо записей на диск, если испорченный baseline уже совпадает с актуальным
дефолтом (это проверяется по номеру inode файла). Полный набор проверок бэкенда
проходит без замечаний: isort, black, pylint (10 из 10), pytest (192 пройденных
теста).