### PR TITLE
Fix a needless login prompt when opening the controller over HTTP

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-mqtt-homeui (2.245.12) stable; urgency=medium
+
+  * Fix a needless login prompt when opening the controller over HTTP: the session was
+    checked before the redirect to HTTPS, on the host whose cookie does not apply
+  * Show the loader during the HTTPS check only if it takes longer than a second, and
+    name the certificate issuing separately from the check itself
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 18 Aug 2026 13:55:00 +0500
+
 wb-mqtt-homeui (2.245.10) stable; urgency=medium
 
   * Fix create first user logic

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -13,6 +13,7 @@
          "password-strength-4": "Strong password",
          "select-all": "Select all",
          "unselect-all": "Unselect all",
+         "checking-connection": "Checking the connection",
          "setting-up-https": "Setting up HTTPS",
          "columns": "Columns",
          "columns-auto": "Auto"

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -13,6 +13,7 @@
          "password-strength-4": "Надежный пароль",
          "select-all": "Выбрать все",
          "unselect-all": "Снять выделение",
+         "checking-connection": "Проверка соединения",
          "setting-up-https": "Настройка HTTPS",
          "columns": "Столбцы",
          "columns-auto": "Авто"

--- a/frontend/src/layouts/app/app.test.tsx
+++ b/frontend/src/layouts/app/app.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+import { render, screen } from '@testing-library/react';
+import type * as ReactRouterDom from 'react-router-dom';
+import { HttpsSetupPhase, uiStore } from '@/stores/ui';
+import { App } from './app';
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...await importOriginal<typeof ReactRouterDom>(),
+  RouterProvider: () => <div data-testid="router" />,
+}));
+
+describe('App', () => {
+  beforeEach(() => {
+    uiStore.setHttpsSetupPhase(HttpsSetupPhase.Checking);
+  });
+
+  it('names the connection check while it is unknown whether HTTPS is going to be set up', () => {
+    render(<App />);
+
+    expect(screen.getByText('common.labels.checking-connection')).toBeDefined();
+  });
+
+  it('names the HTTPS setup once a certificate is being issued', () => {
+    uiStore.setHttpsSetupPhase(HttpsSetupPhase.IssuingCertificate);
+
+    render(<App />);
+
+    expect(screen.getByText('common.labels.setting-up-https')).toBeDefined();
+  });
+
+  it('keeps the loader until both the HTTPS setup is done and the router is built', () => {
+    const router = {} as ReturnType<typeof ReactRouterDom.createHashRouter>;
+
+    const { rerender } = render(<App router={router} />);
+    expect(screen.queryByTestId('router')).toBeNull();
+
+    uiStore.setHttpsSetupPhase(HttpsSetupPhase.Done);
+    rerender(<App />);
+    expect(screen.queryByTestId('router')).toBeNull();
+
+    rerender(<App router={router} />);
+    expect(screen.getByTestId('router')).toBeDefined();
+  });
+});

--- a/frontend/src/layouts/app/app.tsx
+++ b/frontend/src/layouts/app/app.tsx
@@ -4,17 +4,21 @@ import { useTranslation } from 'react-i18next';
 import { RouterProvider } from 'react-router-dom';
 import { Loader } from '@/components/loader';
 import { SkipToContentButton } from '@/components/skip-to-content-button';
-import { uiStore } from '@/stores/ui';
+import { HttpsSetupPhase, uiStore } from '@/stores/ui';
 import { type AppProps } from './types';
 import './styles.css';
 
 export const App = observer(({ router }: AppProps) => {
   const { t } = useTranslation();
 
-  if (uiStore.isSettingUpHttps) {
+  if (uiStore.httpsSetupPhase !== HttpsSetupPhase.Done || !router) {
     return (
       <div className="app-loader">
-        <Loader caption={t('common.labels.setting-up-https')} />
+        <Loader
+          caption={uiStore.httpsSetupPhase === HttpsSetupPhase.IssuingCertificate
+            ? t('common.labels.setting-up-https')
+            : t('common.labels.checking-connection')}
+        />
         <div className="floating"></div>
       </div>
     );

--- a/frontend/src/layouts/app/styles.css
+++ b/frontend/src/layouts/app/styles.css
@@ -1,6 +1,11 @@
+/* The checks before the app starts normally take ~0.2 s, so the loader is delayed by a second and
+   becomes visible only when something really takes long: a certificate being issued, a slow
+   redirect to the https host, or a slow device */
 .app-loader {
     display: flex;
     justify-content: center;
     align-items: center;
     height: 100dvh;
+    opacity: 0;
+    animation: appear-overlay 150ms ease-in 1s forwards;
 }

--- a/frontend/src/layouts/app/types.ts
+++ b/frontend/src/layouts/app/types.ts
@@ -1,5 +1,6 @@
 import { type createHashRouter } from 'react-router-dom';
 
 export interface AppProps {
-  router: ReturnType<typeof createHashRouter>;
+  // Absent until the HTTPS check is done — the router is created only when we stay on this origin
+  router?: ReturnType<typeof createHashRouter>;
 }

--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+import type * as ReactRouterDom from 'react-router-dom';
+import { HttpsSetupPhase } from '@/stores/ui';
+import * as HttpsUtils from '@/utils/https-utils';
+
+const { CertificateStatus, findHttpsRedirectTarget, switchToHttps } = HttpsUtils;
+
+vi.mock('@/utils/https-utils', async (importOriginal) => ({
+  ...await importOriginal<typeof HttpsUtils>(),
+  findHttpsRedirectTarget: vi.fn(),
+  switchToHttps: vi.fn(),
+}));
+vi.mock('@/common/constants', () => ({ APP_NAME: 'TestApp', APP_SHORT_NAME: 'Test', LOGO: '/logo.png' }));
+
+// Only the boot order is under test here, so the heavy parts of the graph are cut away. The app must
+// never finish connecting, otherwise the boot goes on loading dashboards behind the tests.
+vi.mock('@/router/routes', () => ({ routes: [] }));
+vi.mock('@/services', async () => {
+  const services = await import('@/test/mocks/services');
+  return { ...services, mqttClient: { ...services.mqttClient, whenConnected: () => new Promise(() => {}) } };
+});
+
+const renderMock = vi.fn();
+vi.mock('react-dom/client', () => ({ createRoot: () => ({ render: renderMock }) }));
+
+const createHashRouterMock = vi.fn(() => ({ id: 'router' }));
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...await importOriginal<typeof ReactRouterDom>(),
+  createHashRouter: createHashRouterMock,
+  RouterProvider: () => null,
+}));
+
+type PageShowListener = (event: Event) => void;
+
+// The router must not exist while the HTTPS switch is deciding: createHashRouter() initialises the
+// router immediately, which runs authGuard and checks the session cookie of the host we may leave.
+describe('bootstrap: router creation is gated by the HTTPS switch', () => {
+  const findTargetMock = vi.mocked(findHttpsRedirectTarget);
+  const switchToHttpsMock = vi.mocked(switchToHttps);
+  const device = { sn: 'AQC4C7XN', https_cert: CertificateStatus.VALID } as HttpsUtils.DeviceInfo;
+
+  // Every boot re-imports the app, so the ui store has to be taken from that same fresh module graph
+  const boot = async () => {
+    await import('@/main');
+    const { uiStore } = await import('@/stores/ui');
+    return uiStore;
+  };
+
+  const lastRenderedRouter = () => renderMock.mock.lastCall?.[0]?.props?.router;
+
+  // Every boot registers its own pageshow listener on the window shared by the whole file, so the
+  // ones left by previous boots have to go — otherwise they answer events meant for this test
+  const pageShowListeners: PageShowListener[] = [];
+  const addEventListener = window.addEventListener.bind(window);
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    switchToHttpsMock.mockResolvedValue(true);
+    pageShowListeners.splice(0).forEach((listener) => window.removeEventListener('pageshow', listener));
+    vi.spyOn(window, 'addEventListener').mockImplementation((type, listener, options) => {
+      if (type === 'pageshow') {
+        pageShowListeners.push(listener as PageShowListener);
+      }
+      addEventListener(type, listener as PageShowListener, options);
+    });
+  });
+
+  it('renders the loader without a router while the device is being looked up', async () => {
+    findTargetMock.mockReturnValue(new Promise(() => {}));
+
+    const uiStore = await boot();
+
+    expect(createHashRouterMock).not.toHaveBeenCalled();
+    expect(renderMock).toHaveBeenCalledTimes(1);
+    expect(lastRenderedRouter()).toBeUndefined();
+    expect(uiStore.httpsSetupPhase).toBe(HttpsSetupPhase.Checking);
+  });
+
+  it('creates the router when there is no device to switch to', async () => {
+    findTargetMock.mockResolvedValue(null);
+
+    const uiStore = await boot();
+
+    await vi.waitFor(() => expect(createHashRouterMock).toHaveBeenCalledTimes(1));
+    expect(switchToHttpsMock).not.toHaveBeenCalled();
+    expect(lastRenderedRouter()).toEqual({ id: 'router' });
+    expect(uiStore.httpsSetupPhase).toBe(HttpsSetupPhase.Done);
+  });
+
+  it('never creates the router when a redirect to another host has started', async () => {
+    findTargetMock.mockResolvedValue(device);
+
+    const uiStore = await boot();
+
+    await vi.waitFor(() => expect(switchToHttpsMock).toHaveBeenCalledWith(device));
+    expect(createHashRouterMock).not.toHaveBeenCalled();
+    expect(renderMock).toHaveBeenCalledTimes(1);
+    expect(uiStore.httpsSetupPhase).toBe(HttpsSetupPhase.Checking);
+  });
+
+  it('names the HTTPS setup in the loader while a certificate is being issued', async () => {
+    findTargetMock.mockResolvedValue({ ...device, https_cert: CertificateStatus.REQUESTING });
+    switchToHttpsMock.mockReturnValue(new Promise(() => {}));
+
+    const uiStore = await boot();
+
+    await vi.waitFor(() => expect(uiStore.httpsSetupPhase).toBe(HttpsSetupPhase.IssuingCertificate));
+    expect(createHashRouterMock).not.toHaveBeenCalled();
+  });
+
+  it('creates the router when the switch gives up, e.g. no certificate was issued', async () => {
+    findTargetMock.mockResolvedValue({ ...device, https_cert: CertificateStatus.UNAVAILABLE });
+    switchToHttpsMock.mockResolvedValue(false);
+
+    const uiStore = await boot();
+
+    await vi.waitFor(() => expect(createHashRouterMock).toHaveBeenCalledTimes(1));
+    expect(lastRenderedRouter()).toEqual({ id: 'router' });
+    expect(uiStore.httpsSetupPhase).toBe(HttpsSetupPhase.Done);
+  });
+
+  it('runs the app here when the page comes back from the bfcache after a started redirect', async () => {
+    findTargetMock.mockResolvedValue(device);
+
+    const uiStore = await boot();
+    await vi.waitFor(() => expect(switchToHttpsMock).toHaveBeenCalled());
+    expect(createHashRouterMock).not.toHaveBeenCalled();
+
+    // The target host did not work out — the user is back on this one
+    window.dispatchEvent(Object.assign(new Event('pageshow'), { persisted: true }));
+
+    expect(createHashRouterMock).toHaveBeenCalledTimes(1);
+    expect(uiStore.httpsSetupPhase).toBe(HttpsSetupPhase.Done);
+  });
+
+  it('leaves an already booted page alone when it comes back from the bfcache', async () => {
+    findTargetMock.mockResolvedValue(null);
+
+    await boot();
+    await vi.waitFor(() => expect(createHashRouterMock).toHaveBeenCalledTimes(1));
+    window.dispatchEvent(Object.assign(new Event('pageshow'), { persisted: true }));
+
+    expect(createHashRouterMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an ordinary page load, which fires pageshow without persisted', async () => {
+    findTargetMock.mockReturnValue(new Promise(() => {}));
+
+    await boot();
+    window.dispatchEvent(new Event('pageshow'));
+
+    expect(createHashRouterMock).not.toHaveBeenCalled();
+  });
+
+  it('creates the router when looking the device up fails', async () => {
+    findTargetMock.mockRejectedValue(new Error('device info is unreachable'));
+
+    const uiStore = await boot();
+
+    await vi.waitFor(() => expect(createHashRouterMock).toHaveBeenCalledTimes(1));
+    expect(uiStore.httpsSetupPhase).toBe(HttpsSetupPhase.Done);
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import { autorun, runInAction, when } from 'mobx';
+import { autorun, when } from 'mobx';
 import { createRoot } from 'react-dom/client';
 import { createHashRouter } from 'react-router-dom';
 import { APP_NAME, APP_SHORT_NAME } from '@/common/constants';
@@ -9,8 +9,8 @@ import { authStore, UserRole } from '@/stores/auth';
 import { daliGlobalStore } from '@/stores/dali';
 import { dashboardsStore } from '@/stores/dashboards';
 import { registerRulesTab, rulesStore } from '@/stores/rules';
-import { uiStore } from '@/stores/ui';
-import { switchToHttps } from '@/utils/https-utils';
+import { HttpsSetupPhase, uiStore } from '@/stores/ui';
+import { CertificateStatus, findHttpsRedirectTarget, switchToHttps } from '@/utils/https-utils';
 import { routes } from './router/routes';
 import './i18n/config';
 import 'glyphicons-only-bootstrap/css/bootstrap.min.css';
@@ -22,10 +22,51 @@ window.addEventListener('vite:preloadError', () => {
   window.location.reload();
 });
 
-switchToHttps().finally(() => {
-  runInAction(() => {
-    uiStore.isSettingUpHttps = false;
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);
+
+// createHashRouter() runs authGuard at once, so build the router only if we stay on this host:
+// the session cookie is host-bound, and the switch usually sends us to another hostname.
+let isAppStarted = false;
+const startApp = () => {
+  if (isAppStarted) {
+    return;
+  }
+  isAppStarted = true;
+  uiStore.setHttpsSetupPhase(HttpsSetupPhase.Done);
+  root.render(<App router={createHashRouter(routes)} />);
+};
+
+findHttpsRedirectTarget()
+  .then((deviceInfo) => {
+    if (!deviceInfo) {
+      return false;
+    }
+    if (deviceInfo.https_cert !== CertificateStatus.VALID) {
+      // Issuing a certificate takes minutes, and that is what the loader has to talk about
+      uiStore.setHttpsSetupPhase(HttpsSetupPhase.IssuingCertificate);
+    }
+    return switchToHttps(deviceInfo);
+  })
+  .catch((err) => {
+    console.warn('Failed to switch to HTTPS', err);
+    return false;
+  })
+  .then((isRedirectingToHttps) => {
+    if (!isRedirectingToHttps) {
+      startApp();
+    }
+  })
+  .catch((err) => {
+    console.error('Failed to start the app', err);
   });
+
+// A started redirect leaves this page alive with no router. Coming back to it means the target host
+// did not work out, so run the app here instead of restoring a dead loader from the bfcache.
+window.addEventListener('pageshow', (event) => {
+  if (event.persisted) {
+    startApp();
+  }
 });
 
 let connectToMqtt = true;
@@ -70,9 +111,3 @@ mqttClient.whenConnected().then(async () => {
     return deviceManagerProxy.Stop().catch(() => {});
   }
 });
-
-const router = createHashRouter(routes);
-
-createRoot(document.getElementById('root')).render(
-  <App router={router} />,
-);

--- a/frontend/src/stores/ui/types.ts
+++ b/frontend/src/stores/ui/types.ts
@@ -28,6 +28,15 @@ export interface CustomMenuItem {
   children?: CustomMenuItem[];
 }
 
+export enum HttpsSetupPhase {
+  // Deciding whether there is an HTTPS site to move to — normally a matter of milliseconds
+  Checking = 'checking',
+  // Waiting for a certificate to be issued for the device, which takes minutes
+  IssuingCertificate = 'issuing-certificate',
+  // Nothing left to wait for: we stay on this host, so the app can start
+  Done = 'done',
+}
+
 export enum Theme {
   Light = 'light',
   Dark = 'dark',

--- a/frontend/src/stores/ui/ui-store.ts
+++ b/frontend/src/stores/ui/ui-store.ts
@@ -4,11 +4,11 @@ import { authStore } from '@/stores/auth';
 import type { Dashboard } from '@/stores/dashboards';
 import { getMenu } from './api';
 import { getMenuItems, mergeMenuItems, normalizeMenuResponse, toMenuItemInstance } from './menu-items';
-import { type CustomMenuItem, type MenuItemInstance, Theme } from './types';
+import { type CustomMenuItem, HttpsSetupPhase, type MenuItemInstance, Theme } from './types';
 
 export default class UiStore {
   public isConnected = false;
-  public isSettingUpHttps = true;
+  public httpsSetupPhase: HttpsSetupPhase = HttpsSetupPhase.Checking;
   public menuItems: MenuItemInstance[] = [];
   public theme: Theme = Object.values(Theme).includes(localStorage.getItem('theme') as Theme)
     ? localStorage.getItem('theme') as Theme
@@ -33,6 +33,10 @@ export default class UiStore {
     runInAction(() => {
       this.isConnected = isConnected;
     });
+  }
+
+  setHttpsSetupPhase(phase: HttpsSetupPhase) {
+    this.httpsSetupPhase = phase;
   }
 
   async buildMenu(dashboards: Dashboard[], isShowWidgetsPage: boolean, params: URLSearchParams) {

--- a/frontend/src/utils/https-utils.test.ts
+++ b/frontend/src/utils/https-utils.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+import { requestMock } from '@/test/mocks/request';
+import { CertificateStatus, type DeviceInfo, findHttpsRedirectTarget, switchToHttps } from './https-utils';
+
+vi.mock('@/utils/request', () => import('@/test/mocks/request'));
+
+const device: DeviceInfo = {
+  sn: 'AQC4C7XN',
+  ip: '192.168.1.10',
+  https_cert: CertificateStatus.VALID,
+  release_suite: 'stable',
+  release_name: 'wb-2404',
+  rootfs_expanded: true,
+} as DeviceInfo;
+
+// The dashed-IP domain the wildcard certificate is issued for
+const certificateOrigin = 'https://192-168-1-10.aqc4c7xn.ip.wirenboard.com';
+
+const setLocation = (href: string) => {
+  const { protocol, hostname, pathname, hash } = new URL(href);
+  vi.spyOn(window, 'location', 'get').mockReturnValue({
+    protocol, hostname, pathname, hash, href,
+  } as Location);
+};
+
+const answerWith = (responses: { https?: unknown; deviceInfo?: unknown }) => {
+  requestMock.get.mockImplementation((url: string) => {
+    if (url === '/api/https') {
+      return responses.https instanceof Error
+        ? Promise.reject(responses.https)
+        : Promise.resolve({ data: responses.https });
+    }
+    return responses.deviceInfo instanceof Error
+      ? Promise.reject(responses.deviceInfo)
+      : Promise.resolve({ data: responses.deviceInfo });
+  });
+};
+
+describe('findHttpsRedirectTarget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    answerWith({ https: { enabled: true }, deviceInfo: device });
+  });
+
+  it('finds the device when an IP address is opened over http and HTTPS is enabled', async () => {
+    setLocation('http://192.168.1.10/');
+
+    await expect(findHttpsRedirectTarget()).resolves.toEqual(device);
+  });
+
+  it('finds the device when a .local domain is opened', async () => {
+    setLocation('http://wirenboard-aqc4c7xn.local/');
+
+    await expect(findHttpsRedirectTarget()).resolves.toEqual(device);
+  });
+
+  it('has nothing to switch to when the page already speaks HTTPS', async () => {
+    setLocation('https://192.168.1.10/');
+
+    await expect(findHttpsRedirectTarget()).resolves.toBeNull();
+    expect(requestMock.get).not.toHaveBeenCalled();
+  });
+
+  it.each(['http://localhost:8080/', 'http://127.0.0.1:8080/'])('stays on the dev host %s', async (href) => {
+    setLocation(href);
+
+    await expect(findHttpsRedirectTarget()).resolves.toBeNull();
+    expect(requestMock.get).not.toHaveBeenCalled();
+  });
+
+  it('asks the device nothing when the hostname is neither an IP address nor a local domain', async () => {
+    setLocation('http://controller.example.com/');
+
+    await expect(findHttpsRedirectTarget()).resolves.toBeNull();
+    expect(requestMock.get).not.toHaveBeenCalled();
+  });
+
+  it('has nothing to switch to when HTTPS is disabled on the device', async () => {
+    setLocation('http://192.168.1.10/');
+    answerWith({ https: { enabled: false }, deviceInfo: device });
+
+    await expect(findHttpsRedirectTarget()).resolves.toBeNull();
+  });
+
+  it('has nothing to switch to when the device does not answer /device/info', async () => {
+    setLocation('http://192.168.1.10/');
+    answerWith({ https: { enabled: true }, deviceInfo: new Error('unreachable') });
+
+    await expect(findHttpsRedirectTarget()).resolves.toBeNull();
+  });
+
+  it('has nothing to switch to when the answer carries no sane serial number', async () => {
+    setLocation('http://192.168.1.10/');
+    answerWith({ https: { enabled: true }, deviceInfo: { ...device, sn: 'not a serial!' } });
+
+    await expect(findHttpsRedirectTarget()).resolves.toBeNull();
+  });
+
+  it('rejects when the HTTPS status request itself fails, leaving the decision to the caller', async () => {
+    setLocation('http://192.168.1.10/');
+    answerWith({ https: new Error('gateway is down'), deviceInfo: device });
+
+    await expect(findHttpsRedirectTarget()).rejects.toThrow('gateway is down');
+  });
+});
+
+describe('switchToHttps', () => {
+  const setHref = vi.fn();
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(window, 'location', 'get').mockReturnValue({
+      protocol: 'http:',
+      hostname: '192.168.1.10',
+      pathname: '/',
+      hash: '#/dashboards',
+      set href(value: string) {
+        setHref(value);
+      },
+    } as unknown as Location);
+  });
+
+  it('redirects to the certificate domain when the device answers there as itself', async () => {
+    fetchMock.mockResolvedValue({ status: 200, json: async () => ({ sn: device.sn }) });
+
+    await expect(switchToHttps(device)).resolves.toBe(true);
+    expect(setHref).toHaveBeenCalledWith(`${certificateOrigin}/#/dashboards`);
+  });
+
+  it('falls back to the current hostname when the certificate domain is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('no dns'));
+
+    await expect(switchToHttps(device)).resolves.toBe(true);
+    expect(setHref).toHaveBeenCalledWith('https://192.168.1.10/#/dashboards');
+  });
+
+  it('stays put when someone else answers on the certificate domain', async () => {
+    fetchMock.mockResolvedValue({ status: 200, json: async () => ({ sn: 'SOMEONEELSE' }) });
+
+    await expect(switchToHttps(device)).resolves.toBe(false);
+    expect(setHref).not.toHaveBeenCalled();
+  });
+
+  it('stays put when no certificate can be issued for the device', async () => {
+    requestMock.post.mockRejectedValue(new Error('no internet'));
+
+    await expect(switchToHttps({ ...device, https_cert: CertificateStatus.UNAVAILABLE })).resolves.toBe(false);
+    expect(requestMock.post).toHaveBeenCalledWith('/api/https/request_cert');
+    expect(setHref).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/https-utils.ts
+++ b/frontend/src/utils/https-utils.ts
@@ -13,7 +13,7 @@ export enum ReleaseSuite {
   Testing = 'testing',
 }
 
-interface DeviceInfo {
+export interface DeviceInfo {
   sn: string;
   ip: string;
   https_cert: CertificateStatus;
@@ -117,37 +117,45 @@ export function urlIsSwitchableToHttps(): boolean {
 }
 
 /**
- * Checks the current protocol and attempts to redirect to an HTTPS version of the site if applicable.
+ * Looks for a device this site can be switched to over HTTPS.
  *
- * If the current protocol is HTTPS or the hostname is a localhost or 127.0.0.1, the function returns false.
- * If the hostname is an IP address or a local domain, it fetches device information using both HTTP and HTTPS.
- * If the device information matches and certificate is valid, it redirects the browser to the HTTPS URL.
+ * There is nothing to switch to, and null is returned, when:
+ * - we already speak HTTPS, or the hostname is localhost / 127.0.0.1;
+ * - the hostname is neither an IP address nor a local domain;
+ * - HTTPS is disabled on the device;
+ * - the device does not answer /device/info or reports no sane serial number.
  *
- * @returns {Promise<boolean>} - A promise that resolves to true if a redirect to HTTPS was initiated, otherwise false.
+ * Otherwise the device is returned, and its certificate state tells whether the
+ * switch can happen right away — see switchToHttps().
  */
-export async function switchToHttps() {
+export async function findHttpsRedirectTarget(): Promise<DeviceInfo | null> {
   if (location.protocol === 'https:' || ['localhost', '127.0.0.1'].includes(location.hostname)) {
-    return false;
+    return null;
+  }
+
+  // Free and local, so it goes before the request — on a DNS hostname we ask the device nothing
+  if (!urlIsSwitchableToHttps()) {
+    return null;
   }
 
   if (!await isHttpsEnabled()) {
-    return false;
+    return null;
   }
 
-  if (!urlIsSwitchableToHttps()) {
-    return false;
-  }
-
-  let deviceInfo : DeviceInfo;
   try {
-    deviceInfo = await getDeviceInfo();
-    if (!isDeviceSn(deviceInfo.sn)) {
-      return false;
-    }
+    const deviceInfo = await getDeviceInfo();
+    return isDeviceSn(deviceInfo.sn) ? deviceInfo : null;
   } catch (e) {
-    return false;
+    return null;
   }
+}
 
+/**
+ * Redirects the browser to the HTTPS site, preferring the domain the certificate is issued for.
+ *
+ * @returns true when a redirect was started, false when we have to stay where we are.
+ */
+export async function switchToHttps(deviceInfo: DeviceInfo): Promise<boolean> {
   if (await hasInvalidCertificate(deviceInfo.https_cert)) {
     return false;
   }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

При заходе на `http://<ip>` интерфейс просил залогиниться, хотя сессия на https-хосте была валидна.

Причина: `createHashRouter()` в react-router 7 инициализирует роутер прямо при вызове, поэтому
`authGuard` уходил в `/auth/who_am_i` на http-origin параллельно с проверкой HTTPS, получал 401 и
ставил `#/login` — ещё до редиректа. Кука сессии host-only (бэкенд ставит её без `Domain`/`Secure`),
а редирект уводит на другое имя хоста (`<ip>.<sn>.ip.wirenboard.com`), так что проверять сессию до
редиректа бессмысленно.

Теперь лоадер рендерится сразу, а роутер создаётся только если проверка решила, что мы остаёмся на
этом хосте. `https-utils` разделён на «найти устройство, куда переходить» и «перейти», между этими
шагами `main.tsx` крутит состояние лоадера; сам модуль про UI по-прежнему ничего не знает.

___________________________________
**Что поменялось для пользователей:**

- Заход по http на контроллер с валидной сессией больше не приводит к форме логина.
- Лоадер при старте появляется только если ожидание реально затянулось (проверка занимает ~0.2 с),
  и подпись «Настройка HTTPS» показывается лишь когда действительно выпускается сертификат — иначе
  нейтральное «Проверка соединения».
- Возврат «назад» на страницу, с которой был редирект, поднимает интерфейс на этом же хосте вместо
  зависшего лоадера.

___________________________________
**Как проверял/а:**

- Живой контроллер (`10.200.200.1`, sn `AQC4C7XN`), трасса через CDP: до фикса на http-origin шёл
  `GET /auth/who_am_i` → 401 → `#/login` ещё до редиректа; после фикса на http-origin запроса сессии
  нет вовсе — только `/api/https`, `/device/info`, проба https-хоста и навигация.
- Локальный запуск (`localhost`) — приложение поднимается штатно, редирект не срабатывает.
- `npm run check:types`, `npm run lint`, `npm test` — 191 файл / 2439 тестов зелёные.
- Новые тесты: `main.test.tsx` (порядок загрузки, в т.ч. что роутер не создаётся при начатом
  редиректе), `https-utils.test.ts` (все ветки поиска устройства и перехода), `app.test.tsx`
  (подпись лоадера и удержание до появления роутера). Проверено мутациями: откат фикса их роняет.
