### PR TITLE
Remove Wiren Board Cloud branding from Russian cloud status strings CLOUD-614

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.243.13) stable; urgency=medium
+
+  * Remove Wiren Board Cloud branding from Russian cloud status strings
+
+ -- Denis Smagin <denis.smagin@wirenboard.com>  Tue, 28 Jul 2026 12:00:00 +0300
+
 wb-mqtt-homeui (2.243.12) stable; urgency=medium
 
   * Fix History page not loading device topics on direct navigation

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -346,14 +346,14 @@
       },
       "cloud-status": {
          "title": "Подключение к облаку",
-         "activation-link-preamble": "Почти готово! Для подключения контроллера к Wiren Board Cloud, нажмите",
+         "activation-link-preamble": "Почти готово! Для подключения контроллера к облаку нажмите",
          "activation-link": "эту ссылку",
          "status-ok": "Этот контроллер подключен к облаку",
          "status-starting": "Сервис wb-cloud-agent запускается",
          "status-connecting": "Подключаемся к облаку",
          "status-stopped": "Сервис wb-cloud-agent не запущен",
          "status-error": "Ошибка подключения к облаку",
-         "goto-cloud": "Перейти в Wiren Board Cloud"
+         "goto-cloud": "Открыть контроллер в облаке"
       }
    },
    "svg-dashboard": {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

[CLOUD-614](https://wirenboard.youtrack.cloud/issue/CLOUD-614): в русской локализации карточки «Подключение к облаку» (Настройки → Система) жёстко упоминался «Wiren Board Cloud». Карточка общая для всех облачных провайдеров, включая on-premise, где клиенты полностью меняют брендинг. Английская версия уже нейтральна.

___________________________________
**Что поменялось для пользователей:**

Две строки в русской локали стали нейтральными, по образцу английских:
- «Почти готово! Для подключения контроллера к Wiren Board Cloud, нажмите» → «Почти готово! Для подключения контроллера к облаку нажмите»
- «Перейти в Wiren Board Cloud» → «Открыть контроллер в облаке» (англ. «Open this controller in cloud»)

___________________________________
**Как проверял/а:**

`npm run check:types`, `npm run lint`, `npm test` (2308/2308) — чисто. Тесты компонента завязаны на i18n-ключи, изменение чисто строковое.
