### PR TITLE
rules editor: the built-in fs module of wb-rules (typed require/import, module preserve)

### DIFF
--- a/frontend/scripts/generate-wb-rules-completions.mjs
+++ b/frontend/scripts/generate-wb-rules-completions.mjs
@@ -41,16 +41,36 @@ const snippetFor = (name, params) => {
   return `${name}(${args.join(', ')})`;
 };
 
+// Overloads of one function collapse into a single completion, described by
+// the first overload - unless that one is specialised on literal arguments,
+// such as require(id: "fs" | "node:fs") declared ahead of require(id: string):
+// the first general overload then makes the better detail. Only top-level
+// statements are walked, so the members of a `declare module "fs" { ... }`
+// block are not offered as globals.
+const isLiteralType = (t) =>
+  ts.isLiteralTypeNode(t) || (ts.isUnionTypeNode(t) && t.types.every(isLiteralType));
+const isLiteralSpecialization = (fn) =>
+  fn.parameters.length > 0 && fn.parameters.every((p) => p.type && isLiteralType(p.type));
+const overloadFor = new Map();
+for (const stmt of source.statements) {
+  if (!ts.isFunctionDeclaration(stmt) || !stmt.name) continue;
+  const current = overloadFor.get(stmt.name.text);
+  if (!current || (isLiteralSpecialization(current) && !isLiteralSpecialization(stmt))) {
+    overloadFor.set(stmt.name.text, stmt);
+  }
+}
+
 for (const stmt of source.statements) {
   if (ts.isFunctionDeclaration(stmt) && stmt.name) {
     const name = stmt.name.text;
-    if (seen.has(name)) continue; // keep the first overload only
+    if (seen.has(name)) continue; // one entry per function, placed at its first overload
     seen.add(name);
+    const fn = overloadFor.get(name);
     completions.push({
       label: name,
       type: 'function',
-      detail: signatureOf(stmt),
-      snippet: snippetFor(name, stmt.parameters),
+      detail: signatureOf(fn),
+      snippet: snippetFor(name, fn.parameters),
     });
   } else if (ts.isVariableStatement(stmt)) {
     for (const decl of stmt.declarationList.declarations) {

--- a/frontend/src/stores/rules/autocomplete/ts-language-service-fs.test.ts
+++ b/frontend/src/stores/rules/autocomplete/ts-language-service-fs.test.ts
@@ -1,0 +1,55 @@
+import { CompletionContext } from '@codemirror/autocomplete';
+import { EditorState } from '@codemirror/state';
+import { loadTsEditorSupport } from './ts-language-service';
+
+// The engine's built-in fs module (require("fs"), require("fs/promises") and
+// the node: aliases): wb-rules.d.ts declares the modules and types require()
+// of them through overloads ahead of the loose require(id: string): any. Rule
+// files are transpiled to CommonJS with esModuleInterop, so a default import
+// of the module works at runtime and the language service must accept it, as
+// the engine's own check does.
+describe('built-in fs module', () => {
+  // wb-rules.d.ts types require("fs") / require("fs/promises") through
+  // overloads declared ahead of the loose require(id: string): any, so the
+  // engine's own module is checked while every other module name stays any
+  it('types require("fs") and keeps other modules loose', async () => {
+    const content = [
+      'const fs = require("fs");',
+      'fs.readFileSync(1);', // line 2: the path must be a string
+      'fs.readFileSync("/etc/hostname");', // line 3: fine
+      'const m = require("some-unknown.mod");', // line 4: unknown module -> any
+      'm.anything(1);', // line 5: any flows freely
+      '',
+    ].join('\n');
+    const support = await loadTsEditorSupport('fs-require.ts', content);
+    expect(support.getDiagnostics().map((d) => d.line)).toEqual([2]);
+  }, 30000);
+
+  it('accepts namespace and default imports of fs and exports (esModuleInterop, as in the engine check)', async () => {
+    // the engine transpiles rule files to CommonJS with esModuleInterop, so a
+    // default import of the built-in module works at runtime; the language
+    // service mirrors the engine's --esModuleInterop, without which (on a
+    // TypeScript whose defaults differ) TS1192 "has no default export" appears
+    const content = [
+      'import * as fs from "fs";',
+      'import fsd from "fs";',
+      'export const x = fsd.readFileSync("/x");',
+      'export const y = fs.existsSync("/y");',
+      '',
+    ].join('\n');
+    const support = await loadTsEditorSupport('fs-import.ts', content);
+    expect(support.getDiagnostics()).toEqual([]);
+  }, 30000);
+
+  it('completes fs members after the dot', async () => {
+    const content = 'const fs = require("fs");\nfs.';
+    const support = await loadTsEditorSupport('fs-members.ts', content);
+    const state = EditorState.create({ doc: content, extensions: support.extensions });
+    const result = await support.completionSource(
+      new CompletionContext(state, state.doc.length, false),
+    );
+    const labels = (result?.options ?? []).map((o) => o.label);
+    expect(labels).toContain('readFileSync');
+    expect(labels).toContain('promises');
+  }, 30000);
+});

--- a/frontend/src/stores/rules/autocomplete/ts-language-service-fs.test.ts
+++ b/frontend/src/stores/rules/autocomplete/ts-language-service-fs.test.ts
@@ -41,6 +41,21 @@ describe('built-in fs module', () => {
     expect(support.getDiagnostics()).toEqual([]);
   }, 30000);
 
+  it('accepts the CommonJS import/export forms the transpiler emits (module preserve)', async () => {
+    // import x = require("m") and export = ... are what the engine's CommonJS
+    // output runs; --module esnext rejects them as TS1202/TS1203, so the check
+    // (and this service) uses --module preserve
+    const content = [
+      'import x = require("fs");',
+      'const s: string = x.readFileSync("/x");', // typed through the import too
+      'log.info(s);',
+      'export = x;',
+      '',
+    ].join('\n');
+    const support = await loadTsEditorSupport('fs-cjs-forms.ts', content);
+    expect(support.getDiagnostics()).toEqual([]);
+  }, 30000);
+
   it('completes fs members after the dot', async () => {
     const content = 'const fs = require("fs");\nfs.';
     const support = await loadTsEditorSupport('fs-members.ts', content);

--- a/frontend/src/stores/rules/autocomplete/ts-language-service.ts
+++ b/frontend/src/stores/rules/autocomplete/ts-language-service.ts
@@ -77,6 +77,12 @@ async function build(
     // to match the engine's on-controller check
     module: ts.ModuleKind.ESNext,
     moduleDetection: ts.ModuleDetectionKind.Force,
+    // the engine transpiles rule files to CommonJS with esModuleInterop, so a
+    // default import of a built-in module (import fs from "fs") works at
+    // runtime and its check passes --esModuleInterop; stated explicitly here
+    // (TypeScript 6 defaults it on) so the editor's verdict never depends on
+    // the bundled TypeScript's defaults
+    esModuleInterop: true,
   };
 
   const fsMap = new Map<string, string>();

--- a/frontend/src/stores/rules/autocomplete/ts-language-service.ts
+++ b/frontend/src/stores/rules/autocomplete/ts-language-service.ts
@@ -74,8 +74,11 @@ async function build(
     noEmit: true,
     // rule files may use top-level await (the engine wraps them in an async
     // function); TypeScript only allows it in a module, so force module mode
-    // to match the engine's on-controller check
-    module: ts.ModuleKind.ESNext,
+    // to match the engine's on-controller check. "preserve" rather than
+    // esnext: it also accepts the CommonJS forms the transpiler emits and
+    // runs - import x = require("m") and export = ... - which esnext rejects
+    // as TS1202/TS1203 syntax errors
+    module: ts.ModuleKind.Preserve,
     moduleDetection: ts.ModuleDetectionKind.Force,
     // the engine transpiles rule files to CommonJS with esModuleInterop, so a
     // default import of a built-in module (import fs from "fs") works at

--- a/frontend/src/stores/rules/autocomplete/wb-rules.d.ts
+++ b/frontend/src/stores/rules/autocomplete/wb-rules.d.ts
@@ -856,6 +856,9 @@ declare const module: {
   exports: Record<string, any>;
 };
 
+/** The built-in filesystem module (declared at the end of this file). */
+declare function require(id: "fs" | "node:fs"): typeof import("fs");
+declare function require(id: "fs/promises" | "node:fs/promises"): typeof import("fs/promises");
 declare function require(id: string): any;
 /**
  * wb-rules resolves `require("x.mod")` against its own module directories
@@ -873,3 +876,295 @@ declare const global: typeof globalThis;
 
 // CommonJS-style module surface available in every rule file
 declare var exports: Record<string, any>;
+
+// ---------------------------------------------------------------------------
+// Built-in module "fs" - require("fs"), require("fs/promises")
+// ---------------------------------------------------------------------------
+
+/**
+ * Node.js-shaped filesystem API provided by the engine itself.
+ *
+ * Differences from Node: files are read and written as UTF-8 strings (no
+ * Buffer, no other encoding); the asynchronous functions return promises
+ * instead of taking callbacks (`fs.readFile === fs.promises.readFile`);
+ * `exists()` has a promise form; `fs.watch()` takes its listener directly
+ * and returns an object with `close()`; `readFile` refuses files over 10 MiB.
+ * Paths are used as given (relative ones resolve against the engine
+ * process's working directory) with the engine's own privileges.
+ */
+declare module "fs" {
+  export type Encoding = "utf8" | "utf-8";
+  /** Node's file system flags (the `flag` option of writeFile/appendFile). */
+  export type OpenFlag = "r" | "r+" | "w" | "wx" | "w+" | "wx+" | "a" | "ax" | "a+" | "ax+";
+  /** A permission mode: an integer or an octal string such as "644". */
+  export type Mode = number | string;
+  /** A timestamp for utimes: seconds since the epoch, a numeric string or a Date. */
+  export type TimeLike = number | string | Date;
+
+  export interface ReadFileOptions {
+    encoding?: Encoding | null;
+    flag?: OpenFlag;
+  }
+  export interface WriteFileOptions {
+    encoding?: Encoding | null;
+    /** Mode of a newly created file (default 0o666, subject to umask). */
+    mode?: Mode;
+    /** Default "w" for writeFile, "a" for appendFile. */
+    flag?: OpenFlag;
+  }
+  export interface StatOptions {
+    /** BigInt stats are not supported. */
+    bigint?: false;
+    /** false: return undefined for a missing path instead of throwing ENOENT. */
+    throwIfNoEntry?: boolean;
+  }
+  export interface ReaddirOptions {
+    encoding?: Encoding | null;
+    /** true: Dirent objects instead of names. */
+    withFileTypes?: boolean;
+    /** true: descend into subdirectories (names come relative to path). */
+    recursive?: boolean;
+  }
+  export interface MkdirOptions {
+    /** true: create missing parents; the first directory created is returned. */
+    recursive?: boolean;
+    /** Default 0o777, subject to umask. */
+    mode?: Mode;
+  }
+  export interface RmOptions {
+    /** Remove directories and their contents. */
+    recursive?: boolean;
+    /** Ignore a missing path. */
+    force?: boolean;
+  }
+  export interface RmdirOptions {
+    /** @deprecated Node deprecated this spelling; use rm(path, { recursive: true }). */
+    recursive?: boolean;
+  }
+  export interface EncodingOptions {
+    encoding?: Encoding | null;
+  }
+  export interface WatchOptions {
+    persistent?: boolean;
+    /** Recursive watching is not supported. */
+    recursive?: false;
+    encoding?: Encoding | null;
+  }
+  export type WatchEventType = "rename" | "change";
+  /** filename is the changed entry (directory watch) or the watched file's base name. */
+  export type WatchListener = (eventType: WatchEventType, filename: string) => void;
+
+  /** Result of stat()/lstat(): the POSIX fields plus the type predicates. */
+  export class Stats {
+    private constructor();
+    dev: number;
+    ino: number;
+    /** File type and permission bits (compare with constants.S_IF*, mask 0o777). */
+    mode: number;
+    nlink: number;
+    uid: number;
+    gid: number;
+    rdev: number;
+    size: number;
+    blksize: number;
+    blocks: number;
+    atimeMs: number;
+    mtimeMs: number;
+    ctimeMs: number;
+    /** stat(2) has no birth time on Linux; this is ctime. */
+    birthtimeMs: number;
+    atime: Date;
+    mtime: Date;
+    ctime: Date;
+    birthtime: Date;
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isSymbolicLink(): boolean;
+    isBlockDevice(): boolean;
+    isCharacterDevice(): boolean;
+    isFIFO(): boolean;
+    isSocket(): boolean;
+  }
+
+  /** A directory entry from readdir(path, { withFileTypes: true }). */
+  export class Dirent {
+    private constructor();
+    name: string;
+    /** The directory this entry was read from. */
+    parentPath: string;
+    /** @deprecated Node's older name of parentPath. */
+    path: string;
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isSymbolicLink(): boolean;
+    isFIFO(): boolean;
+    isSocket(): boolean;
+    isCharacterDevice(): boolean;
+    isBlockDevice(): boolean;
+  }
+
+  /** Returned by watch(); close() stops the watcher (idempotent). */
+  export class FSWatcher {
+    private constructor();
+    close(): void;
+  }
+
+  export const constants: {
+    readonly F_OK: 0;
+    readonly R_OK: 4;
+    readonly W_OK: 2;
+    readonly X_OK: 1;
+    /** copyFile mode bit: fail if the destination exists. */
+    readonly COPYFILE_EXCL: 1;
+    readonly COPYFILE_FICLONE: 2;
+    readonly COPYFILE_FICLONE_FORCE: 4;
+    readonly S_IFMT: number;
+    readonly S_IFREG: number;
+    readonly S_IFDIR: number;
+    readonly S_IFCHR: number;
+    readonly S_IFBLK: number;
+    readonly S_IFIFO: number;
+    readonly S_IFLNK: number;
+    readonly S_IFSOCK: number;
+  };
+
+  // --- synchronous API: blocks the engine loop for the duration of the call
+
+  /** Reads a whole file as a UTF-8 string (at most 10 MiB). */
+  export function readFileSync(path: string, options?: ReadFileOptions | Encoding | null): string;
+  /** Writes data, creating or truncating the file (flag "w"); not atomic. */
+  export function writeFileSync(path: string, data: string, options?: WriteFileOptions | Encoding | null): void;
+  /** Appends data, creating the file if needed (flag "a"). */
+  export function appendFileSync(path: string, data: string, options?: WriteFileOptions | Encoding | null): void;
+  export function statSync(path: string, options: StatOptions & { throwIfNoEntry: false }): Stats | undefined;
+  export function statSync(path: string, options?: StatOptions): Stats;
+  /** Like statSync but does not follow a final symbolic link. */
+  export function lstatSync(path: string, options: StatOptions & { throwIfNoEntry: false }): Stats | undefined;
+  export function lstatSync(path: string, options?: StatOptions): Stats;
+  export function readdirSync(path: string, options: ReaddirOptions & { withFileTypes: true }): Dirent[];
+  export function readdirSync(path: string, options?: (ReaddirOptions & { withFileTypes?: false }) | Encoding | null): string[];
+  /** true if the path exists (follows symlinks); never throws. */
+  export function existsSync(path: string): boolean;
+  export function mkdirSync(path: string, options: MkdirOptions & { recursive: true }): string | undefined;
+  export function mkdirSync(path: string, options?: (MkdirOptions & { recursive?: false }) | Mode | null): void;
+  /** Removes an empty directory. */
+  export function rmdirSync(path: string, options?: RmdirOptions): void;
+  /** Removes a file, or a directory tree with { recursive: true }. */
+  export function rmSync(path: string, options?: RmOptions): void;
+  /** Removes a file (a directory fails with EISDIR). */
+  export function unlinkSync(path: string): void;
+  export function renameSync(oldPath: string, newPath: string): void;
+  /** Copies a file preserving its mode; mode: constants.COPYFILE_EXCL to refuse overwriting. */
+  export function copyFileSync(src: string, dest: string, mode?: number): void;
+  /** Throws unless the path is accessible for mode (constants.F_OK/R_OK/W_OK/X_OK, default F_OK). */
+  export function accessSync(path: string, mode?: number): void;
+  /** Resolves symbolic links and returns an absolute path. */
+  export function realpathSync(path: string, options?: EncodingOptions | Encoding | null): string;
+  /** Returns the target of a symbolic link. */
+  export function readlinkSync(path: string, options?: EncodingOptions | Encoding | null): string;
+  /** Creates a symbolic link at path pointing to target (type is ignored). */
+  export function symlinkSync(target: string, path: string, type?: string | null): void;
+  export function chmodSync(path: string, mode: Mode): void;
+  /** Creates a unique directory prefix + six random characters and returns its path. */
+  export function mkdtempSync(prefix: string, options?: EncodingOptions | Encoding | null): string;
+  export function truncateSync(path: string, len?: number | null): void;
+  export function utimesSync(path: string, atime: TimeLike, mtime: TimeLike): void;
+
+  /**
+   * Watches a file or a directory (not recursive). The listener runs on the
+   * engine loop; the watcher is closed automatically when the rule file is
+   * reloaded or removed, and when the watched path itself disappears.
+   */
+  export function watch(filename: string, listener: WatchListener): FSWatcher;
+  export function watch(
+    filename: string,
+    options: WatchOptions | Encoding | null | undefined,
+    listener: WatchListener
+  ): FSWatcher;
+
+  // --- asynchronous API: the I/O runs off the engine loop, the promise
+  // settles on it (the same functions as fs.promises)
+
+  export function readFile(path: string, options?: ReadFileOptions | Encoding | null): Promise<string>;
+  export function writeFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
+  export function appendFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
+  export function stat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
+  export function stat(path: string, options?: StatOptions): Promise<Stats>;
+  export function lstat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
+  export function lstat(path: string, options?: StatOptions): Promise<Stats>;
+  export function readdir(path: string, options: ReaddirOptions & { withFileTypes: true }): Promise<Dirent[]>;
+  export function readdir(path: string, options?: (ReaddirOptions & { withFileTypes?: false }) | Encoding | null): Promise<string[]>;
+  /** Promise form of existsSync (a wb-rules addition; Node's fs.promises has no exists). */
+  export function exists(path: string): Promise<boolean>;
+  export function mkdir(path: string, options: MkdirOptions & { recursive: true }): Promise<string | undefined>;
+  export function mkdir(path: string, options?: (MkdirOptions & { recursive?: false }) | Mode | null): Promise<void>;
+  export function rmdir(path: string, options?: RmdirOptions): Promise<void>;
+  export function rm(path: string, options?: RmOptions): Promise<void>;
+  export function unlink(path: string): Promise<void>;
+  export function rename(oldPath: string, newPath: string): Promise<void>;
+  export function copyFile(src: string, dest: string, mode?: number): Promise<void>;
+  export function access(path: string, mode?: number): Promise<void>;
+  export function realpath(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
+  export function readlink(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
+  export function symlink(target: string, path: string, type?: string | null): Promise<void>;
+  export function chmod(path: string, mode: Mode): Promise<void>;
+  export function mkdtemp(prefix: string, options?: EncodingOptions | Encoding | null): Promise<string>;
+  export function truncate(path: string, len?: number | null): Promise<void>;
+  export function utimes(path: string, atime: TimeLike, mtime: TimeLike): Promise<void>;
+
+  /** The asynchronous API as one object; also what require("fs/promises") returns. */
+  export const promises: typeof import("fs/promises");
+}
+
+/** The promise API of the "fs" module (the same functions as fs.promises). */
+declare module "fs/promises" {
+  import type {
+    Dirent,
+    Encoding,
+    EncodingOptions,
+    MkdirOptions,
+    Mode,
+    ReaddirOptions,
+    ReadFileOptions,
+    RmdirOptions,
+    RmOptions,
+    Stats,
+    StatOptions,
+    TimeLike,
+    WriteFileOptions,
+  } from "fs";
+
+  export const constants: typeof import("fs").constants;
+  export function readFile(path: string, options?: ReadFileOptions | Encoding | null): Promise<string>;
+  export function writeFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
+  export function appendFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
+  export function stat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
+  export function stat(path: string, options?: StatOptions): Promise<Stats>;
+  export function lstat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
+  export function lstat(path: string, options?: StatOptions): Promise<Stats>;
+  export function readdir(path: string, options: ReaddirOptions & { withFileTypes: true }): Promise<Dirent[]>;
+  export function readdir(path: string, options?: (ReaddirOptions & { withFileTypes?: false }) | Encoding | null): Promise<string[]>;
+  export function exists(path: string): Promise<boolean>;
+  export function mkdir(path: string, options: MkdirOptions & { recursive: true }): Promise<string | undefined>;
+  export function mkdir(path: string, options?: (MkdirOptions & { recursive?: false }) | Mode | null): Promise<void>;
+  export function rmdir(path: string, options?: RmdirOptions): Promise<void>;
+  export function rm(path: string, options?: RmOptions): Promise<void>;
+  export function unlink(path: string): Promise<void>;
+  export function rename(oldPath: string, newPath: string): Promise<void>;
+  export function copyFile(src: string, dest: string, mode?: number): Promise<void>;
+  export function access(path: string, mode?: number): Promise<void>;
+  export function realpath(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
+  export function readlink(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
+  export function symlink(target: string, path: string, type?: string | null): Promise<void>;
+  export function chmod(path: string, mode: Mode): Promise<void>;
+  export function mkdtemp(prefix: string, options?: EncodingOptions | Encoding | null): Promise<string>;
+  export function truncate(path: string, len?: number | null): Promise<void>;
+  export function utimes(path: string, atime: TimeLike, mtime: TimeLike): Promise<void>;
+}
+
+declare module "node:fs" {
+  export * from "fs";
+}
+declare module "node:fs/promises" {
+  export * from "fs/promises";
+}

--- a/frontend/src/stores/rules/autocomplete/wb-rules.d.ts
+++ b/frontend/src/stores/rules/autocomplete/wb-rules.d.ts
@@ -895,7 +895,7 @@ declare var exports: Record<string, any>;
 declare module "fs" {
   export type Encoding = "utf8" | "utf-8";
   /** Node's file system flags (the `flag` option of writeFile/appendFile). */
-  export type OpenFlag = "r" | "r+" | "w" | "wx" | "w+" | "wx+" | "a" | "ax" | "a+" | "ax+";
+  export type OpenFlag = "r" | "rs" | "r+" | "rs+" | "w" | "wx" | "w+" | "wx+" | "a" | "ax" | "a+" | "ax+" | "as" | "as+";
   /** A permission mode: an integer or an octal string such as "644". */
   export type Mode = number | string;
   /** A timestamp for utimes: seconds since the epoch, a numeric string or a Date. */
@@ -903,6 +903,7 @@ declare module "fs" {
 
   export interface ReadFileOptions {
     encoding?: Encoding | null;
+    /** Default "r"; a creating flag ("a+") yields "" for a new file. */
     flag?: OpenFlag;
   }
   export interface WriteFileOptions {
@@ -915,7 +916,7 @@ declare module "fs" {
   export interface StatOptions {
     /** BigInt stats are not supported. */
     bigint?: false;
-    /** false: return undefined for a missing path instead of throwing ENOENT. */
+    /** false: return undefined for a missing path (ENOENT/ENOTDIR) instead of throwing. */
     throwIfNoEntry?: boolean;
   }
   export interface ReaddirOptions {
@@ -1036,17 +1037,21 @@ declare module "fs" {
   export function writeFileSync(path: string, data: string, options?: WriteFileOptions | Encoding | null): void;
   /** Appends data, creating the file if needed (flag "a"). */
   export function appendFileSync(path: string, data: string, options?: WriteFileOptions | Encoding | null): void;
+  export function statSync(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Stats;
   export function statSync(path: string, options: StatOptions & { throwIfNoEntry: false }): Stats | undefined;
-  export function statSync(path: string, options?: StatOptions): Stats;
+  export function statSync(path: string, options?: StatOptions): Stats | undefined;
   /** Like statSync but does not follow a final symbolic link. */
+  export function lstatSync(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Stats;
   export function lstatSync(path: string, options: StatOptions & { throwIfNoEntry: false }): Stats | undefined;
-  export function lstatSync(path: string, options?: StatOptions): Stats;
+  export function lstatSync(path: string, options?: StatOptions): Stats | undefined;
   export function readdirSync(path: string, options: ReaddirOptions & { withFileTypes: true }): Dirent[];
   export function readdirSync(path: string, options?: (ReaddirOptions & { withFileTypes?: false }) | Encoding | null): string[];
+  export function readdirSync(path: string, options?: ReaddirOptions | Encoding | null): string[] | Dirent[];
   /** true if the path exists (follows symlinks); never throws. */
   export function existsSync(path: string): boolean;
   export function mkdirSync(path: string, options: MkdirOptions & { recursive: true }): string | undefined;
   export function mkdirSync(path: string, options?: (MkdirOptions & { recursive?: false }) | Mode | null): void;
+  export function mkdirSync(path: string, options?: MkdirOptions | Mode | null): string | undefined;
   /** Removes an empty directory. */
   export function rmdirSync(path: string, options?: RmdirOptions): void;
   /** Removes a file, or a directory tree with { recursive: true }. */
@@ -1062,8 +1067,8 @@ declare module "fs" {
   export function realpathSync(path: string, options?: EncodingOptions | Encoding | null): string;
   /** Returns the target of a symbolic link. */
   export function readlinkSync(path: string, options?: EncodingOptions | Encoding | null): string;
-  /** Creates a symbolic link at path pointing to target (type is ignored). */
-  export function symlinkSync(target: string, path: string, type?: string | null): void;
+  /** Creates a symbolic link at path pointing to target (type only matters on Windows). */
+  export function symlinkSync(target: string, path: string, type?: "dir" | "file" | "junction" | null): void;
   export function chmodSync(path: string, mode: Mode): void;
   /** Creates a unique directory prefix + six random characters and returns its path. */
   export function mkdtempSync(prefix: string, options?: EncodingOptions | Encoding | null): string;
@@ -1088,16 +1093,20 @@ declare module "fs" {
   export function readFile(path: string, options?: ReadFileOptions | Encoding | null): Promise<string>;
   export function writeFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
   export function appendFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
+  export function stat(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<Stats>;
   export function stat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
-  export function stat(path: string, options?: StatOptions): Promise<Stats>;
+  export function stat(path: string, options?: StatOptions): Promise<Stats | undefined>;
+  export function lstat(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<Stats>;
   export function lstat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
-  export function lstat(path: string, options?: StatOptions): Promise<Stats>;
+  export function lstat(path: string, options?: StatOptions): Promise<Stats | undefined>;
   export function readdir(path: string, options: ReaddirOptions & { withFileTypes: true }): Promise<Dirent[]>;
   export function readdir(path: string, options?: (ReaddirOptions & { withFileTypes?: false }) | Encoding | null): Promise<string[]>;
+  export function readdir(path: string, options?: ReaddirOptions | Encoding | null): Promise<string[] | Dirent[]>;
   /** Promise form of existsSync (a wb-rules addition; Node's fs.promises has no exists). */
   export function exists(path: string): Promise<boolean>;
   export function mkdir(path: string, options: MkdirOptions & { recursive: true }): Promise<string | undefined>;
   export function mkdir(path: string, options?: (MkdirOptions & { recursive?: false }) | Mode | null): Promise<void>;
+  export function mkdir(path: string, options?: MkdirOptions | Mode | null): Promise<string | undefined>;
   export function rmdir(path: string, options?: RmdirOptions): Promise<void>;
   export function rm(path: string, options?: RmOptions): Promise<void>;
   export function unlink(path: string): Promise<void>;
@@ -1106,7 +1115,7 @@ declare module "fs" {
   export function access(path: string, mode?: number): Promise<void>;
   export function realpath(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
   export function readlink(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
-  export function symlink(target: string, path: string, type?: string | null): Promise<void>;
+  export function symlink(target: string, path: string, type?: "dir" | "file" | "junction" | null): Promise<void>;
   export function chmod(path: string, mode: Mode): Promise<void>;
   export function mkdtemp(prefix: string, options?: EncodingOptions | Encoding | null): Promise<string>;
   export function truncate(path: string, len?: number | null): Promise<void>;
@@ -1138,15 +1147,19 @@ declare module "fs/promises" {
   export function readFile(path: string, options?: ReadFileOptions | Encoding | null): Promise<string>;
   export function writeFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
   export function appendFile(path: string, data: string, options?: WriteFileOptions | Encoding | null): Promise<void>;
+  export function stat(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<Stats>;
   export function stat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
-  export function stat(path: string, options?: StatOptions): Promise<Stats>;
+  export function stat(path: string, options?: StatOptions): Promise<Stats | undefined>;
+  export function lstat(path: string, options?: StatOptions & { throwIfNoEntry?: true }): Promise<Stats>;
   export function lstat(path: string, options: StatOptions & { throwIfNoEntry: false }): Promise<Stats | undefined>;
-  export function lstat(path: string, options?: StatOptions): Promise<Stats>;
+  export function lstat(path: string, options?: StatOptions): Promise<Stats | undefined>;
   export function readdir(path: string, options: ReaddirOptions & { withFileTypes: true }): Promise<Dirent[]>;
   export function readdir(path: string, options?: (ReaddirOptions & { withFileTypes?: false }) | Encoding | null): Promise<string[]>;
+  export function readdir(path: string, options?: ReaddirOptions | Encoding | null): Promise<string[] | Dirent[]>;
   export function exists(path: string): Promise<boolean>;
   export function mkdir(path: string, options: MkdirOptions & { recursive: true }): Promise<string | undefined>;
   export function mkdir(path: string, options?: (MkdirOptions & { recursive?: false }) | Mode | null): Promise<void>;
+  export function mkdir(path: string, options?: MkdirOptions | Mode | null): Promise<string | undefined>;
   export function rmdir(path: string, options?: RmdirOptions): Promise<void>;
   export function rm(path: string, options?: RmOptions): Promise<void>;
   export function unlink(path: string): Promise<void>;
@@ -1155,7 +1168,7 @@ declare module "fs/promises" {
   export function access(path: string, mode?: number): Promise<void>;
   export function realpath(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
   export function readlink(path: string, options?: EncodingOptions | Encoding | null): Promise<string>;
-  export function symlink(target: string, path: string, type?: string | null): Promise<void>;
+  export function symlink(target: string, path: string, type?: "dir" | "file" | "junction" | null): Promise<void>;
   export function chmod(path: string, mode: Mode): Promise<void>;
   export function mkdtemp(prefix: string, options?: EncodingOptions | Encoding | null): Promise<string>;
   export function truncate(path: string, len?: number | null): Promise<void>;


### PR DESCRIPTION
## Что происходит; кому и зачем нужно

Редактор правил узнаёт встроенный модуль `fs` движка wb-rules (wirenboard/wb-rules#231, поверх #1202): типизированные `require("fs")` / `import * as fs from "fs"` в language service, автодополнение `fs.`, и параметры проверки, зеркалящие фоновую проверку движка (`module: preserve`, `esModuleInterop`).

## Что поменялось для пользователей

- В редакторе `const fs = require("fs")`, `import * as fs from "fs"`, `import fs from "fs"`, `import x = require("fs")` типизированы: подсказки по функциям и опциям, ошибки типов (`fs.readFileSync(1)`), `require("some.mod")` по-прежнему `any`.
- Language service проверяет файлы с `module: Preserve` + `esModuleInterop: true` — как движок; иначе `import x = require()` / `export =` (которые теперь работают в `.ts`-правилах) подсвечивались бы как синтаксические ошибки, а `import fs from "fs"` — как отсутствие default-экспорта.
- Генератор глобальных дополнений корректно обрабатывает перегрузки `require` (раньше взял бы первую, специализированную на литералах `"fs" | "node:fs"`); результат `globals-generated.ts` байт-в-байт прежний.

## Как устроено

- `frontend/src/stores/rules/autocomplete/wb-rules.d.ts` — дословная копия `types/wb-rules.d.ts` из wb-rules `quickjs-fs`.
- `ts-language-service.ts` — `ModuleKind.Preserve`, `esModuleInterop: true`.
- `scripts/generate-wb-rules-completions.mjs` — при нескольких перегрузках берётся первая без литеральных параметров.
- Тесты: `ts-language-service-fs.test.ts` (typed require, ESM-импорты + export, `import x = require` / `export =`, completions после `fs.`).

Коммиты: `6d5705e5`, `b85aa0ee`.

## Как проверял

- `npx vitest run src/stores/rules/autocomplete/` — 13 файлов, 89 тестов; `npm run check:types` — 0; eslint по затронутым файлам — 0.
- Тест на `preserve` load-bearing: с `ESNext` падает («Import assignment cannot be used when targeting ECMAScript modules»).
- Примечание: homeui использует TypeScript 6.0.3, где `esModuleInterop`/`allowSyntheticDefaultImports` уже `true` по умолчанию — опция задана явно ради паритета с движком (tsgo), где это не так.
