### PR TITLE
Recreate configs on startup if the existing file is empty (wb-2606)

### DIFF
--- a/backend/configs/usr/lib/cgi-bin/fwupdate_upload.py
+++ b/backend/configs/usr/lib/cgi-bin/fwupdate_upload.py
@@ -88,6 +88,7 @@ def main():
     else:
         _error("Incorrect request body")
 
+    # pylint: disable=possibly-used-before-assignment
     with open(os.path.join(rw_dir, fname), "wb") as fp_save:  # wb-watch-update triggers on fd close
         for chunk in to_chunks(fp_upload):
             fp_save.write(chunk)

--- a/backend/configs/usr/lib/wb-homeui-backend/generate-system-config.sh
+++ b/backend/configs/usr/lib/wb-homeui-backend/generate-system-config.sh
@@ -2,8 +2,6 @@
 
 CONFFILE="/etc/wb-webui.conf"
 
-# -s: a config that exists but is empty (e.g. after a power cut during
-# write) must be re-seeded as if it were missing
 [ -s "$CONFFILE" ] && exit 0
 
 . /usr/lib/wb-utils/wb_env.sh

--- a/backend/configs/usr/lib/wb-homeui-backend/generate-system-config.sh
+++ b/backend/configs/usr/lib/wb-homeui-backend/generate-system-config.sh
@@ -2,7 +2,9 @@
 
 CONFFILE="/etc/wb-webui.conf"
 
-[ -f "$CONFFILE" ] && exit 0
+# -s: a config that exists but is empty (e.g. after a power cut during
+# write) must be re-seeded as if it were missing
+[ -s "$CONFFILE" ] && exit 0
 
 . /usr/lib/wb-utils/wb_env.sh
 

--- a/backend/tests/config_file_test.py
+++ b/backend/tests/config_file_test.py
@@ -1,0 +1,35 @@
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from wb.homeui_backend.config_file import Config
+from wb.homeui_backend.users_storage import UsersStorage
+
+
+class ConfigInitTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+        self.config_path = os.path.join(self.tmp_dir, "wb-homeui-backend.conf")
+        patcher = patch("wb.homeui_backend.config_file.CONFIG_FILE", self.config_path)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.users_storage = MagicMock(spec=UsersStorage)
+
+    def read_config(self) -> dict:
+        with open(self.config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_recreates_config_when_empty(self):
+        """An existing but empty config file is recreated as if it were missing."""
+        with open(self.config_path, "w", encoding="utf-8"):
+            pass
+        self.users_storage.has_users.return_value = True
+
+        config = Config(self.users_storage)
+
+        self.assertTrue(config.is_https_enabled())
+        self.assertEqual(self.read_config(), {"enable_https": True})

--- a/backend/wb/homeui_backend/config_file.py
+++ b/backend/wb/homeui_backend/config_file.py
@@ -14,7 +14,7 @@ class Config:
 
     def __init__(self, users_storage: UsersStorage):
         self.enable_https = False
-        if os.path.exists(CONFIG_FILE):
+        if os.path.exists(CONFIG_FILE) and os.path.getsize(CONFIG_FILE) > 0:
             self._read_config(users_storage)
         else:
             self._create_config(users_storage)

--- a/backend/wb/homeui_backend/users_storage.py
+++ b/backend/wb/homeui_backend/users_storage.py
@@ -14,7 +14,7 @@ class UserType(Enum):
 class User:
     def __init__(
         self, user_id: str, login: str, pwd_hash: str, user_type: UserType, autologin: bool
-    ):  # pylint: disable=too-many-arguments
+    ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self.user_id: str = user_id
         self.login: str = login
         self.pwd_hash: str = pwd_hash

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.208.1-wb102) stable; urgency=medium
+
+  * Recreate configs on startup if the existing file is empty
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 30 Jul 2026 11:05:54 +0300
+
 wb-mqtt-homeui (2.208.1-wb101) stable; urgency=medium
 
   * Fix history dropdown width


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Бэкпорт #1186 в release/wb-2606. 
___________________________________
**Что поменялось для пользователей:**

Пустой /etc/wb-webui.conf или /etc/wb-homeui-backend.conf после сбоя питания больше не приводит к нерабочему веб-интерфейсу — конфиги пересоздаются при старте.

___________________________________
**Как проверял/а:**

на стенде в офисе
