### PR TITLE
fix dropdown scroll and option height

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.251.1) stable; urgency=medium
+
+  * Fix dropdown multiline options overlap in small size
+  * Fix dropdown scroll jump on hover after opening with a selected item
+
+ -- Victor Vedenin <victor.vedenin@wirenboard.com>  Mon, 07 Sep 2026 17:25:00 +0300
+
 wb-mqtt-homeui (2.251.0) stable; urgency=medium
 
   * Search titles translations of device template groups and parameters by id

--- a/frontend/src/components/dropdown/dropdown.tsx
+++ b/frontend/src/components/dropdown/dropdown.tsx
@@ -236,6 +236,10 @@ export const Dropdown = ({
     onMenuOpen: () => {
       setIsMenuOpen(true);
       requestAnimationFrame(() => {
+        const inst = select.current as any;
+        if (inst) {
+          inst.scrollToFocusedOptionOnUpdate = false;
+        }
         const menuList = (select.current as SelectInstance)?.menuListRef;
         if (!menuList) return;
         const selected = menuList.querySelector('[aria-selected="true"]');

--- a/frontend/src/components/dropdown/styles.css
+++ b/frontend/src/components/dropdown/styles.css
@@ -54,6 +54,7 @@
 
 .dropdown__option {
   display: block;
+  line-height: 1.2em;
 }
 
 .dropdown__placeholder {
@@ -106,8 +107,12 @@
 .dropdown-s .dropdown__control,
 .dropdown-s .dropdown__option,
 .dropdown-s .dropdown__group-heading {
-  height: 28px;
+  min-height: 28px;
   padding: 3px 8px;
+}
+
+.dropdown-s .dropdown__control,
+.dropdown-s .dropdown__group-heading {
   max-height: 30px;
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
исправил у дропдауна подскролл при открытии и высоту многострочных опций

___________________________________
**Что поменялось для пользователей:**
<img width="786" height="694" alt="image" src="https://github.com/user-attachments/assets/2b24f323-0c9c-47d5-879b-9c9bfb17d53f" />


___________________________________
**Как проверял/а:**
локально
