### PR TITLE
Show device template parameter fw variants by device firmware

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.249.0) stable; urgency=medium
+
+  * Show the device template parameter variant matching the device firmware
+    (wb-mqtt-serial parameter fw variants)
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@struhe.com>  Wed, 26 Aug 2026 12:58:08 +0300
+
 wb-mqtt-homeui (2.248.1) stable; urgency=medium
 
   * Rename factory reset buttons

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@ wb-mqtt-homeui (2.249.0) stable; urgency=medium
   * Show the device template parameter variant matching the device firmware
     (wb-mqtt-serial parameter fw variants)
 
- -- Petr Krasnoshchekov <petr.krasnoshchekov@struhe.com>  Wed, 26 Aug 2026 12:58:08 +0300
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 26 Aug 2026 15:14:34 +0500
 
 wb-mqtt-homeui (2.248.1) stable; urgency=medium
 

--- a/frontend/src/pages/settings/device-manager/config-editor/components/device-settings-editor/device-settings-param-editor.tsx
+++ b/frontend/src/pages/settings/device-manager/config-editor/components/device-settings-editor/device-settings-param-editor.tsx
@@ -97,7 +97,7 @@ export const ParamEditor = observer((
       {description && (
         <ParamDescription id={descriptionId} description={description} />
       )}
-      {param.hasSeveralVariants && (
+      {param.hasConflictingVariants && (
         <p className="wb-jsonEditor-errorText">
           {t('device-manager.errors.several-param-variants')}
         </p>

--- a/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.test.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.test.ts
@@ -1,0 +1,319 @@
+// @vitest-environment happy-dom
+import type { JsonSchema } from '@/stores/json-schema-editor';
+import type { WbDeviceTemplateParameter } from '../../types';
+import { DeviceSettingsObjectStore } from './device-settings-store';
+
+// Minimal device schema: one common param plus the template parameters under test.
+const makeStore = (parameters: WbDeviceTemplateParameter[], userConfig = {}) =>
+  new DeviceSettingsObjectStore(
+    {
+      type: 'object',
+      properties: { slave_id: { type: 'string' } },
+      device: { parameters },
+    } as unknown as JsonSchema,
+    userConfig,
+  );
+
+const getParam = (store: DeviceSettingsObjectStore, id: string) =>
+  store.topLevelGroup.parameters.find((param) => param.id === id);
+
+const getActiveStore = (store: DeviceSettingsObjectStore, id: string) => {
+  const param = getParam(store, id);
+  return param.variants[param.activeVariantIndex].store;
+};
+
+// A chain of fw variants: the base declaration without fw and its extension since fw 2.2.0.
+const fwChain: WbDeviceTemplateParameter[] = [
+  { id: 'p1', title: 'P1', enum: [0, 1], default: 0 },
+  { id: 'p1', title: 'P1', enum: [0, 1, 2], default: 0, fw: '2.2.0' },
+];
+
+describe('DeviceSettingsObjectStore with a chain of fw variants (base + fw 2.2.0)', () => {
+  it('shows the newest variant with three enum values while the device firmware is unknown', () => {
+    const store = makeStore(fwChain);
+    const param = getParam(store, 'p1');
+
+    expect(param.activeVariantIndex).toBe(1);
+    expect(getActiveStore(store, 'p1').schema.enum).toEqual([0, 1, 2]);
+    expect(param.hasConflictingVariants).toBe(false);
+    expect(param.isSupportedByFirmware).toBe(true);
+    expect(param.supportedFirmware).toBeUndefined();
+  });
+
+  it('shows the base variant with two enum values when the device firmware 2.1.0 is older than the extension', () => {
+    const store = makeStore(fwChain);
+
+    store.setFromDeviceRegisters({ p1: 0 }, '2.1.0');
+
+    const param = getParam(store, 'p1');
+    expect(param.activeVariantIndex).toBe(0);
+    expect(getActiveStore(store, 'p1').schema.enum).toEqual([0, 1]);
+    expect(param.isSupportedByFirmware).toBe(true);
+    expect(param.hasConflictingVariants).toBe(false);
+  });
+
+  it.each(['2.2.0', '3.0.0'])('shows the newest variant when the device firmware is %s', (fw) => {
+    const store = makeStore(fwChain);
+
+    store.setFromDeviceRegisters({ p1: 0 }, fw);
+
+    expect(getParam(store, 'p1').activeVariantIndex).toBe(1);
+    expect(getActiveStore(store, 'p1').schema.enum).toEqual([0, 1, 2]);
+  });
+
+  it('treats the value 2 read from a device with firmware 2.1.0 as a bad value from registers', () => {
+    const store = makeStore(fwChain);
+
+    store.setFromDeviceRegisters({ p1: 2 }, '2.1.0');
+
+    expect(getActiveStore(store, 'p1').value).toBe(2);
+    expect(getParam(store, 'p1').hasBadValueFromRegisters).toBe(true);
+    expect(store.hasBadValuesFromRegisters).toBe(true);
+  });
+
+  it('accepts the value 2 read from a device with firmware 2.2.0', () => {
+    const store = makeStore(fwChain);
+
+    store.setFromDeviceRegisters({ p1: 2 }, '2.2.0');
+
+    expect(getActiveStore(store, 'p1').value).toBe(2);
+    expect(getParam(store, 'p1').hasBadValueFromRegisters).toBe(false);
+    expect(getParam(store, 'p1').hasErrors).toBe(false);
+    expect(store.value.p1).toBe(2);
+  });
+
+  it('switches to the extended variant and accepts the value 2 when a re-read after an update reports 2.2.0', () => {
+    const store = makeStore(fwChain);
+    const param = getParam(store, 'p1');
+    store.setFromDeviceRegisters({ p1: 1 }, '2.1.0');
+    expect(param.activeVariantIndex).toBe(0);
+
+    store.setFromDeviceRegisters({ p1: 2 }, '2.2.0');
+
+    expect(param.activeVariantIndex).toBe(1);
+    expect(param.value).toBe(2);
+    expect(param.hasBadValueFromRegisters).toBe(false);
+    expect(store.value.p1).toBe(2);
+  });
+
+  it('reports a bad value from registers when a re-read on 2.1.0 returns the value 2 accepted on 2.2.0', () => {
+    const store = makeStore(fwChain);
+    const param = getParam(store, 'p1');
+    store.setFromDeviceRegisters({ p1: 2 }, '2.2.0');
+    expect(param.hasBadValueFromRegisters).toBe(false);
+
+    store.setFromDeviceRegisters({ p1: 2 }, '2.1.0');
+
+    expect(param.activeVariantIndex).toBe(0);
+    expect(param.hasBadValueFromRegisters).toBe(true);
+  });
+
+  it('keeps a user config value from the extended enum without errors while the firmware is unknown', () => {
+    const store = makeStore(fwChain, { p1: 2 });
+
+    expect(getParam(store, 'p1').hasErrors).toBe(false);
+    expect(getParam(store, 'p1').value).toBe(2);
+    expect(store.value.p1).toBe(2);
+  });
+
+  it('shows an error and drops on save a user config value outside the enum of the base variant on 2.1.0', () => {
+    const store = makeStore(fwChain, { p1: 2 });
+
+    store.setFromDeviceRegisters({ p1: 0 }, '2.1.0');
+
+    const param = getParam(store, 'p1');
+    expect(param.activeVariantIndex).toBe(0);
+    expect(param.hasErrors).toBe(true);
+    expect(param.shouldStoreInConfig).toBe(false);
+    expect(store.value).not.toHaveProperty('p1');
+  });
+
+  it('disables the parameter without a "supported since" hint when the device reports the unsupported marker', () => {
+    const store = makeStore(fwChain);
+
+    store.setFromDeviceRegisters({ p1: 'unsupported' }, '2.2.0');
+
+    expect(getParam(store, 'p1').isSupportedByFirmware).toBe(false);
+    expect(getParam(store, 'p1').supportedFirmware).toBeUndefined();
+  });
+});
+
+describe('DeviceSettingsObjectStore with a chain of fw variants declared newest first (fw 2.2.0 + base)', () => {
+  const reversedFwChain: WbDeviceTemplateParameter[] = [
+    { id: 'p1', title: 'P1', enum: [0, 1, 2], default: 0, fw: '2.2.0' },
+    { id: 'p1', title: 'P1', enum: [0, 1], default: 0 },
+  ];
+
+  it('shows the fw 2.2.0 variant declared first while the device firmware is unknown', () => {
+    expect(getParam(makeStore(reversedFwChain), 'p1').activeVariantIndex).toBe(0);
+  });
+
+  it.each([
+    { fw: '2.2.0', index: 0 },
+    { fw: '2.1.0', index: 1 },
+  ])('shows the variant at index $index when the device firmware is $fw', ({ fw, index }) => {
+    const store = makeStore(reversedFwChain);
+
+    store.setFromDeviceRegisters({ p1: 0 }, fw);
+
+    expect(getParam(store, 'p1').activeVariantIndex).toBe(index);
+  });
+});
+
+describe('DeviceSettingsObjectStore with a chain of fw variants (fw 1.0 + fw 2.0) on an older device', () => {
+  it('marks the parameter unsupported and reports the lowest fw of the chain when the device firmware is 0.9', () => {
+    const store = makeStore([
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '1.0' },
+      { id: 'p1', title: 'P1', enum: [0, 1, 2], default: 0, fw: '2.0' },
+    ]);
+
+    store.setFromDeviceRegisters({}, '0.9');
+
+    const param = getParam(store, 'p1');
+    expect(param.isSupportedByFirmware).toBe(false);
+    expect(param.supportedFirmware).toBe('1.0');
+    expect(param.activeVariantIndex).toBe(0);
+  });
+});
+
+describe('DeviceSettingsObjectStore when the daemon omitted the firmware version from the read registers', () => {
+  it('keeps a single declaration with fw 1.0 unsupported, shows its device value and does not save it', () => {
+    const store = makeStore([{ id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '1.0' }]);
+
+    store.setFromDeviceRegisters({ p1: 1 }, undefined);
+
+    const param = getParam(store, 'p1');
+    expect(param.isSupportedByFirmware).toBe(false);
+    expect(param.supportedFirmware).toBe('1.0');
+    expect(param.value).toBe(1);
+    expect(param.shouldStoreInConfig).toBe(false);
+    expect(store.value).not.toHaveProperty('p1');
+  });
+
+  it('shows the base variant of the chain (base + fw 2.2.0) and applies the device value', () => {
+    const store = makeStore(fwChain);
+
+    store.setFromDeviceRegisters({ p1: 1 }, undefined);
+
+    const param = getParam(store, 'p1');
+    expect(param.activeVariantIndex).toBe(0);
+    expect(param.isSupportedByFirmware).toBe(true);
+    expect(param.value).toBe(1);
+  });
+});
+
+describe('DeviceSettingsObjectStore with condition variants of different fw (mode==1/fw 1.0, mode==2/fw 2.0)', () => {
+  const parameters: WbDeviceTemplateParameter[] = [
+    { id: 'mode', title: 'Mode', enum: [1, 2], default: 1 },
+    { id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '1.0', condition: 'mode==1', dependencies: ['mode'] },
+    { id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '2.0', condition: 'mode==2', dependencies: ['mode'] },
+  ];
+
+  it('on firmware 1.5 supports the parameter while mode==1 and disables it with hint "since 2.0" on mode==2', () => {
+    const store = makeStore(parameters);
+    store.setFromDeviceRegisters({ mode: 1, p1: 0 }, '1.5');
+
+    const param = getParam(store, 'p1');
+    expect(param.activeVariantIndex).toBe(0);
+    expect(param.isSupportedByFirmware).toBe(true);
+    expect(param.hasConflictingVariants).toBe(false);
+
+    getActiveStore(store, 'mode').setValue(2);
+
+    expect(param.activeVariantIndex).toBe(1);
+    expect(param.isSupportedByFirmware).toBe(false);
+    expect(param.supportedFirmware).toBe('2.0');
+    expect(param.hasConflictingVariants).toBe(false);
+  });
+
+  it('applies the device value on firmware 1.5 when the fw 2.0 declaration comes first in the template', () => {
+    const store = makeStore([
+      { id: 'mode', title: 'Mode', enum: [1, 2], default: 1 },
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '2.0', condition: 'mode==2', dependencies: ['mode'] },
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '1.0', condition: 'mode==1', dependencies: ['mode'] },
+    ]);
+
+    store.setFromDeviceRegisters({ mode: 1, p1: 1 }, '1.5');
+
+    const param = getParam(store, 'p1');
+    expect(param.value).toBe(1);
+    expect(param.isSupportedByFirmware).toBe(true);
+    expect(param.activeVariantIndex).toBe(1);
+    expect(store.value.p1).toBe(1);
+  });
+
+  it('hides the parameter on 1.5 while mode==0 enables no variant and resets it to default after commit', () => {
+    const store = makeStore([
+      { id: 'mode', title: 'Mode', enum: [0, 1, 2], default: 0 },
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '1.0', condition: 'mode==1', dependencies: ['mode'] },
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '2.0', condition: 'mode==2', dependencies: ['mode'] },
+    ]);
+    store.setFromDeviceRegisters({ mode: 0, p1: 1 }, '1.5');
+
+    const param = getParam(store, 'p1');
+    expect(param.activeVariantIndex).toBe(-1);
+    expect(param.value).toBeUndefined();
+    expect(param.isDirty).toBe(false);
+    expect(param.hasErrors).toBe(false);
+    expect(store.value).not.toHaveProperty('p1');
+
+    store.commit();
+    getActiveStore(store, 'mode').setValue(1);
+
+    expect(param.value).toBe(0);
+  });
+});
+
+describe('WbDeviceParameterEditor.hasConflictingVariants', () => {
+  it('reports a template error when declarations with different conditions are enabled at once', () => {
+    const store = makeStore([
+      { id: 'mode', title: 'Mode', enum: [0, 1], default: 1 },
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, condition: 'mode==1', dependencies: ['mode'] },
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, condition: 'mode>0', dependencies: ['mode'] },
+    ]);
+
+    expect(getParam(store, 'p1').hasConflictingVariants).toBe(true);
+  });
+
+  it('does not report an error for a chain of fw variants sharing the same condition', () => {
+    const store = makeStore([
+      { id: 'mode', title: 'Mode', enum: [0, 1], default: 1 },
+      { id: 'p1', title: 'P1', enum: [0, 1], default: 0, condition: 'mode==1', dependencies: ['mode'] },
+      { id: 'p1', title: 'P1', enum: [0, 1, 2], default: 0, fw: '2.0', condition: 'mode==1', dependencies: ['mode'] },
+    ]);
+
+    expect(getParam(store, 'p1').hasConflictingVariants).toBe(false);
+    expect(getParam(store, 'p1').activeVariantIndex).toBe(1);
+  });
+});
+
+describe('DeviceSettingsObjectStore.setFromDeviceRegisters', () => {
+  it('applies the device value to a parameter whose condition depends on a parameter declared later', () => {
+    const store = makeStore([
+      { id: 'p1', title: 'P1', min: 0, max: 10, default: 0, condition: 'mode==1', dependencies: ['mode'] },
+      { id: 'mode', title: 'Mode', enum: [0, 1], default: 0 },
+    ]);
+
+    store.setFromDeviceRegisters({ p1: 5, mode: 1 }, '1.0');
+
+    expect(getParam(store, 'p1').isEnabledByCondition).toBe(true);
+    expect(getParam(store, 'p1').value).toBe(5);
+    expect(store.value.p1).toBe(5);
+  });
+
+  it('disables a parameter after the unsupported marker and restores it when the next read returns a number', () => {
+    const store = makeStore([{ id: 'p1', title: 'P1', enum: [0, 1], default: 0, fw: '1.0' }]);
+
+    store.setFromDeviceRegisters({ p1: 'unsupported' }, '2.0');
+
+    const param = getParam(store, 'p1');
+    expect(param.isSupportedByFirmware).toBe(false);
+    expect(param.shouldStoreInConfig).toBe(false);
+
+    store.setFromDeviceRegisters({ p1: 1 }, '2.0');
+
+    expect(param.isSupportedByFirmware).toBe(true);
+    expect(param.value).toBe(1);
+    expect(store.value.p1).toBe(1);
+  });
+});

--- a/frontend/src/stores/device-manager/device-tab/device-settings-editor/parameter-editor-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-settings-editor/parameter-editor-store.ts
@@ -1,5 +1,5 @@
 import { makeObservable, computed, observable, action, runInAction } from 'mobx';
-import { firmwareIsNewerOrEqual } from '@/stores/device-manager';
+import { compareFirmware, firmwareIsNewerOrEqual } from '@/stores/device-manager';
 import { type JsonSchema, NumberStore, getDefaultValue } from '@/stores/json-schema-editor';
 import { W1_ID_FORMAT } from '@/utils/one-wire-number';
 import type { WbDeviceTemplateParameter } from '../../types';
@@ -7,6 +7,9 @@ import { type Conditions } from './conditions';
 
 export class WbDeviceParameterEditorVariant {
   public store: NumberStore;
+  public readonly fw: string | undefined;
+  public readonly condition: string | undefined;
+  public isSupportedByFirmware: boolean = true;
 
   private _conditionFn?: Function;
   private _dependencies?: string[];
@@ -24,14 +27,22 @@ export class WbDeviceParameterEditorVariant {
     }
     const initialValueToSet = valueFromUserDefinedConfig ?? getDefaultValue(jsonSchema) ?? 0;
     this.store = new NumberStore(jsonSchema, initialValueToSet, parameter.required);
+    this.fw = parameter.fw;
+    this.condition = parameter.condition;
     this._conditionFn = conditions.getFunction(parameter.condition, parameter.dependencies);
     this._dependencies = parameter.dependencies;
     this._otherParameters = otherParameters;
 
     makeObservable(this, {
+      isSupportedByFirmware: observable,
       isEnabledByCondition: computed,
       hasDirtyDependency: computed,
+      setFirmwareInDevice: action,
     });
+  }
+
+  setFirmwareInDevice(fw: string) {
+    this.isSupportedByFirmware = firmwareIsNewerOrEqual(this.fw, fw);
   }
 
   get isEnabledByCondition() {
@@ -59,6 +70,8 @@ export class WbDeviceParameterEditorVariant {
   }
 }
 
+// Template declarations with the same id are variants of one parameter: condition variants are
+// mutually exclusive, fw variants share a condition and differ in fw and enum (the newer adds values)
 export class WbDeviceParameterEditor {
   public id: string;
   public order: number;
@@ -66,8 +79,8 @@ export class WbDeviceParameterEditor {
   public variants: WbDeviceParameterEditorVariant[] = [];
   public isSetInDeviceRegisters: boolean = false;
   public isSetInUserDefinedConfig: boolean = false;
-  public isSupportedByFirmware: boolean = true;
-  public supportedFirmware: string | undefined;
+
+  private _isUnsupportedByDevice: boolean = false;
 
   constructor(
     parameter: WbDeviceTemplateParameter,
@@ -79,18 +92,19 @@ export class WbDeviceParameterEditor {
     this.id = parameter.id;
     this.order = parameter.order ?? 0;
     this.required = this.variants[0].store.required;
-    this.supportedFirmware = parameter.fw;
 
-    makeObservable(this, {
-      isSupportedByFirmware: observable,
+    makeObservable<WbDeviceParameterEditor, '_isUnsupportedByDevice'>(this, {
+      _isUnsupportedByDevice: observable,
       isSetInDeviceRegisters: observable,
       activeVariantIndex: computed,
+      isSupportedByFirmware: computed,
+      supportedFirmware: computed,
       value: computed,
       isEnabledByCondition: computed,
       isDirty: computed,
       hasErrors: computed,
       hasBadValueFromRegisters: computed,
-      hasSeveralVariants: computed,
+      hasConflictingVariants: computed,
       hasDirtyDependency: computed,
       shouldStoreInConfig: computed,
       addVariant: action,
@@ -103,6 +117,15 @@ export class WbDeviceParameterEditor {
 
   get isEnabledByCondition() {
     return this.variants.some((variant) => variant.isEnabledByCondition);
+  }
+
+  get isSupportedByFirmware() {
+    return !this._isUnsupportedByDevice
+      && this.variants.some((variant) => variant.isEnabledByCondition && variant.isSupportedByFirmware);
+  }
+
+  get supportedFirmware() {
+    return this._getEnabledVariantsOldestFirst()[0]?.fw;
   }
 
   get hasErrors() {
@@ -139,12 +162,20 @@ export class WbDeviceParameterEditor {
     return activeVariantIndex !== -1 ? this.variants[activeVariantIndex].store.isDirty : false;
   }
 
+  // The newest variant supported by the device firmware, otherwise the oldest one to show it disabled.
+  // indexOf(undefined) gives -1 when no variant is enabled
   get activeVariantIndex() {
-    return this.variants.findIndex((variant) => variant.isEnabledByCondition);
+    const enabled = this._getEnabledVariantsOldestFirst();
+    const supported = enabled.filter((variant) => variant.isSupportedByFirmware);
+    return this.variants.indexOf(supported.at(-1) ?? enabled[0]);
   }
 
-  get hasSeveralVariants() {
-    return this.variants.filter((variant) => variant.isEnabledByCondition).length > 1;
+  // Shown under the editor as a template error: several declarations match at once, the daemon
+  // rejects such a config as a duplicate parameter. A chain of fw variants shares one condition
+  get hasConflictingVariants() {
+    return new Set(
+      this.variants.filter((variant) => variant.isEnabledByCondition).map((variant) => variant.condition),
+    ).size > 1;
   }
 
   get hasDirtyDependency() {
@@ -194,7 +225,7 @@ export class WbDeviceParameterEditor {
   }
 
   setFromDeviceRegister(value: unknown, isForce?: boolean) {
-    if ((!this.isSetInUserDefinedConfig || isForce) && this.isSupportedByFirmware && typeof value === 'number') {
+    if ((!this.isSetInUserDefinedConfig || isForce) && typeof value === 'number') {
       this.variants.forEach((variant) => {
         variant.store.setValue(value);
         variant.store.commit();
@@ -212,12 +243,13 @@ export class WbDeviceParameterEditor {
         }
       });
     } else if (value === 'unsupported') {
-      this.isSupportedByFirmware = false;
+      this._isUnsupportedByDevice = true;
     }
   }
 
   setFirmwareInDevice(fw: string) {
-    this.isSupportedByFirmware = firmwareIsNewerOrEqual(this.supportedFirmware, fw);
+    this.variants.forEach((variant) => variant.setFirmwareInDevice(fw));
+    this._isUnsupportedByDevice = false;
   }
 
   /**
@@ -252,6 +284,12 @@ export class WbDeviceParameterEditor {
       variant.store.setValue(value);
       variant.store.commit();
     });
+  }
+
+  private _getEnabledVariantsOldestFirst() {
+    return this.variants
+      .filter((variant) => variant.isEnabledByCondition)
+      .sort((a, b) => compareFirmware(a.fw, b.fw));
   }
 }
 

--- a/frontend/src/stores/device-manager/index.ts
+++ b/frontend/src/stores/device-manager/index.ts
@@ -22,6 +22,7 @@ export {
 } from './utils/common';
 
 export {
+  compareFirmware,
   firmwareIsNewer,
   firmwareIsNewerOrEqual
 } from './utils/firmware';

--- a/frontend/src/stores/device-manager/utils/firmware.test.ts
+++ b/frontend/src/stores/device-manager/utils/firmware.test.ts
@@ -1,4 +1,4 @@
-import { firmwareIsNewer, firmwareIsNewerOrEqual } from './firmware';
+import { compareFirmware, firmwareIsNewer, firmwareIsNewerOrEqual } from './firmware';
 
 describe('Firmware version comparison', () => {
   describe.each([
@@ -36,6 +36,21 @@ describe('Firmware version comparison', () => {
   ])('firmwareIsNewerOrEqual($fw1, $fw2)', ({ fw1, fw2, expected }) => {
     test(`returns ${expected}`, () => {
       expect(firmwareIsNewerOrEqual(fw1, fw2)).toBe(expected);
+    });
+  });
+
+  describe.each([
+    { fw1: '1.2.3', fw2: '1.2.3', expected: 0 },
+    { fw1: '1.2.3', fw2: '1.2.4', expected: -1 },
+    { fw1: '1.2.4', fw2: '1.2.3', expected: 1 },
+    { fw1: '1.2.3-rc1', fw2: '1.2.3', expected: -1 },
+    { fw1: '1.2.3+wb1', fw2: '1.2.3', expected: 1 },
+    { fw1: undefined, fw2: undefined, expected: 0 },
+    { fw1: undefined, fw2: '1.2.3', expected: -1 },
+    { fw1: '1.2.3', fw2: undefined, expected: 1 },
+  ])('compareFirmware($fw1, $fw2)', ({ fw1, fw2, expected }) => {
+    test(`returns ${expected}`, () => {
+      expect(Math.sign(compareFirmware(fw1, fw2))).toBe(expected);
     });
   });
 });

--- a/frontend/src/stores/device-manager/utils/firmware.ts
+++ b/frontend/src/stores/device-manager/utils/firmware.ts
@@ -24,26 +24,7 @@ function splitVersion(version: string): { base: string; suffix: number } {
  * undefined === undefined, so, the function returns false in this case.
  */
 export function firmwareIsNewer(fw1?: string, fw2?: string): boolean {
-  if (fw1 === undefined && fw2 === undefined) {
-    return false;
-  }
-  if (fw1 === undefined) {
-    return true;
-  }
-  if (fw2 === undefined) {
-    return false;
-  }
-  const v1 = splitVersion(fw1);
-  const v2 = splitVersion(fw2);
-  const baseRes = v1.base.localeCompare(v2.base, undefined, { numeric: true, sensitivity: 'base' });
-  // Same major, minor and patch
-  if (baseRes === 0) {
-    if (v1.suffix < 0 && v2.suffix < 0) {
-      return v1.suffix > v2.suffix;
-    }
-    return v1.suffix < v2.suffix;
-  }
-  return baseRes < 0;
+  return compareFirmware(fw1, fw2) < 0;
 }
 
 /**
@@ -56,8 +37,30 @@ export function firmwareIsNewer(fw1?: string, fw2?: string): boolean {
  * undefined === undefined, so, the function returns true in this case.
  */
 export function firmwareIsNewerOrEqual(fw1?: string, fw2?: string): boolean {
+  return compareFirmware(fw1, fw2) <= 0;
+}
+
+// Sort comparator: negative when fw1 is older than fw2, zero when equal. Simplified semver for WB devices,
+// https://wirenboard.com/wiki/Modbus-hardware-version: undefined < 1.2.3-rc1 < 1.2.3-rc10 < 1.2.3 < 1.2.3+wb1
+export function compareFirmware(fw1?: string, fw2?: string): number {
   if (fw1 === fw2) {
-    return true;
+    return 0;
   }
-  return firmwareIsNewer(fw1, fw2);
+  if (fw1 === undefined) {
+    return -1;
+  }
+  if (fw2 === undefined) {
+    return 1;
+  }
+  const v1 = splitVersion(fw1);
+  const v2 = splitVersion(fw2);
+  const baseRes = v1.base.localeCompare(v2.base, undefined, { numeric: true, sensitivity: 'base' });
+  if (baseRes !== 0) {
+    return baseRes;
+  }
+  // Same major, minor and patch. Release candidates have negative suffixes, a higher rc number is newer
+  if (v1.suffix < 0 && v2.suffix < 0) {
+    return v2.suffix - v1.suffix;
+  }
+  return v1.suffix - v2.suffix;
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

wb-mqtt-serial 2.269.0 (wirenboard/wb-mqtt-serial#1243) разрешает несколько объявлений параметра с одним `id`, одним `condition` и разными `fw`: новая прошивка расширяет `enum` без шаблона-форка. Демону версия прошивки для этого не нужна, а веб-интерфейс должен показывать `enum` того варианта, который действует на подключённом устройстве. Сейчас редактор настроек берёт первый вариант с истинным условием, `fw` из первого объявления и считает несколько одновременно истинных вариантов ошибкой шаблона, поэтому для линейки fw-вариантов показывает ошибку и случайный `enum`.

___________________________________
**Что поменялось для пользователей:**

- В настройках устройства параметр с fw-вариантами показывает вариант с максимальным `fw`, не превышающим прошивку устройства. Пока прошивка не прочитана, показывается новейший вариант, как в валидации конфига у демона. Если у всех вариантов `fw` новее прошивки, параметр задизейблен с подписью «Поддерживается с прошивки X», где X минимальный `fw` линейки.
- Ошибка «В шаблоне задано несколько вариантов описания этого параметра» показывается только для одновременно истинных объявлений с разными условиями, линейка fw-вариантов ошибкой не считается.
- Поддержка параметра прошивкой определяется по активной ветке условий, а не по первому объявлению: демон теперь допускает разные `fw` у condition-вариантов.
- Значение, прочитанное с устройства, применяется без проверки по прошивке на стороне UI, демон читает только поддержанные объявления.
- Существующие шаблоны без fw-вариантов работают как раньше.

___________________________________
**Как проверял/а:**

`npm run check:types`, `npm run lint`, `npm test` чисто (192 файла, 2489 тестов). Новый `device-settings-store.test.ts`, 24 теста через публичный API стора: линейка на неизвестной, старой и новой прошивке, значение вне `enum` действующего варианта, линейка целиком новее прошивки, condition-варианты с разными `fw`, конфликт условий, линейка в обратном порядке объявлений, повторное чтение после смены прошивки, маркер `unsupported`, порядок объявлений при чтении. `compareFirmware` покрыта в `firmware.test.ts`.
