### PR TITLE
Recreate configs on startup if the existing file is empty

### DIFF
--- a/backend/tests/config_file_test.py
+++ b/backend/tests/config_file_test.py
@@ -1,0 +1,36 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from wb.homeui_backend.config_file import Config
+from wb.homeui_backend.users_storage import UsersStorage
+
+
+class ConfigInitTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+        self.config_path = os.path.join(self.tmp_dir, "wb-homeui-backend.conf")
+        patcher = patch("wb.homeui_backend.config_file.CONFIG_FILE", self.config_path)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.users_storage = MagicMock(spec=UsersStorage)
+        self.users_storage.has_users.return_value = False
+
+    def read_config(self) -> dict:
+        with open(self.config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_recreates_config_when_empty(self):
+        """An existing but empty config file is recreated as if it were missing."""
+        with open(self.config_path, "w", encoding="utf-8"):
+            pass
+        self.users_storage.has_users.return_value = True
+
+        config = Config(self.users_storage)
+
+        self.assertTrue(config.is_https_enabled())
+        self.assertEqual(self.read_config(), {"enable_https": True})

--- a/backend/tests/config_file_test.py
+++ b/backend/tests/config_file_test.py
@@ -18,7 +18,6 @@ class ConfigInitTest(unittest.TestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
         self.users_storage = MagicMock(spec=UsersStorage)
-        self.users_storage.has_users.return_value = False
 
     def read_config(self) -> dict:
         with open(self.config_path, "r", encoding="utf-8") as f:

--- a/backend/tests/dashboards_test.py
+++ b/backend/tests/dashboards_test.py
@@ -524,6 +524,17 @@ class SeedingTest(DashboardsStoreFixture):
         self.assertEqual(len(dashboards), 2)
         self.assertEqual(sorted(ids), ["dashboard1", "dashboard2"])
 
+    def test_seeds_from_board_config_when_empty(self):
+        """An existing but empty config file is treated as absent and seeded from defaults."""
+        board_config = make_config()
+        self.write_board_config("wb6", board_config)
+        with open(self.config_path, "w", encoding="utf-8"):
+            pass
+
+        self.store.seed_and_reconcile("wb6")
+
+        self.assertEqual(self.read_config(), board_config)
+
     def test_missing_board_config_raises(self):
         """No board config file => seeding fails hard (no silent skip); config stays absent.
 

--- a/backend/wb/homeui_backend/config_file.py
+++ b/backend/wb/homeui_backend/config_file.py
@@ -23,7 +23,7 @@ class Config:
 
     def __init__(self, users_storage: UsersStorage):
         self.enable_https = False
-        if os.path.exists(CONFIG_FILE):
+        if os.path.exists(CONFIG_FILE) and os.path.getsize(CONFIG_FILE) > 0:
             self._read_config(users_storage)
         else:
             self._create_config(users_storage)

--- a/backend/wb/homeui_backend/dashboards.py
+++ b/backend/wb/homeui_backend/dashboards.py
@@ -322,7 +322,7 @@ class DashboardsStore:
             self._write_config(config)
 
     def seed_and_reconcile(self, board_suffix: str) -> None:
-        """Seed the config if absent, then reconcile defaults against the baseline state.
+        """Seed the config if absent or empty, then reconcile defaults against the baseline state.
 
         Reconciliation adds defaults never installed here and updates unmodified ones, leaving
         user-modified or user-deleted ones untouched. Raises SeedConfigError if
@@ -333,7 +333,7 @@ class DashboardsStore:
             if board_config is None:
                 raise SeedConfigError(f"No board config for suffix '{board_suffix}'")
 
-            if not os.path.exists(self._config_path):
+            if not os.path.exists(self._config_path) or os.path.getsize(self._config_path) == 0:
                 self._seed(board_config)
                 return
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.243.13) stable; urgency=medium
+
+  * Recreate wb-webui.conf and wb-homeui-backend.conf on startup if the existing file is empty
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 27 Jul 2026 12:00:00 +0300
+
 wb-mqtt-homeui (2.243.12) stable; urgency=medium
 
   * Fix History page not loading device topics on direct navigation


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Пустой (0 байт) `/etc/wb-webui.conf` или `/etc/wb-homeui-backend.conf` ломал старт бэкенда. Теперь пустой файл пересоздаётся при старте

___________________________________
**Что поменялось для пользователей:**

При пустом файле конфига сервис генерирует новый

___________________________________
**Как проверял/а:**

на контроллере
