### PR TITLE
Backport zeroed config recovery to wb-2606

### DIFF
--- a/backend/configs/usr/lib/wb-homeui-backend/generate-system-config.sh
+++ b/backend/configs/usr/lib/wb-homeui-backend/generate-system-config.sh
@@ -2,7 +2,21 @@
 
 CONFFILE="/etc/wb-webui.conf"
 
-[ -s "$CONFFILE" ] && exit 0
+config_is_blank() {
+    if [ ! -s "$1" ]; then
+        return 0
+    fi
+
+    if [ "$(tr -d '\0' < "$1" | wc -c)" -eq 0 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+if ! config_is_blank "$CONFFILE"; then
+    exit 0
+fi
 
 . /usr/lib/wb-utils/wb_env.sh
 

--- a/backend/tests/config_file_test.py
+++ b/backend/tests/config_file_test.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from wb.homeui_backend.config_file import Config
+from wb.homeui_backend.config_file import CHUNK_SIZE, Config, is_blank_file
 from wb.homeui_backend.users_storage import UsersStorage
 
 
@@ -33,3 +33,47 @@ class ConfigInitTest(unittest.TestCase):
 
         self.assertTrue(config.is_https_enabled())
         self.assertEqual(self.read_config(), {"enable_https": True})
+
+    def test_recreates_config_filled_with_nul_bytes(self):
+        """A config of the right size but full of NUL bytes is recreated as if it were missing."""
+        with open(self.config_path, "wb") as f:
+            f.write(bytes(23))
+        self.users_storage.has_users.return_value = True
+
+        config = Config(self.users_storage)
+
+        self.assertTrue(config.is_https_enabled())
+        self.assertEqual(self.read_config(), {"enable_https": True})
+
+
+class IsBlankFileTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+
+    def write(self, content: bytes) -> str:
+        path = os.path.join(self.tmp_dir, "file")
+        with open(path, "wb") as f:
+            f.write(content)
+        return path
+
+    def test_missing_file_is_blank(self):
+        self.assertTrue(is_blank_file(os.path.join(self.tmp_dir, "missing")))
+
+    def test_empty_file_is_blank(self):
+        self.assertTrue(is_blank_file(self.write(b"")))
+
+    def test_all_nul_file_is_blank(self):
+        """A right-sized file of NUL bytes (a power cut before the data was flushed) is blank."""
+        self.assertTrue(is_blank_file(self.write(bytes(24576))))
+
+    def test_content_after_nul_chunks_is_not_blank(self):
+        """Content past the first read chunk still counts, so the whole file gets scanned."""
+        self.assertFalse(is_blank_file(self.write(bytes(CHUNK_SIZE * 2) + b'{"enable_https": true}')))
+
+    def test_config_content_is_not_blank(self):
+        self.assertFalse(is_blank_file(self.write(b'{"enable_https": true}')))
+
+    def test_nul_padded_content_is_not_blank(self):
+        """A partially written file keeps whatever data it has; only the caller may drop it."""
+        self.assertFalse(is_blank_file(self.write(b'{"enable_https": true}' + bytes(4096))))

--- a/backend/tests/db_test.py
+++ b/backend/tests/db_test.py
@@ -1,0 +1,126 @@
+import os
+import shutil
+import sqlite3
+import tempfile
+import unittest
+
+from wb.homeui_backend.db import DB_SCHEMA_VERSION, check_db, open_db
+
+
+class OpenDbTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir, ignore_errors=True)
+
+    def test_recreates_non_sqlite_database_behind_symlink(self):
+        """
+        A power-cut-damaged database is removed from persistent storage and recreated.
+        """
+        data_dir = os.path.join(self.tmp_dir, "mnt", "data", "var", "lib", "wb-homeui")
+        os.makedirs(data_dir)
+        db_target = os.path.join(data_dir, "users.db")
+        damaged_content = bytes(24576)
+        with open(db_target, "wb") as f:
+            f.write(damaged_content)
+
+        db_dir = os.path.join(self.tmp_dir, "var", "lib", "wb-homeui")
+        os.makedirs(db_dir)
+        db_file = os.path.join(db_dir, "users.db")
+        os.symlink(db_target, db_file)
+
+        con = open_db(db_file)
+        self.addCleanup(con.close)
+
+        self.assertTrue(os.path.islink(db_file))
+        self.assertEqual(con.execute("PRAGMA user_version").fetchone()[0], DB_SCHEMA_VERSION)
+        self.assertEqual(
+            [
+                row[0]
+                for row in con.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            ],
+            ["sessions", "users"],
+        )
+        with open(db_target, "rb") as f:
+            self.assertNotEqual(f.read(), damaged_content)
+        self.assertFalse(os.path.exists(f"{db_target}.corrupt"))
+
+    def test_migrates_valid_old_database_in_place(self):
+        """
+        A valid old database is migrated in place and keeps its users.
+        """
+        db_file = os.path.join(self.tmp_dir, "users.db")
+        con = sqlite3.connect(db_file)
+        con.execute(
+            "CREATE TABLE users ("
+            "user_id TEXT PRIMARY KEY NOT NULL, "
+            "login TEXT UNIQUE NOT NULL, "
+            "pwd_hash TEXT NOT NULL, "
+            "type TEXT NOT NULL)"
+        )
+        con.execute("INSERT INTO users VALUES (?, ?, ?, ?)", ("id", "admin", "hash", "admin"))
+        con.commit()
+        con.close()
+
+        con = open_db(db_file)
+        self.addCleanup(con.close)
+
+        self.assertEqual(con.execute("PRAGMA user_version").fetchone()[0], DB_SCHEMA_VERSION)
+        self.assertEqual(
+            con.execute("SELECT user_id, login, pwd_hash, type, autologin FROM users").fetchall(),
+            [("id", "admin", "hash", "admin", 0)],
+        )
+
+    def test_recreates_database_when_it_has_no_tables(self):
+        """
+        A readable database without tables is removed and recreated.
+        """
+        db_file = os.path.join(self.tmp_dir, "users.db")
+        con = sqlite3.connect(db_file)
+        con.execute("CREATE TABLE leftovers (x TEXT)")
+        con.execute("INSERT INTO leftovers VALUES ('keep me')")
+        con.commit()
+        con.execute("DROP TABLE leftovers")
+        con.commit()
+        con.close()
+
+        with open(db_file, "rb") as old_db:
+            con = open_db(db_file)
+            self.addCleanup(con.close)
+
+            self.assertNotEqual(os.stat(db_file).st_ino, os.fstat(old_db.fileno()).st_ino)
+        self.assertEqual(con.execute("PRAGMA user_version").fetchone()[0], DB_SCHEMA_VERSION)
+
+    def test_recreates_locked_database(self):
+        """
+        A database that cannot be checked because it is locked is removed and recreated.
+        """
+        db_file = os.path.join(self.tmp_dir, "users.db")
+        con = open_db(db_file)
+        con.execute("INSERT INTO users VALUES ('id', 'admin', 'hash', 'admin', 0)")
+        con.commit()
+        con.close()
+
+        locker = sqlite3.connect(db_file, timeout=0.1)
+        self.addCleanup(locker.close)
+        locker.execute("BEGIN EXCLUSIVE")
+
+        con = open_db(db_file)
+        self.addCleanup(con.close)
+
+        locker.rollback()
+        self.assertEqual(con.execute("SELECT login FROM users").fetchall(), [])
+
+    def test_check_db_rejects_files_that_need_recreation(self):
+        """
+        Missing, blank and unreadable databases all need recreation.
+        """
+        nul_filled = os.path.join(self.tmp_dir, "nul.db")
+        with open(nul_filled, "wb") as f:
+            f.write(bytes(24576))
+        empty = os.path.join(self.tmp_dir, "empty.db")
+        with open(empty, "wb"):
+            pass
+
+        self.assertFalse(check_db(nul_filled))
+        self.assertFalse(check_db(empty))
+        self.assertFalse(check_db(os.path.join(self.tmp_dir, "missing.db")))

--- a/backend/wb/homeui_backend/config_file.py
+++ b/backend/wb/homeui_backend/config_file.py
@@ -3,21 +3,59 @@
 import json
 import logging
 import os
+import tempfile
+from typing import Any
 
 from .users_storage import UsersStorage
 
 CONFIG_FILE = "/etc/wb-homeui-backend.conf"
 ENABLE_HTTPS_TAG = "enable_https"
+CHUNK_SIZE = 64 * 1024
+
+
+def atomic_write_json(path: str, data: Any) -> None:
+    """Write JSON to path atomically (temp file in the same dir + os.replace).
+
+    Resolves symlinks first: WB config files can point at /mnt/data, and os.replace onto a
+    symlink would replace the link itself rather than its target.
+    """
+    real_path = os.path.realpath(path)
+    directory = os.path.dirname(real_path) or "."
+    os.makedirs(directory, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".wb-homeui-", suffix=".tmp")
+    try:
+        # 0644 (mkstemp creates 0600) so other services can still read the config.
+        os.fchmod(tmp_fd, 0o644)
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=4)
+        os.replace(tmp_path, real_path)
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def is_blank_file(path: str) -> bool:
+    try:
+        with open(path, "rb") as f:
+            while chunk := f.read(CHUNK_SIZE):
+                if chunk.strip(b"\x00"):
+                    return False
+    except FileNotFoundError:
+        return True
+    return True
 
 
 class Config:
 
     def __init__(self, users_storage: UsersStorage):
         self.enable_https = False
-        if os.path.exists(CONFIG_FILE) and os.path.getsize(CONFIG_FILE) > 0:
-            self._read_config(users_storage)
-        else:
+        if is_blank_file(CONFIG_FILE):
             self._create_config(users_storage)
+        else:
+            self._read_config(users_storage)
 
     def _create_config(self, users_storage: UsersStorage) -> None:
         logging.info("Creating config file")
@@ -25,9 +63,7 @@ class Config:
         # it is a transition from previous package versions.
         # Enable HTTPS, as it was always enabled in previous versions
         self.enable_https = users_storage.has_users()
-        config_content = {ENABLE_HTTPS_TAG: self.enable_https}
-        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-            json.dump(config_content, f)
+        atomic_write_json(CONFIG_FILE, {ENABLE_HTTPS_TAG: self.enable_https})
 
     def _read_config(self, users_storage: UsersStorage) -> None:
         try:
@@ -60,7 +96,4 @@ class Config:
 
     def set_https_enabled(self, enabled: bool) -> None:
         self.enable_https = enabled
-        config_content = {ENABLE_HTTPS_TAG: self.enable_https}
-        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-            json.dump(config_content, f, indent=4)
-            f.write("\n")
+        atomic_write_json(CONFIG_FILE, {ENABLE_HTTPS_TAG: self.enable_https})

--- a/backend/wb/homeui_backend/db.py
+++ b/backend/wb/homeui_backend/db.py
@@ -76,6 +76,10 @@ def create_db(db_file: str) -> sqlite3.Connection:
 
 def open_db(db_file: str) -> sqlite3.Connection:
     if not check_db(db_file):
+        db_real_path = os.path.realpath(db_file)
+        if os.path.exists(db_real_path):
+            logging.error("Removing broken database %s", db_real_path)
+            os.remove(db_real_path)
         return create_db(db_file)
 
     con = sqlite3.connect(db_file)
@@ -94,15 +98,20 @@ def check_db(db_file: str) -> bool:
         return False
 
     con = sqlite3.connect(db_file)
+    try:
+        cursor = con.cursor()
+        cursor.execute("PRAGMA quick_check")
+        if cursor.fetchone()[0] != "ok":
+            logging.error("Database is broken. Recreating")
+            return False
 
-    cursor = con.cursor()
-    cursor.execute("PRAGMA quick_check")
-    if cursor.fetchone()[0] != "ok":
-        logging.error("Database is broken. Recreating")
+        cursor.execute("SELECT count(name) FROM sqlite_master WHERE type='table'")
+        if cursor.fetchone()[0] < 1:
+            logging.error("Database has no tables. Recreating")
+            return False
+        return True
+    except sqlite3.DatabaseError as e:
+        logging.error("Database is not readable: %s", e)
         return False
-
-    cursor.execute("SELECT count(name) FROM sqlite_master WHERE type='table'")
-    if cursor.fetchone()[0] < 1:
-        logging.error("Database has no tables. Recreating")
-        return False
-    return True
+    finally:
+        con.close()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-homeui (2.208.1+wb100) stable; urgency=medium
+
+  * Recover from an unreadable users database on startup
+  * Regenerate wb-webui.conf and wb-homeui-backend.conf when their content is
+    all NUL bytes
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 10 Sep 2026 09:42:08 +0000
+
 wb-mqtt-homeui (2.208.1-wb102) stable; urgency=medium
 
   * Recreate configs on startup if the existing file is empty


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Бекпорт исправления из [#1236](https://github.com/wirenboard/homeui/pull/1236) в `release/wb-2606`. После аварийного отключения питания конфиги или база пользователей могут сохранить размер, но оказаться полностью заполненными NUL-байтами. При запуске их нужно распознать как повреждённые и восстановить.

___________________________________
**Что поменялось для пользователей:**

- `wb-homeui-backend.conf` и `wb-webui.conf`, целиком заполненные NUL-байтами, восстанавливаются так же, как отсутствующие или пустые файлы.
- Нечитаемая или не содержащая таблиц база пользователей пересоздаётся; симлинк на базу в постоянном хранилище сохраняется.
- JSON-конфиг записывается атомарно в фактическую цель симлинка.

Версия пакета для бекпорта: `2.208.1+wb100`.

___________________________________
**Как проверял/а:**

- Исходный коммит `6d0703c063a5cfbbd124387b5167cb7d76c2ed21` успешно собрался в master: Jenkins build 840 — SUCCESS.
- Полный набор backend-тестов: 49 passed.
- Black и isort — check passed; pylint — passed.
- `bash -n` и shellcheck для `generate-system-config.sh` — passed (`SC1091` исключён для runtime-файла `/usr/lib/wb-utils/wb_env.sh`).
- [Jenkins PR build 1](https://jenkins.wirenboard.com/job/wirenboard/job/homeui/job/PR-1250/1/) и повторный [build 2](https://jenkins.wirenboard.com/job/wirenboard/job/homeui/job/PR-1250/2/) подтвердили Bullseye (`debian bullseye`, `llvm-toolchain-bullseye-15`), но оба остановились до сборки проекта на `apt update`: в CI-образе отсутствует публичный ключ `BD4CEEDBAA549AA8` для `bullseye-security`.
- Codacy вернул `action_required` без annotations.

**Риски:**

Средние. Ветка `wb-2606` использует старый shell-генератор dashboard-конфига, поэтому соответствующую часть исправления адаптировали к этой архитектуре без переноса более нового слоя dashboards. Валидные конфиги и базы не пересоздаются; эти сценарии покрыты тестами.

---
ИИ: текст подготовил ИИ-агент.
Модель: GPT-5 · Harness: Codex CLI 0.154.0 · Настройки: permission mode disabled; навыки defaults, workflow, wb-jenkins, backport, pr-author
Запустила и отвечает за содержимое: @ekateluv
