### PR TITLE
DALI monitor: collapse repeated errors, explain an empty panel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-mqtt-homeui (2.250.2) stable; urgency=medium
+
+  * DALI bus monitor: a run of identical error lines collapses into one row with a
+    repeat badge; the console panel takes an emptyState for a host with no monitor
+    tabs registered, and the DALI page provides one that says how to enable the
+    monitor per bus
+
+ -- Wiren Board Robot <info@wirenboard.com>  Mon, 31 Aug 2026 20:20:00 +0300
+
 wb-mqtt-homeui (2.249.2) stable; urgency=medium
 
   * Add a note under the DALI bus monitor switch: the gateway has to be

--- a/frontend/src/components/console-panel/console-panel.tsx
+++ b/frontend/src/components/console-panel/console-panel.tsx
@@ -24,11 +24,12 @@ import { Tabs } from '@/components/tabs';
 import { Tooltip } from '@/components/tooltip';
 import { consolePanelStore as store } from '@/stores/console-panel';
 import { getOverflowIds } from './get-overflow-ids';
+import type { ConsolePanelProps } from './types';
 import './styles.css';
 
 const OVERFLOW_BTN_SPACE = 26;
 
-export const ConsolePanel = observer(() => {
+export const ConsolePanel = observer(({ emptyState }: ConsolePanelProps = {}) => {
   const { t } = useTranslation();
   const isMobile = useMediaQuery({ maxWidth: 768 });
   const container = useRef<HTMLDivElement>(null);
@@ -348,7 +349,7 @@ export const ConsolePanel = observer(() => {
         </div>
       </header>
 
-      {activeTab && <activeTab.renderContent />}
+      {activeTab ? <activeTab.renderContent /> : emptyState}
     </aside>
   );
 });

--- a/frontend/src/components/console-panel/types.ts
+++ b/frontend/src/components/console-panel/types.ts
@@ -13,3 +13,9 @@ export interface ConsoleLogScrollerProps {
   scrollKey: number | string;
   children: ReactNode;
 }
+
+export interface ConsolePanelProps {
+  /** Shown in the content area while no tab is registered — an open panel with
+      nothing to say otherwise reads as a rendering bug. */
+  emptyState?: ReactNode;
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1095,6 +1095,9 @@
          "monitor-col-command": "Command",
          "monitor-col-response": "Response",
          "monitor-foreign": "foreign",
+         "monitor-empty-hint": "The bus monitor is off, so no frames are being captured. Enable it for a bus below, or with the Bus Monitor toggle at the bottom of that bus's tab:",
+         "monitor-repeats": "repeated {{count}} times",
+         "monitor-repeats_one": "repeated {{count}} time",
          "monitor-broadcast": "Broadcast"
       },
       "buttons": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1124,6 +1124,11 @@
          "monitor-col-command": "Команда",
          "monitor-col-response": "Ответ",
          "monitor-foreign": "сторонний",
+         "monitor-empty-hint": "Монитор шины выключен, кадры не записываются. Включите его для нужной шины ниже или переключателем «Монитор шины» внизу вкладки этой шины:",
+         "monitor-repeats": "повторено {{count}} раз",
+         "monitor-repeats_one": "повторено {{count}} раз",
+         "monitor-repeats_few": "повторено {{count}} раза",
+         "monitor-repeats_many": "повторено {{count}} раз",
          "monitor-broadcast": "Широковещательные"
       },
       "buttons": {

--- a/frontend/src/pages/settings/configs/dali/components/bus-monitor/bus-monitor-row.tsx
+++ b/frontend/src/pages/settings/configs/dali/components/bus-monitor/bus-monitor-row.tsx
@@ -13,7 +13,7 @@ const formatHexBytes = (hex: string) => hex.match(/.{1,2}/g)?.join(' ') ?? hex;
  * it with the address filter); memoised on the raw line so unchanged rows skip
  * re-rendering as new entries arrive.
  */
-export const BusMonitorRow = memo(({ frame }: { frame: ParsedBusMonitorLine }) => {
+export const BusMonitorRow = memo(({ frame, repeat = 1 }: { frame: ParsedBusMonitorLine; repeat?: number }) => {
   const { t } = useTranslation();
   const { direction, response, badges } = frame;
 
@@ -30,6 +30,11 @@ export const BusMonitorRow = memo(({ frame }: { frame: ParsedBusMonitorLine }) =
           </span>
         )}
         {badges.fromLunatone && <span className="daliMonitor-badge">lunatone</span>}
+        {repeat > 1 && (
+          <span className="daliMonitor-repeatBadge" title={t('dali.labels.monitor-repeats', { count: repeat })}>
+            ×{repeat}
+          </span>
+        )}
       </span>
       <span className="daliMonitor-response">
         {response.kind === 'error' && (

--- a/frontend/src/pages/settings/configs/dali/components/bus-monitor/bus-monitor-tab.tsx
+++ b/frontend/src/pages/settings/configs/dali/components/bus-monitor/bus-monitor-tab.tsx
@@ -15,6 +15,7 @@ import { parseBusMonitorLine } from '@/stores/dali/parse-bus-monitor-line';
 import type { ParsedBusMonitorLine } from '@/stores/dali/types';
 import { downloadFile } from '@/utils/download';
 import { BusMonitorHeader, BusMonitorRow } from './bus-monitor-row';
+import { collapseErrorRows } from './collapse-error-rows';
 import { ConsoleMenu } from './console-menu';
 import type { BusMonitorTabProps } from './types';
 import './styles.css';
@@ -137,10 +138,12 @@ export const DaliBusMonitorContent = observer(({ monitorStore }: { monitorStore:
     })
     : frames;
 
+  const rows = collapseErrorRows(visible);
+
   return (
     <ConsoleLogScroller scrollKey={visible.length}>
       <BusMonitorHeader />
-      {visible.map((frame, i) => <BusMonitorRow key={i} frame={frame} />)}
+      {rows.map((row, i) => <BusMonitorRow key={i} frame={row.frame} repeat={row.repeat} />)}
     </ConsoleLogScroller>
   );
 });

--- a/frontend/src/pages/settings/configs/dali/components/bus-monitor/collapse-error-rows.test.ts
+++ b/frontend/src/pages/settings/configs/dali/components/bus-monitor/collapse-error-rows.test.ts
@@ -1,0 +1,38 @@
+import type { ParsedBusMonitorLine } from '@/stores/dali/types';
+import { collapseErrorRows } from './collapse-error-rows';
+
+const line = (over: Record<string, any> = {}): ParsedBusMonitorLine => ({
+  time: '12:00:00',
+  hex: 'a3fe',
+  command: 'QueryActualLevel(0)',
+  direction: 'out',
+  badges: {},
+  ...over,
+  response: { kind: 'error', text: 'no response', ...(over.response ?? {}) },
+} as ParsedBusMonitorLine);
+
+describe('collapseErrorRows: identical consecutive errors fold into one ×N row', () => {
+  it('counts a run of identical errors once, keeping the latest frame', () => {
+    const rows = collapseErrorRows([
+      line({ time: '12:00:00' }),
+      line({ time: '12:00:01' }),
+      line({ time: '12:00:02' }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].repeat).toBe(3);
+    expect(rows[0].frame.time).toBe('12:00:02');
+  });
+
+  it('a differing hex, command or response text breaks the run', () => {
+    expect(collapseErrorRows([line(), line({ hex: 'a3ff' })])).toHaveLength(2);
+    expect(collapseErrorRows([line(), line({ command: 'Other' })])).toHaveLength(2);
+    expect(collapseErrorRows([line(), line({ response: { text: 'framing error' } })])).toHaveLength(2);
+  });
+
+  it('ordinary traffic never collapses, even when byte-identical', () => {
+    const ok = line({ response: { kind: 'value', text: '42' } });
+    const rows = collapseErrorRows([ok, ok]);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.repeat === 1)).toBe(true);
+  });
+});

--- a/frontend/src/pages/settings/configs/dali/components/bus-monitor/collapse-error-rows.ts
+++ b/frontend/src/pages/settings/configs/dali/components/bus-monitor/collapse-error-rows.ts
@@ -1,0 +1,31 @@
+import type { ParsedBusMonitorLine } from '@/stores/dali/types';
+import type { MonitorRow } from './types';
+
+/**
+ * Consecutive identical error rows collapse into one with a xN badge:
+ * a DALI-2 device initializing probes absent features three times per
+ * instance, and rendering every retry paints the whole viewport red for
+ * what is one fact. Only error rows collapse — ordinary traffic keeps its
+ * one-row-per-frame timeline, and foreign frames their counters. The kept
+ * frame is the LATEST of the run, so the timestamp shows the last retry.
+ */
+export function collapseErrorRows(frames: ParsedBusMonitorLine[]): MonitorRow[] {
+  const rows: MonitorRow[] = [];
+  frames.forEach((frame) => {
+    const prev = rows[rows.length - 1];
+    if (
+      prev
+      && frame.response.kind === 'error'
+      && prev.frame.response.kind === 'error'
+      && prev.frame.hex === frame.hex
+      && prev.frame.command === frame.command
+      && prev.frame.response.text === frame.response.text
+    ) {
+      prev.repeat += 1;
+      prev.frame = frame;
+      return;
+    }
+    rows.push({ frame, repeat: 1 });
+  });
+  return rows;
+}

--- a/frontend/src/pages/settings/configs/dali/components/bus-monitor/monitor-empty-state.tsx
+++ b/frontend/src/pages/settings/configs/dali/components/bus-monitor/monitor-empty-state.tsx
@@ -1,0 +1,58 @@
+import { observer } from 'mobx-react-lite';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/button';
+import { daliGlobalStore } from '@/stores/dali';
+import type { Gateway } from '@/stores/dali/types';
+import './styles.css';
+
+/**
+ * What the console panel shows when it is open but no bus is being monitored —
+ * the "Bus Monitor" header button opens the panel regardless, and an empty
+ * drawer with no explanation read as a bug. Says why it is empty and enables
+ * monitoring for a bus right here, the same action as the toggle at the
+ * bottom of that bus's tab.
+ */
+export const DaliMonitorEmptyState = observer(() => {
+  const { t } = useTranslation();
+  const [gateways, setGateways] = useState<Gateway[]>([]);
+  const [busyBusId, setBusyBusId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    daliGlobalStore.refresh().then(
+      (list) => !cancelled && setGateways(list),
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const enable = async (busId: string, gatewayName: string, busIndex: number) => {
+    setBusyBusId(busId);
+    try {
+      await daliGlobalStore.setBusMonitorEnabled(busId, true, { gatewayName, busIndex });
+    } finally {
+      setBusyBusId(null);
+    }
+  };
+
+  return (
+    <div className="daliMonitorEmpty">
+      <p className="daliMonitorEmpty-hint">{t('dali.labels.monitor-empty-hint')}</p>
+      <div className="daliMonitorEmpty-buses">
+        {gateways.map((gateway) => gateway.buses.map((bus, index) => (
+          <Button
+            key={bus.id}
+            variant="secondary"
+            label={`${gateway.name} / ${t('dali.labels.bus', { num: index + 1 })}`}
+            isLoading={busyBusId === bus.id}
+            disabled={busyBusId !== null}
+            onClick={() => enable(bus.id, gateway.name, index + 1)}
+          />
+        )))}
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/pages/settings/configs/dali/components/bus-monitor/styles.css
+++ b/frontend/src/pages/settings/configs/dali/components/bus-monitor/styles.css
@@ -180,3 +180,39 @@
 .daliMonitor-menuItem:focus {
     box-shadow: var(--input-active-shadow);
 }
+
+.daliMonitor-repeatBadge {
+    flex-shrink: 0;
+    margin-left: 6px;
+    padding: 0 6px;
+    border-radius: 8px;
+    font-size: 11px;
+    background: var(--background-accent-color);
+    color: var(--text-secondary-color);
+}
+
+/* The panel with nothing to monitor: why it is empty, and the one-click way
+   to change that, centered in the drawer's space. */
+.daliMonitorEmpty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    flex: 1;
+    min-height: 120px;
+    padding: 16px;
+    text-align: center;
+}
+
+.daliMonitorEmpty-hint {
+    margin: 0;
+    color: var(--text-secondary-color);
+}
+
+.daliMonitorEmpty-buses {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+}

--- a/frontend/src/pages/settings/configs/dali/components/bus-monitor/types.ts
+++ b/frontend/src/pages/settings/configs/dali/components/bus-monitor/types.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import type { MonitorStore } from '@/stores/dali/monitor-store';
+import type { ParsedBusMonitorLine } from '@/stores/dali/types';
 
 export interface BusMonitorTabProps {
   monitorStore: MonitorStore;
@@ -16,4 +17,10 @@ export interface RegisterBusTabParams {
 export interface ConsoleMenuProps {
   /** Menu body; `close` collapses the menu (call after acting on an item). */
   renderContent: (_close: () => void) => ReactNode;
+}
+
+/** One rendered monitor line: a frame, possibly standing for `repeat` identical errors. */
+export interface MonitorRow {
+  frame: ParsedBusMonitorLine;
+  repeat: number;
 }


### PR DESCRIPTION
## Что сделано
**Свёртка повторов в мониторе шины.** Шина с «болтливым» неотвечающим адресом забивает монитор одной и той же строкой таймаута сотни раз, и кадры, ради которых монитор открыли, тонут. Подряд идущие одинаковые строки-ошибки складываются в одну с бейджем «×N» (тултип — «повторено N раз», с русскими формами множественного числа). Подсчёт — чистая функция `collapseErrorRows` с собственным тестом; тип строки `MonitorRow` в `types.ts`.

**Пустое состояние панели.** `ConsolePanel` получает необязательный `emptyState`: открытая панель без единой вкладки выглядела как баг рендера. Страница DALI даёт для неё `MonitorEmptyState` — объясняет, что монитор выключен, и предлагает включить его по кнопке для каждой шины (используется хостом, у которого монитор по умолчанию выключен — WASM-редактором; контроллерный homeui пока пустое состояние не передаёт, поведение без изменений).

## Тесты
`collapse-error-rows.test.ts` — что сворачивается (только одинаковые ошибки подряд), что нет (разные кадры, нормальные ответы). `tsc`, `eslint`, `vitest` по каталогам монитора и панели — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)