### PR TITLE
Fix python package version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.248.1-wb101) stable; urgency=medium
+
+  * Fix python package version, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 04 Sep 2026 16:20:00 +0400
+
 wb-mqtt-homeui (2.248.1-wb100) stable; urgency=medium
 
   * Fix switch styles

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,7 @@
 
 export DH_VERBOSE=1
 export NO_COLOR=1
+export DEB_VERSION=$(shell dpkg-parsechangelog -S Version)
 
 %:
 	dh $@ --with python3 --with config-package
@@ -17,7 +18,7 @@ override_dh_auto_configure:
 	dh_auto_configure -Dfrontend -O--buildsystem=makefile
 
 override_dh_auto_build:
-	DEB_VERSION=$$(dpkg-parsechangelog -S Version) dh_auto_build -Dbackend -O--buildsystem=pybuild
+	dh_auto_build -Dbackend -O--buildsystem=pybuild
 	dh_auto_build -Dbackend -O--buildsystem=makefile
 	dh_auto_build -Dfrontend -O--buildsystem=makefile
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
follow https://github.com/wirenboard/homeui/pull/1235
```sh
# grep "^Version" /usr/lib/python3/dist-packages/wb_homeui_backend-0.0.0.egg-info/PKG-INFO
Version: 0.0.0
```

___________________________________
**Что поменялось для пользователей:**
```sh
# grep "^Version" /usr/lib/python3/dist-packages/wb_homeui_backend-2.248.1+wb101.egg-info/PKG-INFO
Version: 2.248.1+wb101
```

___________________________________
**Как проверял/а:**


