### PR TITLE
Fix response colours in the DALI bus monitor and raise its limit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-homeui (2.245.8) stable; urgency=medium
+
+  * Fix DALI bus monitor showing a reply that never arrived or arrived corrupted as a
+    successful value: "no response" and framing errors are now marked as errors
+  * Keep 2000 lines in the DALI bus monitor instead of 500
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 12 Aug 2026 15:31:07 +0500
+
 wb-mqtt-homeui (2.245.7) stable; urgency=medium
 
   * Fix broken result of DALI manual commands for which the absence of a reply is itself

--- a/frontend/src/stores/dali/monitor-store.test.ts
+++ b/frontend/src/stores/dali/monitor-store.test.ts
@@ -84,15 +84,15 @@ describe('MonitorStore', () => {
       expect(store.logs).toEqual(['msg1', 'msg2']);
     });
 
-    test('caps at 500 messages', () => {
+    test('caps at 2000 messages', () => {
       store.enableMonitoring('bus1');
       const handler = mqttClientMock.addStickySubscription.mock.calls[0][1];
-      for (let i = 0; i < 501; i++) {
+      for (let i = 0; i < 2001; i++) {
         handler({ payload: `msg${i}` });
       }
-      expect(store.logs).toHaveLength(500);
+      expect(store.logs).toHaveLength(2000);
       expect(store.logs[0]).toBe('msg1');
-      expect(store.logs[499]).toBe('msg500');
+      expect(store.logs[1999]).toBe('msg2000');
     });
   });
 });

--- a/frontend/src/stores/dali/monitor-store.ts
+++ b/frontend/src/stores/dali/monitor-store.ts
@@ -57,7 +57,7 @@ export class MonitorStore {
   }
 
   _subscribeToTopic() {
-    const MAX_MESSAGES = 500;
+    const MAX_MESSAGES = 2000;
     mqttClient.addStickySubscription(this.topic, ({ payload }) => {
       runInAction(() => {
         if (this.logs.length === MAX_MESSAGES) {

--- a/frontend/src/stores/dali/parse-bus-monitor-line.test.ts
+++ b/frontend/src/stores/dali/parse-bus-monitor-line.test.ts
@@ -19,6 +19,37 @@ describe('parseBusMonitorLine', () => {
     expect(f.response.kind).toBe('none');
   });
 
+  it('reads "no response" as an error, not as a hex + value pair', () => {
+    const f = parseBusMonitorLine('12:34:56.870 >> 0191 QueryControlGearPresent(A0) - no response');
+    expect(f.command).toBe('QueryControlGearPresent(A0)');
+    expect(f.response).toEqual({ kind: 'error', text: 'no response' });
+  });
+
+  it('keeps a frameless decoded answer whole instead of splitting it into hex and value', () => {
+    const f = parseBusMonitorLine('12:34:56.870 >> 0191 QueryControlGearPresent(A0) - False');
+    expect(f.response).toEqual({ kind: 'value', text: 'False', value: 'False' });
+  });
+
+  it('splits a multi-word decoded answer only after its backward-packet hex', () => {
+    const f = parseBusMonitorLine(
+      '22:26:26.266 >> 01202f FF24.F32.QueryFeedbackCapability(A0, I0) - 0001 visible feedback',
+    );
+    expect(f.command).toBe('FF24.F32.QueryFeedbackCapability(A0, I0)');
+    expect(f.response).toEqual({
+      kind: 'value', text: '0001 visible feedback', hex: '0001', value: 'visible feedback',
+    });
+  });
+
+  it('treats a corrupt reply as an error in either python-dali wording, not as a value', () => {
+    const parenthesised = parseBusMonitorLine('16:14:01.491 >> bb00 QueryShortAddress - 0000 (framing error)');
+    expect(parenthesised.response).toEqual({ kind: 'error', text: '0000 (framing error)' });
+
+    const bitmap = parseBusMonitorLine(
+      '16:14:01.491 >> a390 QueryStatus(A5) - 00ff response received with framing error',
+    );
+    expect(bitmap.response.kind).toBe('error');
+  });
+
   it('request with an error response', () => {
     const f = parseBusMonitorLine('12:34:56.950 >> a3fa QueryActualLevel(A5) - no power on bus');
     expect(f.command).toBe('QueryActualLevel(A5)');

--- a/frontend/src/stores/dali/parse-bus-monitor-line.ts
+++ b/frontend/src/stores/dali/parse-bus-monitor-line.ts
@@ -1,4 +1,4 @@
-import type { ParsedBusMonitorLine } from './types';
+import type { BusMonitorResponse, ParsedBusMonitorLine } from './types';
 
 /**
  * Closed set of gateway status texts that can appear in the response position.
@@ -19,6 +19,11 @@ const STATUS_TEXTS = [
 const TIME_RE = /^(\d{2}:\d{2}:\d{2}\.\d{3})\s+/;
 const DIR_RE = /^(>>|<<)\s*/;
 const HEX_RE = /^([0-9a-fA-F]+)\b\s*/;
+/** `{hex} {value}` of a backward packet ('00fe 254'); an answer with no frame has no hex half. */
+const RESPONSE_HEX_RE = /^([0-9a-fA-F]+)\s+(.+)$/;
+const NO_RESPONSE_TEXT = 'no response';
+/** A reply that arrived corrupt: python-dali reports it in the decode, not as a gateway status. */
+const FRAMING_ERROR_RE = /framing error/;
 const FROM_LUNATONE_RE = /\s*\(from lunatone\)\s*$/;
 const FC_RE = /\s*\(fc:\s*(\d+)\)\s*$/;
 
@@ -31,6 +36,17 @@ const trailingStatus = (text: string): string | null => {
     }
   }
   return found;
+};
+
+const parseResponse = (respText: string): BusMonitorResponse => {
+  if (STATUS_TEXTS.includes(respText) || respText === NO_RESPONSE_TEXT || FRAMING_ERROR_RE.test(respText)) {
+    return { kind: 'error', text: respText };
+  }
+  const withHex = respText.match(RESPONSE_HEX_RE);
+  if (withHex) {
+    return { kind: 'value', text: respText, hex: withHex[1], value: withHex[2].trim() };
+  }
+  return { kind: 'value', text: respText, value: respText };
 };
 
 /**
@@ -92,15 +108,7 @@ export const parseBusMonitorLine = (raw: string): ParsedBusMonitorLine => {
   const sepIdx = rest.indexOf(' - ');
   if (sepIdx !== -1) {
     result.command = rest.slice(0, sepIdx).trim();
-    const respText = rest.slice(sepIdx + 3).trim();
-    if (STATUS_TEXTS.includes(respText)) {
-      result.response = { kind: 'error', text: respText };
-    } else {
-      const sp = respText.indexOf(' ');
-      result.response = sp === -1
-        ? { kind: 'value', text: respText, value: respText }
-        : { kind: 'value', text: respText, hex: respText.slice(0, sp), value: respText.slice(sp + 1).trim() };
-    }
+    result.response = parseResponse(rest.slice(sepIdx + 3).trim());
     return result;
   }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В мониторе шины DALI половина строки после ` - ` резалась на hex и значение по первому пробелу.
У ответа без backward-кадра hex-половины нет, поэтому `no response` разрывался пополам: `no`
красился серым как hex, `response` — зелёным как значение.

По ходу выяснилось, что успешным значением показывались вообще все отказы, которых нет в таблице
статусов шлюза из README wb-mqtt-dali: сам `no response` и битый ответ, который python-dali
печатает как `0000 (framing error)` (числовой ответ) или `00ff response received with framing
error` (битовый).

Плюс буфер монитора в 500 строк маловат, когда разбираешь трафик.

___________________________________
**Что поменялось для пользователей:**

- `no response` и битый ответ в любой из трёх формулировок красятся как ошибка — красным и с фоном
  строки, наравне с `no power on bus`.
- Значение из нескольких слов (`0001 visible feedback`) по-прежнему делится на hex и расшифровку,
  а ответ без кадра больше не делится.
- Монитор держит 2000 строк вместо 500.

___________________________________
**Как проверял/а:**

Юнит-тесты: 4 новых случая на разбор строки (`no response`, обе формулировки framing error,
многословное значение) и обновлённый тест на лимит буфера. Полный прогон фронтенда — 188 файлов,
2407 тестов; `npm run check:types` и `npm run lint` чисто.
