### PR TITLE
SOFT-7316

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.246.5) stable; urgency=medium
+
+  * Fix device card expanding on hover when the cell history icon appears
+  * Temporarily disable custom column layout when a device type filter is active
+
+ -- Victor Vedenin <victor.vedenin@struhe.com>  Thu, 20 Aug 2026 17:10:00 +0300
+
 wb-mqtt-homeui (2.246.4) stable; urgency=medium
 
   * Show the terminal on-screen key panel only on devices without a physical keyboard: it was

--- a/frontend/src/components/cell/cell.tsx
+++ b/frontend/src/components/cell/cell.tsx
@@ -79,7 +79,7 @@ export const CellContent = observer(({ cell, name, isCompact, isReadOnly, extra,
                 </Tooltip>
               </Suspense>
             )}
-            {name || cell.name}
+            <span className="deviceCell-nameText">{name || cell.name}</span>
 
             {cell.displayType === CellComponent.Range && !hideHistory && (
               <CellHistory cell={cell} />

--- a/frontend/src/components/cell/styles.css
+++ b/frontend/src/components/cell/styles.css
@@ -46,6 +46,11 @@
     justify-content: space-between;
     white-space: nowrap;
     overflow: hidden;
+    min-width: 0;
+}
+
+.deviceCell-nameText {
+    overflow: hidden;
     text-overflow: ellipsis;
 }
 

--- a/frontend/src/components/columns-wrapper/styles.css
+++ b/frontend/src/components/columns-wrapper/styles.css
@@ -11,6 +11,7 @@
 
 .columnsWrapper-column {
     width: 100%;
+    min-width: 0;
     display: flex;
     flex-direction: column;
 }

--- a/frontend/src/pages/devices/devices.tsx
+++ b/frontend/src/pages/devices/devices.tsx
@@ -204,11 +204,11 @@ const DevicesPage = observer(() => {
   }, [devicesStore.filteredDevices, actions]);
 
   const viewColumnItems = useMemo(() => {
-    if (!prefs.order) return undefined;
+    if (!prefs.order || typeFilter) return undefined;
     return reconcileOrder(displayedIds, prefs.order).map((col) =>
       col.map((id) => <Fragment key={id}>{renderDevice(id)}</Fragment>),
     );
-  }, [displayedIds, prefs.order, renderDevice]);
+  }, [displayedIds, prefs.order, typeFilter, renderDevice]);
 
   return (
     <PageLayout


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
при выборе фильтра в устройствах теперь применяется стандартная сортировка, чтобы избегать ситуаций с пустыми колонками
при ховере на ячейку устройства теперь карточка не разъезжается, а многоточится название устройства

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**
локально
