### PR TITLE
Correct wb-2609 homeui backport version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-homeui (2.248.1+wb100) stable; urgency=medium
+wb-mqtt-homeui (2.248.1-wb103) stable; urgency=medium
 
   * Recover from an unreadable users database on startup
   * Regenerate wb-webui.conf and wb-homeui-backend.conf when their content is


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Исправляет версию уже влитого бекпорта #1251 для `release/wb-2609`: вместо ошибочной `2.248.1+wb100` пакет должен продолжать release-последовательность как `2.248.1-wb103`.

Ошибочные `wb-homeui-backend` и `wb-mqtt-homeui` версии `2.248.1+wb100` удалены из release-пула джобами [remove-deb #27](https://jenkins.wirenboard.com/job/pipelines/job/remove-deb/27/) и [remove-deb #28](https://jenkins.wirenboard.com/job/pipelines/job/remove-deb/28/).

___________________________________
**Что поменялось для пользователей:**

Функциональных изменений нет. Меняется только Debian-версия бекпорта на `2.248.1-wb103`.

___________________________________
**Как проверял/а:**

- `dpkg-parsechangelog -S Version` → `2.248.1-wb103`;
- `dpkg --compare-versions 2.248.1-wb102 lt 2.248.1-wb103`;
- `git diff --check`;
- удаление ошибочных пакетов завершилось успешно в Jenkins #27 и #28.

**Риски:**

`2.248.1-wb103` по правилам Debian ниже уже созданной `2.248.1+wb100`, поэтому корректная публикация зависит от выполненного удаления ошибочной версии из пула. Тег `v2.248.1+wb100` в git остаётся как исторический.

---
ИИ: текст подготовил ИИ-агент.
Модель: GPT-5 · Harness: Codex CLI 0.154.0 · Настройки: permission mode disabled; навыки backport, wb-jenkins, workflow, pr-author, defaults
Запустила и отвечает за содержимое: @ekateluv
