### PR TITLE
Fix colour temperature limits in DALI group and broadcast editors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.243.5) stable; urgency=medium
+
+  * Fix colour temperature limits in DALI group and broadcast editors
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 21 Jul 2026 11:28:29 +0500
+
 wb-mqtt-homeui (2.243.4) stable; urgency=medium
 
   * Fix history load on page refresh

--- a/frontend/src/pages/settings/configs/dali/components/group-tab-content/styles.css
+++ b/frontend/src/pages/settings/configs/dali/components/group-tab-content/styles.css
@@ -15,6 +15,6 @@
     min-width: 0;
 }
 
-.dali-groupParam-editor .input {
-    width: 100%;
+.dali-groupParam-editor .input:not(.dali-color-temperature-slider-input) {
+     width: 100%;
 }

--- a/frontend/src/stores/dali/bus-store.ts
+++ b/frontend/src/stores/dali/bus-store.ts
@@ -5,6 +5,7 @@ import { BaseItemStore, ItemType } from './base-item-store';
 import { BusCommandsStore } from './bus-commands-store';
 import { DeviceStore } from './device-store';
 import { GroupStore } from './group-store';
+import { relativizeTcLimitPaths } from './tc-limit-paths';
 import type { CommissioningState } from './types';
 
 const IDLE_COMMISSIONING_STATE: CommissioningState = {
@@ -135,6 +136,7 @@ export class BusStore extends BaseItemStore {
       this.translator = new Translator();
       const schema = loadJsonSchema(data.schema);
       if (schema) {
+        relativizeTcLimitPaths(schema);
         this.translator.addTranslations(schema.translations);
         this.objectStore = new ObjectStore(schema, data.config, false, new StoreBuilder());
       }

--- a/frontend/src/stores/dali/group-store.ts
+++ b/frontend/src/stores/dali/group-store.ts
@@ -3,6 +3,7 @@ import { daliProxy } from '@/services';
 import { ObjectStore, StoreBuilder, Translator, loadJsonSchema } from '@/stores/json-schema-editor';
 import { BaseItemStore } from './base-item-store';
 import type { BusStore } from './bus-store';
+import { relativizeTcLimitPaths } from './tc-limit-paths';
 
 export class GroupStore extends BaseItemStore {
   readonly type = 'group' as const;
@@ -31,6 +32,7 @@ export class GroupStore extends BaseItemStore {
       const data = await daliProxy.GetGroup({ groupId: this.id });
       this.translator = new Translator();
       const schema = loadJsonSchema(data);
+      relativizeTcLimitPaths(schema);
       this.translator.addTranslations(schema.translations);
       this.objectStore = new ObjectStore(schema, {}, false, new StoreBuilder());
       this.objectStore.setDefault();

--- a/frontend/src/stores/dali/tc-limit-paths.test.ts
+++ b/frontend/src/stores/dali/tc-limit-paths.test.ts
@@ -1,0 +1,82 @@
+import type { JsonSchema } from '@/stores/json-schema-editor';
+import { relativizeTcLimitPaths } from './tc-limit-paths';
+
+const tcField = (min?: string, max?: string): JsonSchema => ({
+  type: 'number',
+  format: 'dali-tc',
+  options: { wb: { dali_tc: { ...(min && { min_limit: min }), ...(max && { max_limit: max }) } } },
+});
+
+// Mirrors the real GetGroup/GetBus schema: flat top-level sections, each mounted
+// as its own editor root, with dali_tc limit paths stored absolute from the root.
+const makeSchema = (): JsonSchema => ({
+  type: 'object',
+  properties: {
+    power_on_colour_32: {
+      type: 'object',
+      properties: { tc: tcField('tc_limits.tc_coolest', 'tc_limits.tc_warmest') },
+    },
+    scene_32: {
+      type: 'object',
+      properties: { tc: tcField('tc_limits.tc_coolest', 'tc_limits.tc_warmest') },
+    },
+    tc_limits: {
+      type: 'object',
+      properties: {
+        tc_warmest: tcField('tc_limits.tc_coolest', 'tc_limits.tc_physical_warmest'),
+        tc_coolest: tcField('tc_limits.tc_physical_coolest', 'tc_limits.tc_warmest'),
+      },
+    },
+  },
+});
+
+const daliTc = (schema: JsonSchema, section: string, field: string) =>
+  schema.properties[section].properties[field].options?.wb?.dali_tc;
+
+describe('relativizeTcLimitPaths', () => {
+  it('strips the section prefix from in-section (tc_limits interlock) paths', () => {
+    const schema = makeSchema();
+    relativizeTcLimitPaths(schema);
+    expect(daliTc(schema, 'tc_limits', 'tc_warmest')).toEqual({
+      min_limit: 'tc_coolest',
+      max_limit: 'tc_physical_warmest',
+    });
+    expect(daliTc(schema, 'tc_limits', 'tc_coolest')).toEqual({
+      min_limit: 'tc_physical_coolest',
+      max_limit: 'tc_warmest',
+    });
+  });
+
+  it('leaves cross-section paths (a colour section pointing at the sibling tc_limits section) untouched', () => {
+    const schema = makeSchema();
+    relativizeTcLimitPaths(schema);
+    expect(daliTc(schema, 'power_on_colour_32', 'tc')).toEqual({
+      min_limit: 'tc_limits.tc_coolest',
+      max_limit: 'tc_limits.tc_warmest',
+    });
+    expect(daliTc(schema, 'scene_32', 'tc')).toEqual({
+      min_limit: 'tc_limits.tc_coolest',
+      max_limit: 'tc_limits.tc_warmest',
+    });
+  });
+
+  it('recurses into array items so tc fields nested under array sections are rewritten', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        tc_limits: {
+          type: 'array',
+          items: { type: 'object', properties: { tc_warmest: tcField('tc_limits.tc_coolest') } },
+        },
+      },
+    };
+    relativizeTcLimitPaths(schema);
+    const items = schema.properties.tc_limits.items as JsonSchema;
+    expect(items.properties.tc_warmest.options?.wb?.dali_tc?.min_limit).toBe('tc_coolest');
+  });
+
+  it('is a no-op for a schema without properties', () => {
+    expect(() => relativizeTcLimitPaths(undefined)).not.toThrow();
+    expect(() => relativizeTcLimitPaths({ type: 'object' })).not.toThrow();
+  });
+});

--- a/frontend/src/stores/dali/tc-limit-paths.ts
+++ b/frontend/src/stores/dali/tc-limit-paths.ts
@@ -1,0 +1,48 @@
+import type { JsonSchema } from '@/stores/json-schema-editor';
+
+// The DALI group and bus (broadcast) editors mount each top-level schema section
+// as its own JsonSchemaEditor, so every section is the root store its dali_tc
+// sliders resolve limit paths against. The schema, however, stores those paths
+// absolute from the whole-object root (e.g. 'tc_limits.tc_coolest'). Rewrite each
+// path that points inside its own section to be relative to that section's root,
+// so the in-section interlocks (the tc_limits warmest/coolest bounds) resolve.
+//
+// Cross-section references — a colour section's `tc` pointing at the sibling
+// `tc_limits` section — are intentionally left untouched: the target lives in a
+// different mount, is unreachable by any relative path, and the slider falls back
+// to its default bounds.
+//
+// Not needed for the device editor: it mounts the whole object as a single tree,
+// where the absolute paths already resolve.
+
+const relativizeLimitPath = (path: string | undefined, prefix: string): string | undefined =>
+  typeof path === 'string' && path.startsWith(prefix) ? path.slice(prefix.length) : path;
+
+const relativizeNode = (node: JsonSchema, prefix: string): void => {
+  const tc = node.options?.wb?.dali_tc;
+  if (tc) {
+    if (tc.min_limit !== undefined) {
+      tc.min_limit = relativizeLimitPath(tc.min_limit, prefix);
+    }
+    if (tc.max_limit !== undefined) {
+      tc.max_limit = relativizeLimitPath(tc.max_limit, prefix);
+    }
+  }
+  if (node.properties) {
+    Object.values(node.properties).forEach((child) => relativizeNode(child, prefix));
+  }
+  if (Array.isArray(node.items)) {
+    node.items.forEach((item) => relativizeNode(item, prefix));
+  } else if (node.items) {
+    relativizeNode(node.items, prefix);
+  }
+};
+
+export const relativizeTcLimitPaths = (schema: JsonSchema | undefined): void => {
+  if (!schema?.properties) {
+    return;
+  }
+  Object.entries(schema.properties).forEach(([key, section]) => {
+    relativizeNode(section, `${key}.`);
+  });
+};


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В групповом и широковещательном (broadcast) редакторах DALI не работали взаимосвязи параметров цветовой температуры (интерлоки в «Colour Temperature Limits»): слайдеры игнорировали границы и открывались на дефолтном диапазоне 1000–10000K.

Причина: эти редакторы монтируют каждую top-level секцию схемы отдельным `JsonSchemaEditor` со своим `rootStore`, а пути ограничений `dali_tc.min_limit/max_limit` в схеме заданы абсолютно от корня объекта (`tc_limits.tc_coolest`) и не резолвились от корня секции. В редакторе устройства всё одним деревом — там работало.

Фикс: при получении схемы (`GroupStore.load`, `BusStore.load`) переписываем внутрисекционные пути ограничений на относительные к своей секции. Кросс-секционные ссылки (`power_on_colour`/`system_failure`/`scene` → соседняя секция `tc_limits`) при таком монтировании путём недостижимы и осознанно остаются на дефолтном диапазоне.

SOFT-7162

___________________________________
**Что поменялось для пользователей:**

В групповом и broadcast-редакторах DALI слайдеры цветовой температуры в «Colour Temperature Limits» теперь корректно ограничивают друг друга (physical/UI warmest ↔ coolest), как в редакторе устройства.

___________________________________
**Как проверял/а:**

- `npm run check:types` — чисто; `npm test` — 179 файлов, 2287 тестов зелёные (+4 новых теста на `relativizeTcLimitPaths`); lint изменённых файлов чисто.
- Живая проверка на контроллере 10.200.200.1, группа `wb-dali_12_bus_2_g1`: интерлоки `tc_limits` стали взаимозависимыми; кросс-секционные TC остаются на дефолте (ожидаемо).
