### PR TITLE
DALI: host capabilities for hosts that are not a controller

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-homeui (2.250.0) stable; urgency=medium
+
+  * DALI: host capabilities for embedding hosts — the syslog toggle and the MQTT id
+    editor only where a controller's syslog and broker exist; topic copy on cell click
+    behind a policy a broker-less host switches off
+
+ -- Wiren Board Robot <info@wirenboard.com>  Mon, 31 Aug 2026 20:00:00 +0300
+
 wb-mqtt-homeui (2.249.2) stable; urgency=medium
 
   * Add a note under the DALI bus monitor switch: the gateway has to be

--- a/frontend/src/components/cell/cell-alert.tsx
+++ b/frontend/src/components/cell/cell-alert.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from '@/components/tooltip';
 import { CellError } from '@/stores/devices/cell-type';
 import { copyToClipboard } from '@/utils/clipboard';
 import { CellHistory } from './cell-history';
+import { topicCopyPolicy } from './topic-copy-policy';
 import { type CellAlertProps } from './types';
 import './styles.css';
 
@@ -15,22 +16,28 @@ export const CellAlert = observer(({ cell, name, hideHistory }: CellAlertProps) 
     ? 'gray'
     : cell.value ? 'danger' : 'success';
 
+  const alert = (
+    <Alert
+      size="small"
+      variant={variant}
+      className="deviceCell-alert"
+      onClick={topicCopyPolicy.enabled ? () => copyToClipboard(cell.id) : undefined}
+    >
+      {name || cell.name}
+    </Alert>
+  );
+
   return (
     <>
-      <Tooltip
-        text={<span><b>'{cell.id}'</b> {t('widget.labels.copy')}</span>}
-        placement="top-start"
-        trigger="click"
-      >
-        <Alert
-          size="small"
-          variant={variant}
-          className="deviceCell-alert"
-          onClick={() => copyToClipboard(cell.id)}
+      {topicCopyPolicy.enabled ? (
+        <Tooltip
+          text={<span><b>'{cell.id}'</b> {t('widget.labels.copy')}</span>}
+          placement="top-start"
+          trigger="click"
         >
-          {name || cell.name}
-        </Alert>
-      </Tooltip>
+          {alert}
+        </Tooltip>
+      ) : alert}
 
       {!hideHistory && <CellHistory cell={cell} />}
     </>

--- a/frontend/src/components/cell/cell.tsx
+++ b/frontend/src/components/cell/cell.tsx
@@ -15,6 +15,7 @@ import { Tooltip } from '@/components/tooltip';
 import { CellComponent } from '@/stores/devices';
 import { CellError } from '@/stores/devices/cell-type';
 import { copyToClipboard } from '@/utils/clipboard';
+import { topicCopyPolicy } from './topic-copy-policy';
 import { type CellProps } from './types';
 import './styles.css';
 
@@ -59,15 +60,11 @@ export const CellContent = observer(({ cell, name, isCompact, isReadOnly, extra,
         },
       )}
     >
-      {!isCompact && ![CellComponent.Alert, CellComponent.Button].includes(cell.displayType) && (
-        <Tooltip
-          text={<span><b>'{cell.id}'</b> {t('widget.labels.copy')}</span>}
-          placement="top-start"
-          trigger="click"
-        >
+      {!isCompact && ![CellComponent.Alert, CellComponent.Button].includes(cell.displayType) && (() => {
+        const nameBlock = (
           <div
             className="deviceCell-name"
-            onClick={() => copyToClipboard(cell.id)}
+            onClick={topicCopyPolicy.enabled ? () => copyToClipboard(cell.id) : undefined}
           >
             {cell.error?.includes(CellError.Period) && (
               <Suspense>
@@ -85,8 +82,22 @@ export const CellContent = observer(({ cell, name, isCompact, isReadOnly, extra,
               <CellHistory cell={cell} />
             )}
           </div>
-        </Tooltip>
-      )}
+        );
+        // Without a broker to use the topic in, neither the copy nor its
+        // "copied to clipboard" tooltip has a point — see topicCopyPolicy.
+        if (!topicCopyPolicy.enabled) {
+          return nameBlock;
+        }
+        return (
+          <Tooltip
+            text={<span><b>'{cell.id}'</b> {t('widget.labels.copy')}</span>}
+            placement="top-start"
+            trigger="click"
+          >
+            {nameBlock}
+          </Tooltip>
+        );
+      })()}
       {isCompact && !hideHistory && cell.displayType === CellComponent.Range && (
         <CellHistory cell={cell} />
       )}

--- a/frontend/src/components/cell/topic-copy-policy.ts
+++ b/frontend/src/components/cell/topic-copy-policy.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether clicking a cell's name copies its MQTT topic id.
+ *
+ * On a controller the id is the topic a rule or a dashboard would use, so the
+ * copy is worth the click. A host with no broker — the standalone WASM
+ * device editor drives cells from an in-browser loopback — has nowhere to
+ * paste it, and "copied to clipboard" there is just a puzzling toast. Such a
+ * host switches this off once at startup.
+ */
+export const topicCopyPolicy = {
+  enabled: true,
+};

--- a/frontend/src/pages/settings/configs/dali/components/bus-tab-content/bus-tab-content.tsx
+++ b/frontend/src/pages/settings/configs/dali/components/bus-tab-content/bus-tab-content.tsx
@@ -8,6 +8,7 @@ import { FormButtonGroup } from '@/components/form';
 import { JsonSchemaEditor, ParamDescription } from '@/components/json-schema-editor';
 import { Loader } from '@/components/loader';
 import { daliGlobalStore, type BusStore } from '@/stores/dali';
+import { daliHostCapabilities } from '@/stores/dali/host-capabilities';
 import type { ObjectParamStore } from '@/stores/json-schema-editor/object-store';
 import { useAsyncAction } from '@/utils/async-action';
 import { BusCommands } from '../bus-commands';
@@ -157,11 +158,13 @@ export const BusTabContent = observer(({ store }: { store: BusStore }) => {
         />
         <ParamDescription description={t('dali.labels.bus-monitor-description')} />
       </div>
-      <BusToggle
-        label={t('dali.labels.bus-monitor-syslog')}
-        value={store.busMonitorSyslogEnabled}
-        onToggle={(v) => store.setBusMonitorSyslogEnabled(v)}
-      />
+      {daliHostCapabilities.syslogMonitor && (
+        <BusToggle
+          label={t('dali.labels.bus-monitor-syslog')}
+          value={store.busMonitorSyslogEnabled}
+          onToggle={(v) => store.setBusMonitorSyslogEnabled(v)}
+        />
+      )}
     </>
   );
 });

--- a/frontend/src/stores/dali/device-store-mqtt-id-hidden.test.ts
+++ b/frontend/src/stores/dali/device-store-mqtt-id-hidden.test.ts
@@ -1,0 +1,44 @@
+import { loadJsonSchemaMock } from '@/test/mocks/json-schema-editor';
+import { daliProxyMock } from '@/test/mocks/services';
+import { DeviceStore } from './device-store';
+import { daliHostCapabilities } from './host-capabilities';
+
+vi.mock('@/services', () => import('@/test/mocks/services'));
+vi.mock('@/stores/json-schema-editor', () => import('@/test/mocks/json-schema-editor'));
+vi.mock('@/utils/format-error', () => import('@/test/mocks/format-error'));
+
+describe('DeviceStore.load hides the MQTT id editor when the host has no external broker', () => {
+  const schemaWithMqttId = () => ({
+    translations: {},
+    properties: { mqtt_id: { options: { grid_columns: 6 } }, name: {} },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    daliProxyMock.GetDevice.mockResolvedValue({ schema: {}, name: 'Lamp', config: { groups: [] } });
+  });
+
+  afterEach(() => {
+    daliHostCapabilities.externalBroker = true;
+  });
+
+  it('marks mqtt_id hidden on a broker-less host, keeping its other options', async () => {
+    daliHostCapabilities.externalBroker = false;
+    const schema = schemaWithMqttId();
+    loadJsonSchemaMock.mockReturnValue(schema as any);
+
+    await new DeviceStore('dev1', 'Lamp').load();
+
+    expect(schema.properties.mqtt_id.options).toEqual({ grid_columns: 6, hidden: true });
+    expect(schema.properties.name).toEqual({});
+  });
+
+  it('leaves the schema alone on a controller host', async () => {
+    const schema = schemaWithMqttId();
+    loadJsonSchemaMock.mockReturnValue(schema as any);
+
+    await new DeviceStore('dev1', 'Lamp').load();
+
+    expect(schema.properties.mqtt_id.options).toEqual({ grid_columns: 6 });
+  });
+});

--- a/frontend/src/stores/dali/device-store.ts
+++ b/frontend/src/stores/dali/device-store.ts
@@ -4,6 +4,7 @@ import { type GetDeviceParams } from '@/stores/dali/types';
 import { ObjectStore, StoreBuilder, Translator, loadJsonSchema } from '@/stores/json-schema-editor';
 import { BaseItemStore, ItemType } from './base-item-store';
 import type { BusStore } from './bus-store';
+import { daliHostCapabilities } from './host-capabilities';
 
 export class DeviceStore extends BaseItemStore {
   readonly type = ItemType.Device;
@@ -47,6 +48,14 @@ export class DeviceStore extends BaseItemStore {
       const data = await daliProxy.GetDevice(params);
       this.translator = new Translator();
       const schema = loadJsonSchema(data.schema);
+      if (!daliHostCapabilities.externalBroker) {
+        // With no external broker the MQTT id names nothing anyone can see;
+        // keep the daemon's default instead of offering an editor for it.
+        const mqttIdSchema = schema.properties?.mqtt_id;
+        if (mqttIdSchema) {
+          mqttIdSchema.options = { ...mqttIdSchema.options, hidden: true };
+        }
+      }
       this.translator.addTranslations(schema.translations);
       this.objectStore = new ObjectStore(schema, data.config, false, new StoreBuilder());
       this.setError(null);

--- a/frontend/src/stores/dali/host-capabilities.ts
+++ b/frontend/src/stores/dali/host-capabilities.ts
@@ -1,0 +1,24 @@
+/**
+ * What the app hosting the DALI page can actually do.
+ *
+ * NOT observable on purpose: hosts flip these once at startup, before the
+ * first render — a runtime mutation would not re-render observers.
+ *
+ * The page runs in two homes: homeui on a controller, and the standalone WASM
+ * device editor in a browser. Some controls only mean something on a
+ * controller — "Save to syslog" needs a syslog to save to. The controller
+ * host leaves the defaults; the WASM host switches off what it cannot honor
+ * (see the editor's main.tsx).
+ */
+export const daliHostCapabilities = {
+  /** wb-mqtt-dali can copy bus monitor rows to the controller's syslog. */
+  syslogMonitor: true,
+  /**
+   * The daemon's MQTT topics are served by a real broker that other tools
+   * (dashboards, rules, history) can see, so a device's MQTT id is a
+   * meaningful, user-editable identity. The WASM host runs a loopback broker
+   * nothing external ever reaches — there the id is an implementation detail
+   * and its editor is hidden.
+   */
+  externalBroker: true,
+};

--- a/frontend/src/stores/devices/devices-store.ts
+++ b/frontend/src/stores/devices/devices-store.ts
@@ -4,6 +4,7 @@ import { mqttClient } from '@/services';
 import Cell from './cell';
 import Device from './device';
 import { isTopicsAreEqual, splitTopic } from './helpers';
+import { sendCellValueUpdate } from './send-cell-value';
 import type { ValueType } from './types';
 
 export default class DevicesStore {
@@ -168,8 +169,7 @@ export default class DevicesStore {
   }
 
   async sendCellValueUpdate(deviceId: string, controlId: string, value: string) {
-    const topic = `/devices/${deviceId}/controls/${controlId}/on`;
-    await mqttClient.send(topic, value, false);
+    await sendCellValueUpdate(deviceId, controlId, value);
   }
 
   #getOrCreateTopics(deviceId: string) {

--- a/frontend/src/stores/devices/send-cell-value.ts
+++ b/frontend/src/stores/devices/send-cell-value.ts
@@ -1,0 +1,10 @@
+import { mqttClient } from '@/services';
+
+/**
+ * Publish a control write the way every WB daemon expects it — non-retained,
+ * on the `/on` command topic. The one spelling of that topic, shared by
+ * DevicesStore and the DALI page's embedded controls.
+ */
+export async function sendCellValueUpdate(deviceId: string, controlId: string, value: string) {
+  await mqttClient.send(`/devices/${deviceId}/controls/${controlId}/on`, value, false);
+}


### PR DESCRIPTION
Первый из серии PR, на которые разбит #1223 (он закрывается в пользу этих). Каждый — самостоятельная единица от `master`; остальные не зависят друг от друга, кроме отмеченного.

## Что сделано
У страницы DALI второй дом — автономный WASM-редактор устройств — без syslog и без брокера, который видит кто-то ещё. `daliHostCapabilities` (`stores/dali/host-capabilities.ts`) — неглубокий набор флагов, которые такой хост выставляет до первого рендера:
- `syslogMonitor` — переключатель «Сохранять в syslog» на вкладке шины показывается только там, где syslog есть;
- `externalBroker` — редактор MQTT-id устройства скрывается там, где id никому не виден (демон оставляет id по умолчанию; схема демона его требует — прячется только редактор).

Копирование топика по клику на контрол и его тултип «скопировано» — за `topicCopyPolicy`, которую хост без брокера очищает; путь записи значения контрола сведён в один хелпер `sendCellValueUpdate`.

Контроллерный homeui сохраняет все умолчания — поведение не меняется.

## Тесты
`device-store-mqtt-id-hidden.test.ts` — редактор id скрыт при `externalBroker = false` и не тронут иначе. `tsc --noEmit`, `eslint`, `vitest` по затронутым каталогам — чисто.

Связанные: wirenboard/wb-wasm-device-editor#96 (хост, который эти флаги выставляет).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
