### PR TITLE
fix: restore channel patterns in wb-autocomplete fields INT-1247

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.245.6) stable; urgency=medium
+
+  * Fix channel patterns like +/+ disappearing from MQTT history settings
+  * Show "Nothing found" in dropdowns instead of an empty box
+
+ -- Valerii Trofimov <valeriy.trofimov@wirenboard.com>  Tue, 11 Aug 2026 17:01:00 +0300
+
 wb-mqtt-homeui (2.245.5) stable; urgency=medium
 
   * Fix cell fraction after zero

--- a/frontend/src/components/dropdown/dropdown-creatable.test.tsx
+++ b/frontend/src/components/dropdown/dropdown-creatable.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Dropdown } from './dropdown';
+
+const options = [
+  { value: 'wb-adc/A1', label: 'A1 [wb-adc/A1]' },
+  { value: 'wb-adc/A2', label: 'A2 [wb-adc/A2]' },
+];
+
+describe('Dropdown with isCreatable', () => {
+  test('displays a value missing from options as-is instead of an empty field', async () => {
+    render(<Dropdown options={options} value="+/+" isCreatable isSearchable onChange={vi.fn()} />);
+    expect(await screen.findByText('+/+')).toBeDefined();
+  });
+
+  test('without isCreatable a value missing from options renders nothing (strict select)', () => {
+    render(
+      <Dropdown options={options} value="+/+" placeholder="Choose..." isSearchable onChange={vi.fn()} />,
+    );
+    expect(screen.queryByText('+/+')).toBeNull();
+    expect(screen.getByText('Choose...')).toBeDefined();
+  });
+
+  test('typed free-form value can be committed through the create option', async () => {
+    const onChange = vi.fn();
+    render(<Dropdown options={options} value="" isCreatable isSearchable onChange={onChange} />);
+
+    // CreatableSelect is lazy-loaded, wait for the input to appear
+    await waitFor(() => {
+      expect(document.querySelector('input[aria-autocomplete="list"]')).toBeTruthy();
+    });
+    const input = document.querySelector('input[aria-autocomplete="list"]')!;
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '+/+' } });
+
+    const createOption = await waitFor(() => {
+      const option = document.querySelector('.dropdown__option');
+      expect(option).toBeTruthy();
+      return option!;
+    });
+    expect(createOption.textContent).toContain('+/+');
+    fireEvent.click(createOption);
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ value: '+/+' }));
+  });
+
+  test('value present in options still resolves to its label', async () => {
+    render(<Dropdown options={options} value="wb-adc/A2" isCreatable isSearchable onChange={vi.fn()} />);
+    expect(await screen.findByText('A2 [wb-adc/A2]')).toBeDefined();
+  });
+
+  test('multiselect displays values missing from options instead of dropping them', async () => {
+    render(
+      <Dropdown
+        options={options}
+        value={['wb-adc/A1', '+/+']}
+        multiselect
+        isCreatable
+        isSearchable
+        onChange={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText('A1 [wb-adc/A1]')).toBeDefined();
+    expect(await screen.findByText('+/+')).toBeDefined();
+  });
+
+  test('multiselect without isCreatable still drops values missing from options', async () => {
+    render(
+      <Dropdown
+        options={options}
+        value={['wb-adc/A1', '+/+']}
+        multiselect
+        isSearchable
+        onChange={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText('A1 [wb-adc/A1]')).toBeDefined();
+    expect(screen.queryByText('+/+')).toBeNull();
+  });
+});

--- a/frontend/src/components/dropdown/dropdown.test.tsx
+++ b/frontend/src/components/dropdown/dropdown.test.tsx
@@ -118,6 +118,12 @@ describe('Dropdown', () => {
     expect(await screen.findByText('Nothing here')).toBeDefined();
   });
 
+  test('shows the default empty-search message when noOptionsMessage is not given', async () => {
+    render(<Dropdown options={[]} value={null} isSearchable onChange={vi.fn()} />);
+    fireEvent.mouseDown(document.querySelector('.dropdown__control')!);
+    expect(await screen.findByText('common.labels.empty-search')).toBeDefined();
+  });
+
   test('uses placeholder as aria-label fallback', () => {
     render(<Dropdown options={options} value="a" placeholder="Select..." onChange={vi.fn()} />);
     const input = document.querySelector('[aria-label="Select..."]');

--- a/frontend/src/components/dropdown/dropdown.tsx
+++ b/frontend/src/components/dropdown/dropdown.tsx
@@ -94,14 +94,6 @@ const MenuPortal = (props: any, size: DropdownProps['size']) => (
   <components.MenuPortal{...props} className={getClassNames(props.className, size)} />
 );
 
-const NoOptionsMessage = (props: any, message: string = '') => {
-  return (
-    <components.NoOptionsMessage {...props}>
-      <span className="custom-css-class">{message}</span>
-    </components.NoOptionsMessage>
-  );
-};
-
 export const Dropdown = ({
   id,
   options,
@@ -119,6 +111,8 @@ export const Dropdown = ({
   noOptionsMessage,
   isButton,
   isCreatable,
+  createOptionPosition,
+  isValidNewOption,
   formatCreateLabel,
   minWidth = '150px',
   menuPortal = true,
@@ -171,7 +165,16 @@ export const Dropdown = ({
         return undefined;
       }
       const values = Array.isArray(value) ? value : [value];
+      // a creatable dropdown takes arbitrary values, so one missing from options must still show
+      if (isCreatable) {
+        return values
+          .filter((item) => item !== undefined && item !== null && item !== '')
+          .map((item) => findOption(options, item) ?? { value: item, label: String(item) });
+      }
       return values.map((item) => findOption(options, item)).filter(Boolean);
+    }
+    if (isCreatable && value !== undefined && value !== null && value !== '') {
+      return findOption(options, value) ?? { value, label: String(value) };
     }
     return findOption(options, value) ?? null;
   };
@@ -202,7 +205,6 @@ export const Dropdown = ({
     components: {
       MenuPortal: (props: any) => MenuPortal({ ...props, className }, size),
       DropdownIndicator: (props: any) => DropdownIndicator(props, isButton),
-      NoOptionsMessage: (props: any) => NoOptionsMessage(props, noOptionsMessage),
       Placeholder: (props: any) => Placeholder(props),
       SingleValue: (props: any) => SingleValue(props),
     },
@@ -229,7 +231,7 @@ export const Dropdown = ({
       );
     },
     tabSelectsValue: false,
-    noOptionsMessage: () => t('common.labels.empty-search'),
+    noOptionsMessage: () => noOptionsMessage || t('common.labels.empty-search'),
     unstyled: true,
     onMenuOpen: () => {
       setIsMenuOpen(true);
@@ -249,6 +251,8 @@ export const Dropdown = ({
     onChange: handleChange,
     ...(isCreatable && {
       formatCreateLabel: formatCreateLabel ?? ((inputValue: string) => `${t('common.buttons.add')} "${inputValue}"`),
+      createOptionPosition,
+      isValidNewOption,
     }),
   };
 

--- a/frontend/src/components/dropdown/types.ts
+++ b/frontend/src/components/dropdown/types.ts
@@ -27,5 +27,7 @@ export interface DropdownProps<T = string | boolean | number | null | string[]> 
   captureMenuScroll?: boolean;
   isLoading?: boolean;
   isCreatable?: boolean;
+  createOptionPosition?: 'first' | 'last';
+  isValidNewOption?: (_inputValue: string, _selectValue: Option<T>[]) => boolean;
   formatCreateLabel?: (_inputValue: string) => string;
 }

--- a/frontend/src/components/json-editor/extensions/autocomplete.js
+++ b/frontend/src/components/json-editor/extensions/autocomplete.js
@@ -3,6 +3,23 @@ import { createElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Dropdown } from '@/components/dropdown';
 
+// wb-mqtt-db matches a pattern as one whole segment of device/control replaced by +, nothing else.
+const CHANNEL_PATTERN = /^(?:\+\/(?:\+|[^/+#]+)|[^/+#]+\/\+)$/;
+
+// Patterns are never in the topics list, so ask the schema itself instead of listing the schemas
+// that take them — fields addressing one control forbid + by their own pattern, read-only ones
+// are filled by their service.
+const acceptsChannelPatterns = (schema) => {
+  if (schema.readOnly || schema.readonly) {
+    return false;
+  }
+  if (!schema.pattern) {
+    return true;
+  }
+  const accepted = new RegExp(schema.pattern);
+  return ['+/+', '+/control', 'device/+'].some((probe) => accepted.test(probe));
+};
+
 export function makeAutocompleteEditor(topics) {
   return class extends JSONEditor.AbstractEditor {
     build() {
@@ -26,6 +43,7 @@ export function makeAutocompleteEditor(topics) {
       }
 
       this.control.controlgroup = formControl;
+      this.takesChannelPatterns = acceptsChannelPatterns(this.schema);
 
       this.render();
     }
@@ -42,6 +60,16 @@ export function makeAutocompleteEditor(topics) {
       }
     }
 
+    // The create option sits first and takes the focus, so a half-typed channel must keep leading
+    // to a real one instead of being committed literally.
+    _isValidNewOption(inputValue, selectValue) {
+      const typed = inputValue || '';
+      if (!CHANNEL_PATTERN.test(typed)) {
+        return false;
+      }
+      return !selectValue.some((option) => String(option.value) === typed);
+    }
+
     render() {
       if (!this.reactRoot) {
         this.reactRoot = createRoot(this.control);
@@ -53,6 +81,11 @@ export function makeAutocompleteEditor(topics) {
           value: this.value,
           isSearchable: true,
           isClearable: true,
+          ...(this.takesChannelPatterns && {
+            isCreatable: true,
+            createOptionPosition: 'first',
+            isValidNewOption: (inputValue, selectValue) => this._isValidNewOption(inputValue, selectValue),
+          }),
           onChange: (option) => {
             this.setValue(option?.value || '');
             this.onChange(true);

--- a/frontend/src/components/json-editor/extensions/autocomplete.test.js
+++ b/frontend/src/components/json-editor/extensions/autocomplete.test.js
@@ -1,0 +1,201 @@
+// @vitest-environment happy-dom
+import { fireEvent, waitFor } from '@testing-library/react';
+import { createJSONEditor } from './wb-json-editor';
+
+// mirrors the channels field of wb-mqtt-db.schema.json — no pattern of its own, +/+ is valid there
+const historySchema = {
+  type: 'object',
+  properties: {
+    channels: {
+      type: 'array',
+      format: 'table',
+      items: {
+        type: 'string',
+        title: 'Channel pattern',
+        minLength: 3,
+        format: 'wb-autocomplete',
+        options: {
+          wb: { data: 'devices' },
+        },
+      },
+    },
+  },
+  required: ['channels'],
+};
+
+// mirrors a field addressing one control — wb-scenarios, alarms and waterius forbid + themselves
+const singleControlSchema = {
+  type: 'object',
+  properties: {
+    channels: {
+      type: 'array',
+      format: 'table',
+      items: {
+        type: 'string',
+        title: 'Control',
+        minLength: 3,
+        pattern: '^[^/+#]+/[^/+#]+$',
+        format: 'wb-autocomplete',
+        options: {
+          patternmessage: 'Invalid format',
+          wb: { data: 'devices' },
+        },
+      },
+    },
+  },
+  required: ['channels'],
+};
+
+// mirrors the topic field of wb-mqtt-opcua and wb-mqtt-iec104 — no pattern, but filled by the service
+const readonlySchema = {
+  type: 'object',
+  properties: {
+    channels: {
+      type: 'array',
+      format: 'table',
+      items: {
+        type: 'string',
+        title: 'MQTT device and control',
+        readonly: true,
+        format: 'wb-autocomplete',
+        options: {
+          wb: { data: 'devices' },
+        },
+      },
+    },
+  },
+  required: ['channels'],
+};
+
+const topics = [
+  {
+    label: 'wb-adc',
+    options: [
+      { value: 'wb-adc/A1', label: 'A1 [wb-adc/A1]' },
+      { value: 'wb-adc/A2', label: 'A2 [wb-adc/A2]' },
+    ],
+  },
+];
+
+const buildEditor = async (value, schema = historySchema) => {
+  const element = document.createElement('div');
+  document.body.appendChild(element);
+  const editor = createJSONEditor(element, schema, value, 'en', 'root', topics);
+  await new Promise((resolve) => editor.on('ready', resolve));
+  return { editor, element };
+};
+
+const typeInto = async (element, text) => {
+  const input = await waitFor(() => {
+    const el = element.querySelector('input[aria-autocomplete="list"]');
+    expect(el).toBeTruthy();
+    return el;
+  });
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value: text } });
+  await waitFor(() => {
+    expect(document.querySelector('.dropdown__menu')).toBeTruthy();
+  });
+};
+
+const menuOptions = () => [...document.querySelectorAll('.dropdown__option')].map((o) => o.textContent);
+
+describe('wb-autocomplete editor in a schema that takes channel patterns', () => {
+  test('a wildcard value from the config stays in the editor state and is shown in the field', async () => {
+    const { editor, element } = await buildEditor({ channels: ['+/+'] });
+
+    expect(editor.getValue().channels).toEqual(['+/+']);
+    expect(editor.validate()).toEqual([]);
+
+    const cell = element.querySelector('[data-schemapath="root.channels.0"]');
+    await waitFor(() => {
+      expect(cell.textContent).toContain('+/+');
+    });
+
+    editor.destroy();
+  });
+
+  test('the value survives a new row being added', async () => {
+    const { editor } = await buildEditor({ channels: ['+/+'] });
+
+    editor.getEditor('root.channels').add_row_button.click();
+
+    expect(editor.getValue().channels[0]).toBe('+/+');
+
+    editor.destroy();
+  });
+
+  test.each([['+/+'], ['+/Temperature'], ['wb-adc/+']])(
+    'the pattern %s is offered as the first option and commits to the config',
+    async (pattern) => {
+      const { editor, element } = await buildEditor({ channels: ['wb-adc/A1'] });
+
+      await typeInto(element, pattern);
+
+      const options = menuOptions();
+      expect(options[0]).toContain('common.buttons.add');
+      expect(options[0]).toContain(pattern);
+
+      fireEvent.click(document.querySelectorAll('.dropdown__option')[0]);
+
+      await waitFor(() => {
+        expect(editor.getValue().channels).toEqual([pattern]);
+      });
+
+      editor.destroy();
+    },
+  );
+
+  test('a half-typed real channel is not offered as typed, the suggestions stay', async () => {
+    const { element } = await buildEditor({ channels: ['+/+'] });
+
+    await typeInto(element, 'wb-adc/A');
+
+    expect(menuOptions()).toEqual(['A1 [wb-adc/A1]', 'A2 [wb-adc/A2]']);
+  });
+
+  test.each([['wb-adc/A9'], ['nonsense'], ['+'], ['wb-adc/+/A1'], ['wb-adc/#'], ['#/A1']])(
+    'the value %s is neither a channel nor a pattern, so the menu offers nothing at all',
+    async (typed) => {
+      const { element } = await buildEditor({ channels: ['+/+'] });
+
+      await typeInto(element, typed);
+
+      expect(menuOptions()).toEqual([]);
+    },
+  );
+});
+
+describe('wb-autocomplete editor in a schema that forbids channel patterns', () => {
+  test('the field stays a strict select and a wildcard cannot be typed in', async () => {
+    const { element } = await buildEditor({ channels: ['wb-adc/A1'] }, singleControlSchema);
+
+    await typeInto(element, '+/+');
+
+    expect(menuOptions()).toEqual([]);
+  });
+
+  test('a read-only field takes nothing typed in either, although it has no pattern', async () => {
+    const { element } = await buildEditor({ channels: ['wb-adc/A1'] }, readonlySchema);
+
+    await typeInto(element, '+/+');
+
+    expect(menuOptions()).toEqual([]);
+  });
+
+  test('a wildcard already in the config is reported as invalid instead of being shown', async () => {
+    const { editor, element } = await buildEditor({ channels: ['+/+'] }, singleControlSchema);
+
+    expect(editor.validate()).toEqual([
+      expect.objectContaining({ path: 'root.channels.0', property: 'pattern' }),
+    ]);
+
+    const cell = element.querySelector('[data-schemapath="root.channels.0"]');
+    await waitFor(() => {
+      expect(cell.querySelector('.dropdown__control')).toBeTruthy();
+    });
+    expect(cell.textContent).not.toContain('+/+');
+
+    editor.destroy();
+  });
+});


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В конфиге «История данных MQTT» поле «Шаблон канала» группы с `+/+` выглядит пустым, вписать шаблон заново нельзя, а одно касание «пустого» поля молча подменяет шаблон первым конкретным каналом. Вернуть его можно только правкой JSON руками.

Регрессия с `bc5372f9` (2.198.0), где редактор `format: wb-autocomplete` переехал с datalist-инпута на react-select `Dropdown`. Тот умеет только выбирать из списка каналов контроллера, а шаблонов вида `+/+` в этом списке нет по своей природе.

1. **`json-editor/extensions/autocomplete.js`** — поле снова принимает шаблон с клавиатуры, но только там, где схема его допускает. Признак выводится из самой схемы, а не из списка известных конфигов: поля на один контрол (wb-scenarios, alarms, wb-mqtt-waterius) уже запрещают `+` своим `pattern`, а поле с `readonly` заполняет сервис. Принимается только форма `+/+`, `device/+` или `+/control`, так что опечатка в конфиг не попадёт.

2. **`components/dropdown/dropdown.tsx` и `types.ts`** — значение, которого нет в списке опций, у creatable-дропдауна теперь отображается вместо пустого поля, иначе ловушка с подменой остаётся и при разрешённом вводе. Добавлены пропы `createOptionPosition` и `isValidNewOption`, дефолты не менялись.

Сюда же вошёл независимый дефект, найденный по ходу. Кастомный `NoOptionsMessage` печатал проп `noOptionsMessage` и выбрасывал `props.children`, а react-select передаёт текст именно детьми. Проп не передавал ни один вызов из 31 файла с `<Dropdown`, поэтому вместо «Ничего не найдено» во всех дропдаунах рисовалось пустое окно, хотя перевод вычислялся. Обёртка удалена, текст ушёл в штатный `noOptionsMessage`.

___________________________________
**Что поменялось для пользователей:**

<img width="1640" height="663" alt="image" src="https://github.com/user-attachments/assets/b2eb47ef-b838-43d9-ad29-78d8d5dd1fcb" />
<img width="1137" height="167" alt="image" src="https://github.com/user-attachments/assets/1347d6a3-e56e-4ba1-88d2-7f3b3721a121" />
<img width="1179" height="242" alt="image" src="https://github.com/user-attachments/assets/90afa897-3fe3-4ef3-8e92-0cbb548053be" />

В «Истории данных MQTT» шаблон канала снова виден и вводится с клавиатуры — набранный предлагается первой строкой как «Добавить "+/+"», при наборе части имени канала список работает как обычный автокомплит.

Остальные конфиги с автокомплитом каналов не меняются, шаблон туда по-прежнему не ввести.

Любой дропдаун с поиском, ничего не найдя, пишет «Ничего не найдено» вместо пустого окна.

___________________________________
**Как проверял/а:**

`npm run check:types`, `npm run lint`, `npm test` без замечаний.

На контроллере: шаблон виден и сохраняется в `/etc/wb-mqtt-db.conf`, wb-mqtt-db работает без `Bad channel`, `wb-adc/+` предлагается, `wb-adc/#` и опечатка не предлагаются и дают «Ничего не найдено».

Проверил установкой пакета, все хорошо.