### PR TITLE
Fix collapsing colour temperature slider in DALI bus editor

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.243.7) stable; urgency=medium
+
+  * Fix collapsing colour temperature slider in DALI bus editor
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 22 Jul 2026 15:41:44 +0500
+
 wb-mqtt-homeui (2.243.6) stable; urgency=medium
 
   * Update completions

--- a/frontend/src/pages/settings/configs/dali/components/bus-tab-content/styles.css
+++ b/frontend/src/pages/settings/configs/dali/components/bus-tab-content/styles.css
@@ -21,7 +21,7 @@
     min-width: 0;
 }
 
-.dali-busParam-editor .input {
+.dali-busParam-editor .input:not(.dali-color-temperature-slider-input) {
     width: 100%;
 }
 


### PR DESCRIPTION
## Проблема

В редакторе настроек **шины (broadcast)** DALI ползунок цветовой температуры схлопывался в нулевую ширину — поле ввода в кельвинах растягивалось на всю строку, а сам ползунок исчезал.

## Причина

В стилях редактора шины есть правило:

```css
.dali-busParam-editor .input {
    width: 100%;
}
```

Этот селектор (специфичность `0,2,0`) перебивает собственную ширину Kelvin-поля слайдера (`.dali-color-temperature-slider-input { width: 70px }`, специфичность `0,1,0`). Поле раздувается до 100%, а соседний `.range-container` (`flex: 1; min-width: 0`) сжимается до нуля.

В редакторе групп было такое же правило — его уже поправили в #1176, а редактор шины пропустили.

## Исправление

Исключаем Kelvin-поле слайдера из правила на всю ширину — ровно так же, как в фиксе для групп:

```css
.dali-busParam-editor .input:not(.dali-color-temperature-slider-input) {
    width: 100%;
}
```

Только CSS, одна строка.

## Проверки

- `npm run lint` — чисто (только предсуществующие warning'и `max-lines` в несвязанных файлах)
- `npm run check:types` — чисто
- `npm test` — 2287/2287 проходят
