### PR TITLE
Cap a DALI RGB colour at 254 per channel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-homeui (2.253.2) stable; urgency=medium
+
+  * Fix DALI RGB colour picker producing the reserved MASK value (255) on a
+    channel, so a pure red no longer reads as "do not change"
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 10 Sep 2026 10:15:00 +0500
+
 wb-mqtt-homeui (2.253.1) stable; urgency=medium
 
   * Fix json-editor silently dropping an enabled optional parameter when its

--- a/frontend/src/components/json-schema-editor/components/channel-slider.tsx
+++ b/frontend/src/components/json-schema-editor/components/channel-slider.tsx
@@ -2,7 +2,7 @@ import { useCallback, type ChangeEvent, type MouseEvent, type TouchEvent, type K
 import { Switch } from '@/components/switch';
 
 const CHANNEL_MIN = 0;
-const CHANNEL_MAX = 254;
+export const CHANNEL_MAX = 254;
 const MASK_VALUE = 255;
 
 export interface ChannelSliderProps {

--- a/frontend/src/components/json-schema-editor/dali-rgb-param-editor.test.tsx
+++ b/frontend/src/components/json-schema-editor/dali-rgb-param-editor.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { loadJsonSchema, ObjectStore, StoreBuilder, Translator } from '@/stores/json-schema-editor';
+import { JsonSchemaEditor } from './json-schema-editor';
+
+const buildStore = (color: string) =>
+  new ObjectStore(
+    loadJsonSchema({
+      type: 'object',
+      required: ['color'],
+      properties: {
+        color: { type: 'string', title: 'Color', format: 'dali-rgb' },
+      },
+    }),
+    { color },
+    false,
+    new StoreBuilder(),
+  );
+
+describe('dali-rgb editor', () => {
+  test('a colour picked with a 255 channel (pure red) is capped at 254, so it never turns into MASK', async () => {
+    const store = buildStore('0;0;0');
+    const { container } = render(<JsonSchemaEditor store={store} translator={new Translator()} />);
+
+    const picker = await waitFor(() => {
+      const el = container.querySelector('input[type="color"]');
+      expect(el).not.toBeNull();
+      return el as HTMLInputElement;
+    });
+    fireEvent.change(picker, { target: { value: '#ff0000' } });
+
+    expect(store.getParamByKey('color').store.value).toBe('254;0;0');
+  });
+});

--- a/frontend/src/components/json-schema-editor/dali-rgb-param-editor.test.tsx
+++ b/frontend/src/components/json-schema-editor/dali-rgb-param-editor.test.tsx
@@ -18,6 +18,13 @@ const buildStore = (color: string) =>
   );
 
 describe('dali-rgb editor', () => {
+  // The editor arrives through React.lazy, and on a loaded builder that import
+  // alone outlasts the 1s waitFor window. Warm the module cache, so the
+  // Suspense promise resolves from it.
+  beforeAll(async () => {
+    await import('./dali-rgb-param-editor');
+  });
+
   test('a colour picked with a 255 channel (pure red) is capped at 254, so it never turns into MASK', async () => {
     const store = buildStore('0;0;0');
     const { container } = render(<JsonSchemaEditor store={store} translator={new Translator()} />);
@@ -26,7 +33,7 @@ describe('dali-rgb editor', () => {
       const el = container.querySelector('input[type="color"]');
       expect(el).not.toBeNull();
       return el as HTMLInputElement;
-    });
+    }, { timeout: 4000 });
     fireEvent.change(picker, { target: { value: '#ff0000' } });
 
     expect(store.getParamByKey('color').store.value).toBe('254;0;0');

--- a/frontend/src/components/json-schema-editor/dali-rgb-param-editor.tsx
+++ b/frontend/src/components/json-schema-editor/dali-rgb-param-editor.tsx
@@ -3,7 +3,7 @@ import { useCallback, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Colorpicker } from '@/components/colorpicker';
 import { rgbToHex, hexToRgb } from '@/utils/color';
-import { ChannelSlider } from './components/channel-slider';
+import { CHANNEL_MAX, ChannelSlider } from './components/channel-slider';
 import type { DaliRGBEditorProps } from './types';
 
 const MASK_VALUE = 255;
@@ -35,8 +35,11 @@ const DaliRGBEditor = observer(({ store, inputId }: DaliRGBEditorProps) => {
     String(b === MASK_VALUE ? 0 : b),
   );
 
+  // A picked colour may hit 255 on a channel (pure red, white, ...), which DALI
+  // reserves for MASK; cap it at the highest real level.
   const onColorChange = useCallback((hex: string) => {
-    store.setValue(hexToRgb(hex));
+    const [red, green, blue] = parseRGB(hexToRgb(hex)).map((v) => Math.min(CHANNEL_MAX, v));
+    store.setValue(toRGBString(red, green, blue));
   }, [store]);
 
   const onRChange = useCallback((val: number) => {

--- a/frontend/src/components/json-schema-editor/styles.css
+++ b/frontend/src/components/json-schema-editor/styles.css
@@ -179,6 +179,8 @@
 .dali-rgb-channel-mask {
     font-size: var(--font-size-small);
     white-space: nowrap;
+    /* Body line-height is inherited as 20.3px; keep the row at the slider's 19px */
+    line-height: 1;
 }
 
 .dali-rgb-editor-values {


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В DALI значение 255 в канале зарезервировано под MASK, «этот канал не менять». Редактор параметра `dali-rgb` писал в стор значение прямо из палитры, поэтому чистый красный `#ff0000` сохранялся как `255;0;0` и устройство читало его как «красный не менять» вместо полной яркости. То же с белым и любым цветом, у которого канал выходит на 255. Слайдеры каналов уже ограничены 254, ограничения не было только у палитры.

___________________________________
**Что поменялось для пользователей:**

- Цвет, выбранный в палитре, ограничивается 254 по каждому каналу: чистый красный сохраняется как `254;0;0` и включает канал на максимум, а не превращается в MASK.
- Ввод значения слайдером и переключатель MASK работают как раньше.
- Подпись MASK рядом с каналом больше не растягивает строку: у неё был унаследованный от body `line-height` 20.3px против 19px у слайдера.

___________________________________
**Как проверял/а:**

`npm run check:types`, `npm run lint`, `npm test` чисто (197 файлов, 2521 тест), backend `pytest` 233 теста. Новый `dali-rgb-param-editor.test.tsx`: выбор `#ff0000` в палитре через публичный API стора даёт `254;0;0`.

Второй коммит убирает гонку этого теста с ленивым импортом: редактор приходит через `React.lazy`, и на загруженном билдере импорт не успевает за дефолтную секунду `waitFor`, поле цвета ещё не в DOM. Модуль прогревается в хуке, окно ожидания расширено до 4 секунд. Проверено искусственной задержкой 3 секунды в `lazy()`: без правки тест падает, с правкой проходит.

Влит текущий master, конфликт был только в `debian/changelog`, версия стала 2.253.3.
