### PR TITLE
fix: show "no response" for DALI commands answered by silence

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.245.7) stable; urgency=medium
+
+  * Fix broken result of DALI manual commands for which the absence of a reply is itself
+    an answer: such commands now show "no response" plus the decoded value
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 12 Aug 2026 12:47:16 +0500
+
 wb-mqtt-homeui (2.245.6) stable; urgency=medium
 
   * Fix channel patterns like +/+ disappearing from MQTT history settings

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1072,6 +1072,7 @@
          "commands-placeholder": "One command per line.\nCtrl+Space — commands list\n\nFormat: Name(arg, ...)\nA<n> address 0–63, G<n> group, I<n> instance\nExamples: Off(A5),\n          DAPC(A5, 0xFE),\n          DT8.Activate",
          "commands-sent": "sent successfully",
          "commands-not-sent": "not sent",
+         "commands-no-response": "no response",
          "commands-truncated-warning": "Bus connection lost: response truncated",
          "commands-catalog-title": "Insert command",
          "commands-catalog-search": "Search commands…",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1101,6 +1101,7 @@
          "commands-placeholder": "По одной команде на строку.\nCtrl+Space — список команд\n\nФормат: Name(arg, ...)\nA<n> адрес 0–63, G<n> группа, I<n> instance\nПримеры: Off(A5),\n         DAPC(A5, 0xFE),\n         DT8.Activate",
          "commands-sent": "отправлено успешно",
          "commands-not-sent": "не отправлено",
+         "commands-no-response": "нет ответа",
          "commands-truncated-warning": "Связь с шиной потеряна: ответ обрезан",
          "commands-catalog-title": "Вставить команду",
          "commands-catalog-search": "Поиск команд…",

--- a/frontend/src/pages/settings/configs/dali/components/bus-commands/commands-results.tsx
+++ b/frontend/src/pages/settings/configs/dali/components/bus-commands/commands-results.tsx
@@ -12,7 +12,11 @@ interface CommandsResultsProps {
 const formatResult = (row: ResultRow, t: (key: string) => string): string => {
   if (row.status === 'ok') {
     if (row.response) {
-      return `0x${row.response.raw.toString(16).toUpperCase()} (${row.response.value})`;
+      const { raw, value } = row.response;
+      if (raw === null || raw === undefined) {
+        return `${t('dali.labels.commands-no-response')} (${value})`;
+      }
+      return `0x${raw.toString(16).toUpperCase()} (${value})`;
     }
     return t('dali.labels.commands-sent');
   }

--- a/frontend/src/stores/dali/types.ts
+++ b/frontend/src/stores/dali/types.ts
@@ -160,7 +160,11 @@ export interface SendCommandParams {
 }
 
 export interface SendCommandResponseValue {
-  raw: number;
+  /**
+   * Absent or null for commands where the absence of a reply is itself an answer: there is no
+   * backward frame to show the raw bytes of, while `value` still holds the decoded answer.
+   */
+  raw?: number | null;
   value: string;
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В «Ручном вводе команд» на странице конфигурации DALI ответ RPC `SendCommand` может прийти без поля `raw` или с `raw: null`, при этом `value` заполнен: для части команд DALI отсутствие ответа на шине — само по себе ответ.

`formatResult` считал `raw` обязательным числом и звал `raw.toString(16)`, так что на таком ответе рендер таблицы результатов падал с `TypeError`. Error boundary в приложении нет, поэтому падение рендера уносит страницу целиком, а не одну строку результата.

1. **`stores/dali/types.ts`** — `SendCommandResponseValue.raw` стал необязательным (`number | null`), с комментарием про этот контракт: показывать нечего, потому что нет обратного пакета, а декодированный ответ лежит в `value`.

2. **`pages/settings/configs/dali/components/bus-commands/commands-results.tsx`** — при отсутствующем `raw` вместо hex выводится «нет ответа», `value` остаётся в скобках. Проверка явная (`null`/`undefined`), поэтому `raw: 0` — валидный обратный пакет — по-прежнему рисуется как `0x0`.

3. **`i18n/locales/{en,ru}.json`** — строка `commands-no-response`: «no response» / «нет ответа».

___________________________________
**Что поменялось для пользователей:**

Результат команды, на которую устройство не ответило, выглядит как `нет ответа (No)` — вместо белого экрана вместо всей страницы.

Остальные результаты не меняются: `0xFE (254)` для обычного ответа, «отправлено успешно» для команд без ответа, «не отправлено» и текст ошибки.

___________________________________
**Как проверял/а:**

`npm run check:types`, `npm run lint`, `npm test` — без замечаний.

На контроллере не проверял: нужна команда, на которую устройство отвечает молчанием.
