### PR TITLE
fix: prevent duplicate devices on serial bus re-scan SOFT-6775

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.243.10) stable; urgency=medium
+
+  * Fix duplicate devices created when re-scanning the serial bus after adding devices without saving
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 24 Jul 2026 10:49:56 +0300
+
 wb-mqtt-homeui (2.243.9) stable; urgency=medium
 
   * Add opt-in new json-schema-editor for configs via the wb-json-editor flag

--- a/frontend/src/pages/settings/device-manager/config-editor/stores/config-editor-page-store.test.ts
+++ b/frontend/src/pages/settings/device-manager/config-editor/stores/config-editor-page-store.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { type DeviceTypesStore } from '@/stores/device-manager';
+import type { ScannedDevice } from '@/stores/device-manager/types';
+import { Translator, type JsonSchema } from '@/stores/json-schema-editor';
+import { ConfigEditorPageStore } from './config-editor-page-store';
+import { PortTab, makeSerialPortTabName } from './port-tab-store';
+
+// A minimal serial device schema whose top-level (template-independent) properties include `sn`,
+// so the serial number survives into editedData just as it does for real wb-mqtt-serial devices.
+const deviceSchema = (): JsonSchema =>
+  ({
+    type: 'object',
+    properties: {
+      slave_id: { type: 'string' },
+      sn: { type: 'string' },
+      enabled: { type: 'boolean' },
+    },
+    device: {},
+  } as unknown as JsonSchema);
+
+// isWbDevice=false keeps ReadRegistersState at Unsupported, so loadContent does not try to read
+// registers from a device over a (non-existent) serial proxy.
+const makeDeviceTypesStore = (): DeviceTypesStore =>
+  ({
+    getSchema: async () => deviceSchema(),
+    isUnknown: () => false,
+    isDeprecated: () => false,
+    withSubdevices: () => false,
+    isModbusDevice: () => true,
+    isWbDevice: () => false,
+    getName: (type: string) => `name:${type}`,
+    getDefaultId: (type: string, slaveId: string) => `${type}_${slaveId}`,
+  } as unknown as DeviceTypesStore);
+
+const makeStoreWithPort = (deviceTypesStore: DeviceTypesStore) => {
+  const store = new ConfigEditorPageStore(
+    async () => ({} as any),
+    async () => {},
+    () => {},
+    () => {},
+    deviceTypesStore,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+  const portTab = new PortTab(
+    { path: '/dev/ttyRS485-1', enabled: true, baud_rate: 9600, parity: 'N', data_bits: 8, stop_bits: 2 },
+    {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        enabled: { type: 'boolean' },
+        baud_rate: { type: 'number' },
+        parity: { type: 'string' },
+        data_bits: { type: 'number' },
+        stop_bits: { type: 'number' },
+      },
+    } as unknown as JsonSchema,
+    makeSerialPortTabName,
+    new Translator(),
+  );
+  store.tabs.addPortTab(portTab, true);
+  return { store, portTab };
+};
+
+const makeScannedDevice = (overrides: Partial<ScannedDevice> = {}): ScannedDevice =>
+  ({
+    title: 'Scanned device',
+    sn: '4285517795',
+    address: 5,
+    type: 'wb-map12',
+    port: '/dev/ttyRS485-1',
+    baudRate: 9600,
+    parity: 'N',
+    stopBits: 2,
+    gotByFastScan: false,
+    bootloaderMode: false,
+    ...overrides,
+  } as ScannedDevice);
+
+describe('ConfigEditorPageStore.addScannedDeviceToConfig serial-number persistence', () => {
+  it('writes the scanned device serial number into the created device config entry', async () => {
+    const { store, portTab } = makeStoreWithPort(makeDeviceTypesStore());
+
+    await store.addScannedDeviceToConfig(makeScannedDevice({ sn: '4285517795' }), new Set<string>(), false);
+
+    expect(portTab.children).toHaveLength(1);
+    expect(portTab.children[0].editedData.sn).toBe('4285517795');
+    expect(portTab.children[0].editedData.slave_id).toBe('5');
+  });
+
+  it('adds a device that reports no serial number without failing and without an sn entry', async () => {
+    const { store, portTab } = makeStoreWithPort(makeDeviceTypesStore());
+
+    await store.addScannedDeviceToConfig(makeScannedDevice({ sn: '' }), new Set<string>(), false);
+
+    expect(portTab.children).toHaveLength(1);
+    expect(portTab.children[0].editedData.sn).toBeUndefined();
+    expect(portTab.children[0].editedData.slave_id).toBe('5');
+  });
+});

--- a/frontend/src/pages/settings/device-manager/config-editor/stores/config-editor-page-store.ts
+++ b/frontend/src/pages/settings/device-manager/config-editor/stores/config-editor-page-store.ts
@@ -311,6 +311,9 @@ export class ConfigEditorPageStore {
     const jsonSchema = loadJsonSchema(await this.deviceTypesStore.getSchema(device.type));
     const deviceConfig = getDefaultValue(jsonSchema) ?? {};
     deviceConfig.slave_id = String(device.newAddress ? device.newAddress : device.address);
+    if (device.sn) {
+      deviceConfig.sn = device.sn;
+    }
     const deviceId = deviceConfig?.id || this.deviceTypesStore.getDefaultId(device.type, deviceConfig.slave_id);
     if (topics.has(deviceId)) {
       deviceConfig.id = deviceId + '_2';

--- a/frontend/src/pages/settings/device-manager/config-editor/stores/configured-devices.test.ts
+++ b/frontend/src/pages/settings/device-manager/config-editor/stores/configured-devices.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+import { type DeviceTypesStore } from '@/stores/device-manager';
+import { ConfiguredDevices } from './configured-devices';
+
+// Minimal DeviceTypesStore: every type is a modbus device except 'non-modbus', so its device is
+// excluded from the configured-devices list (and therefore from the serial-number set).
+const makeDeviceTypesStore = (): DeviceTypesStore =>
+  ({
+    isModbusDevice: (type: string) => type !== 'non-modbus',
+    getDeviceSignatures: () => ['SIG'],
+  } as unknown as DeviceTypesStore);
+
+const makeDeviceTab = (slaveId: string, sn: unknown, deviceType = 'wb-map12') => ({
+  slaveId,
+  editedData: { device_type: deviceType, sn },
+});
+
+const makePortTab = (path: string, children: ReturnType<typeof makeDeviceTab>[]) => ({
+  path,
+  portType: 'serial',
+  baseConfig: {},
+  children,
+});
+
+describe('ConfiguredDevices.getConfiguredDevicesBySerialNumber', () => {
+  it('indexes the configured devices by their non-empty serial numbers across all ports, keeping the ' +
+    'configured device type', () => {
+    const portTabs = [
+      makePortTab('/dev/ttyRS485-1', [makeDeviceTab('10', '111'), makeDeviceTab('11', '112')]),
+      makePortTab('/dev/ttyRS485-2', [makeDeviceTab('12', '222')]),
+    ];
+
+    const index = new ConfiguredDevices(portTabs, makeDeviceTypesStore()).getConfiguredDevicesBySerialNumber();
+
+    expect(new Set(index.keys())).toEqual(new Set(['111', '112', '222']));
+    // The device type is retrievable by sn — that is what lets a re-scan show the configured name.
+    expect(index.get('111')?.deviceType).toBe('wb-map12');
+  });
+
+  it('excludes empty, absent and null serial numbers, and normalises numeric ones to strings', () => {
+    const portTabs = [
+      makePortTab('/dev/ttyRS485-1', [
+        makeDeviceTab('10', '111'),
+        makeDeviceTab('11', ''),
+        makeDeviceTab('12', undefined),
+        makeDeviceTab('13', null),
+        makeDeviceTab('14', 4285517795),
+      ]),
+    ];
+
+    const index = new ConfiguredDevices(portTabs, makeDeviceTypesStore()).getConfiguredDevicesBySerialNumber();
+
+    expect(new Set(index.keys())).toEqual(new Set(['111', '4285517795']));
+  });
+
+  it('does not index non-modbus devices', () => {
+    const portTabs = [
+      makePortTab('/dev/ttyRS485-1', [
+        makeDeviceTab('10', '111'),
+        makeDeviceTab('11', '999', 'non-modbus'),
+      ]),
+    ];
+
+    const index = new ConfiguredDevices(portTabs, makeDeviceTypesStore()).getConfiguredDevicesBySerialNumber();
+
+    expect(new Set(index.keys())).toEqual(new Set(['111']));
+  });
+
+  it('returns an empty map for an empty config', () => {
+    const index = new ConfiguredDevices([], makeDeviceTypesStore()).getConfiguredDevicesBySerialNumber();
+
+    expect(index.size).toBe(0);
+  });
+});

--- a/frontend/src/pages/settings/device-manager/config-editor/stores/configured-devices.ts
+++ b/frontend/src/pages/settings/device-manager/config-editor/stores/configured-devices.ts
@@ -1,6 +1,6 @@
 import { getIntAddress } from '@/stores/device-manager';
 import { type DeviceTypesStore } from '@/stores/device-manager';
-import { type ConfiguredDevice } from './types';
+import { type ConfiguredDevice, type ConfiguredDevicesByPort } from './types';
 
 /**
  * Generates a list of configured devices based on the given portTabChildren and deviceTypesStore.
@@ -14,7 +14,7 @@ function makeConfiguredDevicesList(portTabChildren, deviceTypesStore: DeviceType
     if (deviceTypesStore.isModbusDevice(deviceType)) {
       acc.push({
         address: deviceTab.slaveId,
-        sn: deviceTab.editedData.sn,
+        sn: String(deviceTab.editedData.sn ?? ''),
         deviceType: deviceType,
         signatures: deviceTypesStore.getDeviceSignatures(deviceType),
       });
@@ -23,7 +23,7 @@ function makeConfiguredDevicesList(portTabChildren, deviceTypesStore: DeviceType
   }, []);
 }
 
-function getConfiguredModbusDevices(portTabs, deviceTypesStore) {
+function getConfiguredModbusDevices(portTabs, deviceTypesStore): ConfiguredDevicesByPort {
   return portTabs.reduce((acc, portTab) => {
     acc[portTab.path] = {
       type: portTab.portType,
@@ -35,7 +35,7 @@ function getConfiguredModbusDevices(portTabs, deviceTypesStore) {
 }
 
 export class ConfiguredDevices {
-  configuredDevices = [];
+  configuredDevices: ConfiguredDevicesByPort = {};
 
   constructor(portTabs, deviceTypesStore) {
     this.configuredDevices = getConfiguredModbusDevices(portTabs, deviceTypesStore);
@@ -56,5 +56,20 @@ export class ConfiguredDevices {
       (acc, [path, port]) => acc.set(path, getAddressesSet(port.devices)),
       new Map(),
     );
+  }
+
+  /**
+   * @description Configured devices indexed by non-empty serial number, so a re-scan can both
+   * recognise a device by its sn and reuse the type it is configured with.
+   */
+  getConfiguredDevicesBySerialNumber(): Map<string, ConfiguredDevice> {
+    return Object.values(this.configuredDevices).reduce((acc, port) => {
+      port.devices.forEach((device) => {
+        if (device.sn) {
+          acc.set(device.sn, device);
+        }
+      });
+      return acc;
+    }, new Map<string, ConfiguredDevice>());
   }
 }

--- a/frontend/src/pages/settings/device-manager/config-editor/stores/types.ts
+++ b/frontend/src/pages/settings/device-manager/config-editor/stores/types.ts
@@ -1,4 +1,5 @@
-import type{ DeviceTypeDescriptionGroup } from '@/stores/device-manager/types';
+import type { PortTabConfig } from '@/stores/device-manager/port-tab/types';
+import type { DeviceTypeDescriptionGroup } from '@/stores/device-manager/types';
 import type { JsonSchema } from '@/stores/json-schema-editor';
 
 export interface ConfiguredDevice {
@@ -7,6 +8,15 @@ export interface ConfiguredDevice {
   deviceType: string;
   signatures: string[];
 }
+
+export interface ConfiguredPort {
+  type: string;
+  config: PortTabConfig;
+  devices: ConfiguredDevice[];
+}
+
+// Configured modbus devices grouped by port path (the internal shape ConfiguredDevices holds).
+export type ConfiguredDevicesByPort = Record<string, ConfiguredPort>;
 
 export interface SerialPort {
   baud_rate: number;

--- a/frontend/src/pages/settings/device-manager/scan/scan.tsx
+++ b/frontend/src/pages/settings/device-manager/scan/scan.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/button';
 import { useConfirm } from '@/components/confirm';
 import { Progress } from '@/components/progress';
 import { PageLayout } from '@/layouts/page';
-import { type NewDevicesScanPageStore } from '@/pages/settings/device-manager/scan';
 import { ScanState } from '@/pages/settings/device-manager/scan/stores/types';
 import { authStore, UserRole } from '@/stores/auth';
 import { DevicesTable } from './components/desktop';
@@ -18,7 +17,7 @@ import './styles.css';
 const ScanPage = observer(({ pageStore, scanType }: ScanPageProps) => {
   const { t, i18n } = useTranslation();
   const isDesktop = useMediaQuery({ minWidth: 874 });
-  const [confirmAddressChange, isConfirmOpened, handleConfirm, handleClose] = useConfirm<any>();
+  const [confirmAddressChange, isConfirmOpened, handleConfirm, handleClose, devicesToModify] = useConfirm<any>();
   const nothingFound = !pageStore.commonScanStore.devicesStore.newDevices.length
     && !pageStore.commonScanStore.devicesStore.alreadyConfiguredDevices.length;
 
@@ -120,7 +119,7 @@ const ScanPage = observer(({ pageStore, scanType }: ScanPageProps) => {
       {scanType === 'new' && (
         <SetupAddressModal
           isOpened={isConfirmOpened}
-          devices={(pageStore as NewDevicesScanPageStore).devicesToModify}
+          devices={devicesToModify ?? []}
           onConfirm={handleConfirm}
           onClose={handleClose}
         />

--- a/frontend/src/pages/settings/device-manager/scan/stores/new-devices-scan-page-store.test.ts
+++ b/frontend/src/pages/settings/device-manager/scan/stores/new-devices-scan-page-store.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+import { type DeviceTypesStore } from '@/stores/device-manager';
+import type { ScannedDevice } from '@/stores/device-manager/types';
+import { type ConfiguredDevices } from '../../config-editor/stores/configured-devices';
+import { NewDevicesScanPageStore } from './new-devices-scan-page-store';
+import { makeConfiguredDevices, makeDeviceTypesStore, makeScanned } from './test-fixtures';
+import { SelectionPolicy } from './types';
+
+const makeStore = (configuredDevices: ConfiguredDevices, deviceTypesStore: DeviceTypesStore) => {
+  const onLeave = vi.fn();
+  const store = new NewDevicesScanPageStore({} as any, deviceTypesStore, onLeave);
+  store.configuredDevices = configuredDevices;
+  // Mirror NewDevicesScanPageStore.select: the new-devices flow enables serial-number matching.
+  store.commonScanStore.devicesStore.init(SelectionPolicy.Multiple, configuredDevices, {
+    matchConfiguredBySerialNumber: true,
+  });
+  return { store, onLeave };
+};
+
+describe('NewDevicesScanPageStore.onOk address reassignment', () => {
+  it('gives two selected conflicting devices with empty serial numbers on the same port distinct ' +
+    'new addresses, and passes the same objects (with newAddress applied) on to addDevices ' +
+    '(Defect 2 regression)', async () => {
+    const deviceTypesStore = makeDeviceTypesStore();
+    const { store, onLeave } = makeStore(makeConfiguredDevices(deviceTypesStore), deviceTypesStore);
+    store.commonScanStore.devicesStore.setDevices([
+      makeScanned({ uuid: 'a', sn: '', slaveId: 5 }),
+      makeScanned({ uuid: 'b', sn: '', slaveId: 5 }),
+    ]);
+    const confirmAddressChange = vi.fn(async (_devices: ScannedDevice[]) => true);
+
+    await store.onOk(confirmAddressChange);
+
+    expect(confirmAddressChange).toHaveBeenCalledTimes(1);
+    // The conflicting subset is handed to the dialog via the confirm payload (Option B), not stored.
+    const modified = confirmAddressChange.mock.calls[0][0];
+    expect(modified).toHaveLength(1);
+    expect(modified[0].newAddress).toBe(1);
+    expect(onLeave).toHaveBeenCalledTimes(1);
+    const added = onLeave.mock.calls[0][0] as ScannedDevice[];
+    expect(added).toHaveLength(2);
+    const finalAddresses = added.map((d) => d.newAddress ?? d.address).sort((x, y) => x - y);
+    // Both devices are added with distinct, non-conflicting addresses (5 kept, the other reassigned).
+    expect(finalAddresses).toEqual([1, 5]);
+    expect(new Set(finalAddresses).size).toBe(2);
+  });
+
+  it('reassigns a genuinely new device whose address collides with an existing configured address, ' +
+    'writing newAddress onto the object handed to addDevices', async () => {
+    const deviceTypesStore = makeDeviceTypesStore();
+    const { store, onLeave } = makeStore(
+      makeConfiguredDevices(deviceTypesStore, [{ slaveId: '5', sn: '111' }]),
+      deviceTypesStore,
+    );
+    store.commonScanStore.devicesStore.setDevices([makeScanned({ uuid: 'a', sn: '222', slaveId: 5 })]);
+    const confirmAddressChange = vi.fn(async () => true);
+
+    await store.onOk(confirmAddressChange);
+
+    expect(confirmAddressChange).toHaveBeenCalledTimes(1);
+    const added = onLeave.mock.calls[0][0] as ScannedDevice[];
+    expect(added).toHaveLength(1);
+    expect(added[0].address).toBe(5);
+    expect(added[0].newAddress).toBe(1);
+  });
+
+  it('does not open the confirm dialog and assigns no new address when there is no conflict', async () => {
+    const deviceTypesStore = makeDeviceTypesStore();
+    const { store, onLeave } = makeStore(makeConfiguredDevices(deviceTypesStore), deviceTypesStore);
+    store.commonScanStore.devicesStore.setDevices([makeScanned({ uuid: 'a', sn: '', slaveId: 7 })]);
+    const confirmAddressChange = vi.fn(async () => true);
+
+    await store.onOk(confirmAddressChange);
+
+    expect(confirmAddressChange).not.toHaveBeenCalled();
+    const added = onLeave.mock.calls[0][0] as ScannedDevice[];
+    expect(added).toHaveLength(1);
+    expect(added[0].newAddress).toBeUndefined();
+  });
+
+  it('does not add any device when the user cancels the address-conflict dialog', async () => {
+    const deviceTypesStore = makeDeviceTypesStore();
+    const { store, onLeave } = makeStore(makeConfiguredDevices(deviceTypesStore), deviceTypesStore);
+    store.commonScanStore.devicesStore.setDevices([
+      makeScanned({ uuid: 'a', sn: '', slaveId: 5 }),
+      makeScanned({ uuid: 'b', sn: '', slaveId: 5 }),
+    ]);
+    const confirmAddressChange = vi.fn(async () => null);
+
+    await store.onOk(confirmAddressChange);
+
+    expect(confirmAddressChange).toHaveBeenCalledTimes(1);
+    expect(onLeave).not.toHaveBeenCalled();
+  });
+});
+
+describe('NewDevicesScanPageStore.onOk re-scan idempotency (Scenario 1)', () => {
+  it('does not re-offer or reassign a device already in the config (matched by serial number) on ' +
+    're-scan: it stays in the already-configured list while a genuinely new device is added normally', async () => {
+    const deviceTypesStore = makeDeviceTypesStore();
+    // The config already contains a device with sn '111' at slave_id 10 (e.g. added but not saved).
+    const { store, onLeave } = makeStore(
+      makeConfiguredDevices(deviceTypesStore, [{ slaveId: '10', sn: '111' }]),
+      deviceTypesStore,
+    );
+    // Re-scan returns that same device (sn '111', still at slave_id 10) plus one genuinely new device.
+    store.commonScanStore.devicesStore.setDevices([
+      makeScanned({ uuid: 'already-configured', sn: '111', slaveId: 10 }),
+      makeScanned({ uuid: 'new', sn: '222', slaveId: 6 }),
+    ]);
+
+    // The already-configured device is not selectable and is absent from the selection.
+    expect(store.commonScanStore.devicesStore.alreadyConfiguredDevices).toHaveLength(1);
+    expect(store.commonScanStore.devicesStore.alreadyConfiguredDevices[0].selectable).toBe(false);
+    expect(store.commonScanStore.getSelectedDevices().map((d) => d.sn)).toEqual(['222']);
+
+    const confirmAddressChange = vi.fn(async () => true);
+    await store.onOk(confirmAddressChange);
+
+    // No conflict is raised for the already-configured device, and it is never handed to addDevices.
+    expect(confirmAddressChange).not.toHaveBeenCalled();
+    const added = onLeave.mock.calls[0][0] as ScannedDevice[];
+    expect(added).toHaveLength(1);
+    expect(added[0].sn).toBe('222');
+    expect(added.some((d) => d.sn === '111')).toBe(false);
+  });
+});

--- a/frontend/src/pages/settings/device-manager/scan/stores/new-devices-scan-page-store.ts
+++ b/frontend/src/pages/settings/device-manager/scan/stores/new-devices-scan-page-store.ts
@@ -1,4 +1,4 @@
-import { makeObservable, observable, action, computed } from 'mobx';
+import { makeObservable, observable, action } from 'mobx';
 import { type deviceManagerProxy as deviceManagerProxyInstance } from '@/services';
 import { type DeviceTypesStore } from '@/stores/device-manager';
 import type { ScannedDevice } from '@/stores/device-manager/types';
@@ -22,7 +22,11 @@ export class NewDevicesScanPageStore {
     this.active = false;
     this.onLeave = onLeave;
 
-    makeObservable(this, { active: observable, select: action, stopScanning: action, devicesToModify: computed });
+    makeObservable(this, {
+      active: observable,
+      select: action,
+      stopScanning: action,
+    });
   }
 
   // Expected props structure
@@ -49,24 +53,24 @@ export class NewDevicesScanPageStore {
   select(configuredDevices: ConfiguredDevices) {
     this.configuredDevices = configuredDevices;
     this.active = true;
-    this.commonScanStore.startScanning(SelectionPolicy.Multiple, configuredDevices);
+    this.commonScanStore.startScanning(SelectionPolicy.Multiple, configuredDevices, {
+      matchConfiguredBySerialNumber: true,
+    });
   }
 
-  async onOk(confirmAddressChange: () => Promise<any>) {
+  async onOk(confirmAddressChange: (_devices: ScannedDevice[]) => Promise<any>) {
     try {
+      // Resolve address conflicts on a single selected-devices array and pass that same array on to
+      // addDevices, so the reassigned newAddress is never lost or mis-matched (e.g. when a device
+      // reports no serial number). The conflicting subset is handed to the confirm dialog through
+      // its payload, so this store keeps no transient UI state.
       const devices = this.commonScanStore.getSelectedDevices();
-      if (this.devicesToModify.length) {
-        const updatedDevices = await confirmAddressChange();
-        if (!updatedDevices) {
+      const devicesToModify = this._resolveDuplicateAddresses(devices);
+      if (devicesToModify.length) {
+        const confirmed = await confirmAddressChange(devicesToModify);
+        if (!confirmed) {
           return;
         }
-
-        devices.forEach((device) => {
-          const updatedDevice = updatedDevices.find((ud: any) => ud.sn === device.sn && ud.port === device.port);
-          if (updatedDevice && updatedDevice.newAddress) {
-            device.newAddress = updatedDevice.newAddress;
-          }
-        });
       }
       this.stopScanning();
       this?.onLeave(devices);
@@ -78,24 +82,6 @@ export class NewDevicesScanPageStore {
     this?.onLeave([]);
   }
 
-  get devicesToModify(): ScannedDevice[] {
-    const modbusAddressesSet = new ModbusAddressSet(this.configuredDevices.getUsedAddresses());
-    const devices = this.commonScanStore.getSelectedDevices();
-    const devicesWithDuplicateAddresses = devices.filter((device) => {
-      return !modbusAddressesSet.tryToAddUsedAddress(device.port, device.address);
-    });
-    const devicesToModify = [];
-    devicesWithDuplicateAddresses.forEach((scannedDevice: any) => {
-      const newAddress = modbusAddressesSet.fixAddress(scannedDevice.port, scannedDevice.address);
-      if (newAddress !== scannedDevice.address) {
-        scannedDevice.newAddress = newAddress;
-        devicesToModify.push(scannedDevice);
-      }
-    });
-
-    return devicesToModify;
-  }
-
   get isScanning() {
     return this.commonScanStore.isScanning;
   }
@@ -105,5 +91,27 @@ export class NewDevicesScanPageStore {
       this.commonScanStore.stopScanning();
     }
     this.active = false;
+  }
+
+  /**
+   * Assigns a new, non-conflicting address to every selected device whose address is already used
+   * (by the in-memory config or by another selected device). The new address is written onto the
+   * same object that onOk passes to addDevices, so the reassignment cannot be dropped. Returns the
+   * subset of devices that received a new address, for the confirmation dialog to display.
+   */
+  _resolveDuplicateAddresses(devices: Partial<ScannedDevice>[]): ScannedDevice[] {
+    const modbusAddressesSet = new ModbusAddressSet(this.configuredDevices.getUsedAddresses());
+    const devicesWithDuplicateAddresses = devices.filter((device) => {
+      return !modbusAddressesSet.tryToAddUsedAddress(device.port, device.address);
+    });
+    const devicesToModify: ScannedDevice[] = [];
+    devicesWithDuplicateAddresses.forEach((device) => {
+      const newAddress = modbusAddressesSet.fixAddress(device.port, device.address);
+      if (newAddress !== device.address) {
+        device.newAddress = newAddress;
+        devicesToModify.push(device as ScannedDevice);
+      }
+    });
+    return devicesToModify;
   }
 }

--- a/frontend/src/pages/settings/device-manager/scan/stores/scan-page-store.test.ts
+++ b/frontend/src/pages/settings/device-manager/scan/stores/scan-page-store.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { type DeviceTypesStore } from '@/stores/device-manager';
+import { CommonScanStore } from './scan-page-store';
+import { makeConfiguredDevices, makeDeviceTypesStore, makeScanned } from './test-fixtures';
+import { SelectionPolicy } from './types';
+
+describe('DevicesStore.setDevices classification', () => {
+  let deviceTypesStore: DeviceTypesStore;
+  let store: CommonScanStore;
+
+  beforeEach(() => {
+    deviceTypesStore = makeDeviceTypesStore();
+    store = new CommonScanStore({} as any, deviceTypesStore);
+  });
+
+  // The new-devices flow opts into serial-number de-duplication (matchConfiguredBySerialNumber),
+  // mirroring NewDevicesScanPageStore.select.
+  describe('new-devices flow (serial-number matching enabled)', () => {
+    it('places a scanned device whose serial number is already in the in-memory config into the ' +
+      'already-configured list, not into new devices', () => {
+      store.devicesStore.init(
+        SelectionPolicy.Multiple,
+        makeConfiguredDevices(deviceTypesStore, [{ slaveId: '10', sn: '111' }]),
+        { matchConfiguredBySerialNumber: true },
+      );
+
+      store.devicesStore.setDevices([makeScanned({ uuid: 'a', sn: '111' })]);
+
+      expect(store.devicesStore.newDevices).toHaveLength(0);
+      expect(store.devicesStore.alreadyConfiguredDevices).toHaveLength(1);
+      // Recognised by serial number even though the backend reports no configured_device_type;
+      // the display name is derived from the scanned signature.
+      expect(store.devicesStore.alreadyConfiguredDevices[0].title).toBe('name:wb-map12');
+      expect(store.devicesStore.alreadyConfiguredDevices[0].selectable).toBe(false);
+    });
+
+    it('shows the type from the in-memory config, not a signature guess, for a device recognised by ' +
+      'serial number', () => {
+      // Config types the device as 'wb-map12e'; signature-derivation would instead yield 'wb-map12',
+      // so asserting the former proves the type comes from the matched config entry.
+      store.devicesStore.init(
+        SelectionPolicy.Multiple,
+        makeConfiguredDevices(deviceTypesStore, [{ slaveId: '10', sn: '111', deviceType: 'wb-map12e' }]),
+        { matchConfiguredBySerialNumber: true },
+      );
+
+      store.devicesStore.setDevices([makeScanned({ uuid: 'a', sn: '111' })]);
+
+      expect(store.devicesStore.alreadyConfiguredDevices).toHaveLength(1);
+      expect(store.devicesStore.alreadyConfiguredDevices[0].title).toBe('name:wb-map12e');
+    });
+
+    it('keeps a scanned device with a serial number not present in the config in the new-devices list', () => {
+      store.devicesStore.init(
+        SelectionPolicy.Multiple,
+        makeConfiguredDevices(deviceTypesStore, [{ slaveId: '10', sn: '111' }]),
+        { matchConfiguredBySerialNumber: true },
+      );
+
+      store.devicesStore.setDevices([makeScanned({ uuid: 'b', sn: '222', slaveId: 6 })]);
+
+      expect(store.devicesStore.newDevices).toHaveLength(1);
+      expect(store.devicesStore.alreadyConfiguredDevices).toHaveLength(0);
+    });
+
+    it('classifies a scanned device as new without throwing when serial-number matching is enabled ' +
+      'but the config is null (defensive guard)', () => {
+      store.devicesStore.init(SelectionPolicy.Multiple, null, { matchConfiguredBySerialNumber: true });
+
+      store.devicesStore.setDevices([makeScanned({ uuid: 'f', sn: '111' })]);
+
+      expect(store.devicesStore.newDevices).toHaveLength(1);
+      expect(store.devicesStore.alreadyConfiguredDevices).toHaveLength(0);
+    });
+
+    it('still routes a device the backend reports as configured (configured_device_type) to the ' +
+      'already-configured list even without a serial-number match', () => {
+      store.devicesStore.init(SelectionPolicy.Multiple, makeConfiguredDevices(deviceTypesStore, []), {
+        matchConfiguredBySerialNumber: true,
+      });
+
+      store.devicesStore.setDevices([
+        makeScanned({ uuid: 'c', sn: '', slaveId: 7, configuredDeviceType: 'wb-mr6c' }),
+      ]);
+
+      expect(store.devicesStore.newDevices).toHaveLength(0);
+      expect(store.devicesStore.alreadyConfiguredDevices).toHaveLength(1);
+      expect(store.devicesStore.alreadyConfiguredDevices[0].title).toBe('name:wb-mr6c');
+    });
+  });
+
+  // The search-disconnected flow leaves serial-number matching OFF (default), mirroring
+  // SearchDisconnectedScanPageStore, which does not set the flag.
+  describe('search-disconnected flow (serial-number matching disabled)', () => {
+    it('preserves the search-disconnected override: the searched device (matching port + slave_id) ' +
+      'stays selectable in new devices even though the backend reports it as configured', () => {
+      store.devicesStore.init(
+        SelectionPolicy.Single,
+        makeConfiguredDevices(deviceTypesStore, [{ slaveId: '10', sn: '333' }]),
+        {
+          allowToSelectDevicesInBootloader: true,
+          selectableConfiguredDevice: { portPath: '/dev/ttyRS485-1', slaveId: 7 },
+        },
+      );
+
+      store.devicesStore.setDevices([
+        makeScanned({ uuid: 'd', sn: '333', slaveId: 7, configuredDeviceType: 'wb-mr6c' }),
+      ]);
+
+      expect(store.devicesStore.newDevices).toHaveLength(1);
+      expect(store.devicesStore.alreadyConfiguredDevices).toHaveLength(0);
+    });
+
+    it('keeps a searched device that moved to a different slave_id selectable in new devices, even ' +
+      'though its serial number is still in the config (would break restore otherwise)', () => {
+      // Disconnected device is configured at slave_id 10 with sn '111'; the user searches for it.
+      store.devicesStore.init(
+        SelectionPolicy.Single,
+        makeConfiguredDevices(deviceTypesStore, [{ slaveId: '10', sn: '111' }]),
+        {
+          allowToSelectDevicesInBootloader: true,
+          selectableConfiguredDevice: { portPath: '/dev/ttyRS485-1', slaveId: 10 },
+        },
+      );
+
+      // It is found again at a different slave_id (e.g. after a factory reset), so the backend
+      // reports no configured_device_type and isSearchedDevice is false.
+      store.devicesStore.setDevices([
+        makeScanned({ uuid: 'e', sn: '111', slaveId: 20, configuredDeviceType: '' }),
+      ]);
+
+      expect(store.devicesStore.alreadyConfiguredDevices).toHaveLength(0);
+      expect(store.devicesStore.newDevices).toHaveLength(1);
+      expect(store.devicesStore.newDevices[0].selectable).toBe(true);
+    });
+  });
+});

--- a/frontend/src/pages/settings/device-manager/scan/stores/scan-page-store.ts
+++ b/frontend/src/pages/settings/device-manager/scan/stores/scan-page-store.ts
@@ -4,15 +4,24 @@ import i18n from '@/i18n/config';
 import { type deviceManagerProxy as deviceManagerProxyInstance } from '@/services';
 import type { DeviceTypesStore } from '@/stores/device-manager';
 import { type ScannedDevice } from '@/stores/device-manager/types';
+import { type ConfiguredDevices } from '../../config-editor/stores/configured-devices';
+import { type ConfiguredDevice } from '../../config-editor/stores/types';
 import { GlobalErrorStore } from './global-error-store';
 import { ScanningProgressStore } from './scanning-progress-store';
 import { SingleDeviceStore } from './single-device-store';
-import { type FullScannedDevice, type SelectableConfiguredDevice, SelectionPolicy, ScanState } from './types';
+import {
+  type DevicesStoreInitOptions,
+  type FullScannedDevice,
+  type SelectableConfiguredDevice,
+  type StartScanningOptions,
+  SelectionPolicy,
+  ScanState,
+} from './types';
 
 class DevicesStore {
   public newDevices: SingleDeviceStore[] = [];
   public alreadyConfiguredDevices: SingleDeviceStore[] = [];
-  public configuredDevices = {};
+  public configuredDevicesBySn: Map<string, ConfiguredDevice> = new Map();
   public deviceTypesStore: DeviceTypesStore;
   public selectionPolicy: SelectionPolicy = SelectionPolicy.Multiple;
   public allowToSelectDevicesInBootloader = false;
@@ -34,6 +43,17 @@ class DevicesStore {
       scannedDevice,
       [this.deviceTypesStore.getName(scannedDevice.configured_device_type)],
       [scannedDevice.configured_device_type],
+      false,
+    );
+  }
+
+  // A device the backend has not matched (no configured_device_type) but that is already in the
+  // unsaved in-memory config, recognised by serial number: its type comes from that config entry.
+  makeSerialNumberMatchedDeviceStore(scannedDevice: FullScannedDevice, configuredDevice: ConfiguredDevice) {
+    return new SingleDeviceStore(
+      scannedDevice,
+      [this.deviceTypesStore.getName(configuredDevice.deviceType)],
+      [configuredDevice.deviceType],
       false,
     );
   }
@@ -86,6 +106,12 @@ class DevicesStore {
       // be selectable, otherwise the user can't re-apply connection settings (e.g. baud rate) to it.
       if (scannedDevice.configured_device_type && !this.isSearchedDevice(scannedDevice)) {
         this.alreadyConfiguredDevices.push(this.makeConfiguredDeviceStore(scannedDevice));
+        return;
+      }
+      // Not matched by the backend: recognise it by serial number in the unsaved in-memory config
+      const configuredMatch = this.configuredDevicesBySn.get(String(scannedDevice.sn ?? ''));
+      if (configuredMatch) {
+        this.alreadyConfiguredDevices.push(this.makeSerialNumberMatchedDeviceStore(scannedDevice, configuredMatch));
       } else {
         this.newDevices.push(this.makeNewDeviceStore(scannedDevice));
       }
@@ -100,13 +126,18 @@ class DevicesStore {
 
   }
 
-  init(
-    selectionPolicy: SelectionPolicy,
-    configuredDevices,
-    allowToSelectDevicesInBootloader: boolean,
-    selectableConfiguredDevice: SelectableConfiguredDevice = null,
-  ) {
-    this.configuredDevices = configuredDevices;
+  init(selectionPolicy: SelectionPolicy, configuredDevices: ConfiguredDevices, options: DevicesStoreInitOptions = {}) {
+    const {
+      allowToSelectDevicesInBootloader,
+      selectableConfiguredDevice = null,
+      matchConfiguredBySerialNumber = false,
+    } = options;
+    // configured_device_type covers only the saved config on disk; indexing the in-memory config by
+    // serial number lets a re-scan also recognise devices added but not yet saved. Only the new-devices
+    // flow opts in, and the index is built once here since the config does not change during a scan.
+    this.configuredDevicesBySn = matchConfiguredBySerialNumber
+      ? (configuredDevices?.getConfiguredDevicesBySerialNumber() ?? new Map<string, ConfiguredDevice>())
+      : new Map<string, ConfiguredDevice>();
     this.allowToSelectDevicesInBootloader = !!allowToSelectDevicesInBootloader;
     this.selectableConfiguredDevice = selectableConfiguredDevice;
     this.newDevices.forEach((device) => device.disposer?.());
@@ -268,33 +299,21 @@ export class CommonScanStore {
    * Starts the scanning process.
    *
    * @param {SelectionPolicy} selectionPolicy - The selection policy for scanning.
-   * @param {Array} configuredDevices - The list of configured devices.
-   * @param {string} portPath - The path of the port.
-   * @param {boolean} useModbusTcp - Whether to use Modbus TCP protocol.
-   * @param {Array} outOfOrderSlaveIds - The list of out-of-order slave IDs.
-   * @param {boolean} allowToSelectDevicesInBootloader - The flag to allow to select devices in bootloader.
-   * @param {SelectableConfiguredDevice} selectableConfiguredDevice - An already configured device
-   *   (port + slave_id) that must stay selectable, used when searching for a disconnected device.
+   * @param {ConfiguredDevices} configuredDevices - The current (saved or unsaved) config.
+   * @param {StartScanningOptions} options - Per-flow scan knobs (port, protocol, out-of-order slave
+   *   ids, bootloader selection, searched device, serial-number de-duplication). All optional; the
+   *   new-devices flow only sets `matchConfiguredBySerialNumber`.
    * @returns {void}
    */
   startScanning(
     selectionPolicy: SelectionPolicy,
-    configuredDevices,
-    portPath?: string,
-    useModbusTcp?: boolean,
-    outOfOrderSlaveIds?: string[],
-    allowToSelectDevicesInBootloader?: boolean,
-    selectableConfiguredDevice?: SelectableConfiguredDevice,
+    configuredDevices: ConfiguredDevices,
+    options: StartScanningOptions = {},
   ): void {
-    this.devicesStore.init(
-      selectionPolicy,
-      configuredDevices,
-      allowToSelectDevicesInBootloader,
-      selectableConfiguredDevice,
-    );
-    this.portPath = portPath;
-    this.useModbusTcp = useModbusTcp;
-    this.outOfOrderSlaveIds = outOfOrderSlaveIds;
+    this.devicesStore.init(selectionPolicy, configuredDevices, options);
+    this.portPath = options.portPath;
+    this.useModbusTcp = options.useModbusTcp;
+    this.outOfOrderSlaveIds = options.outOfOrderSlaveIds;
     this.startExtendedScanning();
   }
 

--- a/frontend/src/pages/settings/device-manager/scan/stores/search-disconnected-scan-page-store.ts
+++ b/frontend/src/pages/settings/device-manager/scan/stores/search-disconnected-scan-page-store.ts
@@ -61,15 +61,13 @@ export class SearchDisconnectedScanPageStore {
       // it as configured. Keep it selectable so its connection settings can be re-applied.
       selectableConfiguredDevice = { portPath, slaveId: slaveIdInt };
     }
-    this.commonScanStore.startScanning(
-      SelectionPolicy.Single,
-      configuredDevices,
+    this.commonScanStore.startScanning(SelectionPolicy.Single, configuredDevices, {
       portPath,
       useModbusTcp,
       outOfOrderSlaveIds,
-      true,
+      allowToSelectDevicesInBootloader: true,
       selectableConfiguredDevice,
-    );
+    });
   }
 
   onOk() {

--- a/frontend/src/pages/settings/device-manager/scan/stores/test-fixtures.ts
+++ b/frontend/src/pages/settings/device-manager/scan/stores/test-fixtures.ts
@@ -1,0 +1,64 @@
+// Shared test fixtures for the scan-store tests (scan-page-store.test.ts and
+// new-devices-scan-page-store.test.ts). The two suites exercise tightly-coupled stores
+// (NewDevicesScanPageStore wraps CommonScanStore) against the same FullScannedDevice / ConfiguredDevices
+// shapes, so the builders live here to keep them in sync when those shapes change.
+import { type DeviceTypesStore } from '@/stores/device-manager';
+import { ConfiguredDevices } from '../../config-editor/stores/configured-devices';
+import { type FullScannedDevice } from './types';
+
+export const makeDeviceTypesStore = (): DeviceTypesStore =>
+  ({
+    findNotDeprecatedDeviceTypes: () => ['wb-map12'],
+    getName: (type: string) => `name:${type}`,
+    isModbusDevice: () => true,
+    getDeviceSignatures: () => ['MAP12'],
+  } as unknown as DeviceTypesStore);
+
+export const makeConfiguredDevices = (
+  deviceTypesStore: DeviceTypesStore,
+  devices: { slaveId: string; sn: string; deviceType?: string }[] = [],
+) =>
+  new ConfiguredDevices(
+    [
+      {
+        path: '/dev/ttyRS485-1',
+        portType: 'serial',
+        baseConfig: {},
+        children: devices.map((d) => ({
+          slaveId: d.slaveId,
+          editedData: { device_type: d.deviceType ?? 'wb-map12', sn: d.sn },
+        })),
+      },
+    ],
+    deviceTypesStore,
+  );
+
+export interface ScannedOverrides {
+  uuid?: string;
+  sn?: string;
+  slaveId?: number;
+  path?: string;
+  configuredDeviceType?: string;
+}
+
+export const makeScanned = (overrides: ScannedOverrides = {}): FullScannedDevice =>
+  ({
+    uuid: overrides.uuid ?? 'uuid',
+    port: { path: overrides.path ?? '/dev/ttyRS485-1' },
+    cfg: {
+      slave_id: overrides.slaveId ?? 5,
+      baud_rate: 9600,
+      parity: 'N',
+      data_bits: 8,
+      stop_bits: 2,
+    },
+    title: 'Scanned device',
+    sn: overrides.sn ?? '',
+    device_signature: 'MAP12',
+    fw_signature: '',
+    configured_device_type: overrides.configuredDeviceType ?? '',
+    last_seen: 0,
+    bootloader_mode: false,
+    errors: [],
+    fw: { version: '1.0', ext_support: false, fast_modbus_command: 0 },
+  } as unknown as FullScannedDevice);

--- a/frontend/src/pages/settings/device-manager/scan/stores/types.ts
+++ b/frontend/src/pages/settings/device-manager/scan/stores/types.ts
@@ -51,3 +51,20 @@ export interface SelectableConfiguredDevice {
   portPath: string;
   slaveId: number;
 }
+
+export interface DevicesStoreInitOptions {
+  allowToSelectDevicesInBootloader?: boolean;
+  // An already configured device (port + slave_id) that must stay selectable, used when searching
+  // for a disconnected device.
+  selectableConfiguredDevice?: SelectableConfiguredDevice;
+  // Treat a scanned device as already configured when its serial number is in the current config.
+  // Only the new-devices flow enables this; the search-disconnected flow keeps it off so a device
+  // that moved to a different slave_id stays selectable/restorable.
+  matchConfiguredBySerialNumber?: boolean;
+}
+
+export interface StartScanningOptions extends DevicesStoreInitOptions {
+  portPath?: string;
+  useModbusTcp?: boolean;
+  outOfOrderSlaveIds?: string[];
+}


### PR DESCRIPTION
## Проблема

В менеджере устройств последовательной шины (**Настройки → Устройства на шине**): сканируем шину,
добавляем найденные устройства в конфиг, **не сохраняем** и сканируем **снова** — только что
добавленные устройства опять предлагаются как *новые*, а их адреса помечаются как конфликтующие.
При применении переназначения устройство добавлялось второй раз / перепрошивалось, оставляя
дублирующие записи в конфиге (исходная запись сохраняла старый адрес и «умирала»). Воспроизведено
на WB 7.4 с wb-2602 / wb-2606.

Совпали два независимых фронтенд-дефекта:

1. Классификация при скане опиралась только на бэкендовое `configured_device_type` (отражает
   **сохранённый** конфиг на диске), поэтому устройство, добавленное в homeui, но ещё не сохранённое,
   возвращалось как *новое*.
2. В разрешении конфликтов адресов выбранный новый адрес писался в один массив выбранных устройств,
   а затем «сшивался» с **другим** массивом по `(sn, port)`. Устройства без серийного номера
   сопоставлялись неверно: одно получало чужой адрес, другое добавлялось со старым конфликтным.

## Исправление (только фронтенд)

- `ConfiguredDevices` отдаёт конфиг, проиндексированный по серийному номеру
  (`getConfiguredDevicesBySerialNumber`). Просканированное устройство, уже присутствующее в конфиге
  (сохранённом **или** нет), распознаётся по `sn` и показывается в разделе **«Уже настроенные»** с
  типом из его конфиг-записи, а не из догадки по сигнатуре.
- При добавлении просканированного устройства его `sn` сохраняется в создаваемую запись конфига.
- Конфликты адресов разрешаются на **одном** массиве выбранных устройств, который и передаётся в
  `addDevices` — повторного сопоставления по `(sn, port)` больше нет, поэтому переназначенный адрес
  не теряется, в том числе для устройств без серийного номера.
- Поток «поиск отключённого устройства» не изменился (сопоставление по серийнику включается только
  для потока добавления новых устройств).

Изменений в бэкенде / wb-device-manager / формате конфига нет.

## Тесты

Добавлено покрытие vitest: классификация, индексация по серийнику, сохранение `sn`, переназначение
адресов (в т.ч. два конфликтующих устройства с **пустыми** серийниками на одном порту). Пайплайн
зелёный: `npm run check:types`, `npm run lint`, `npm test` (2308 тестов).

**Известное ограничение (осознанно):** устройства, не сообщающие серийный номер при стандартном
скане, между сканами не дедуплицируются.
