### PR TITLE
Hide the chart link in text cells when history is disabled

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-homeui (2.255.1) stable; urgency=medium
 
-  * Hide the chart link in text cells when history is disabled
+  * Hide the chart link in text and date-time cells when history is disabled
 
  -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 10 Sep 2026 21:20:00 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.255.1) stable; urgency=medium
+
+  * Hide the chart link in text cells when history is disabled
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 10 Sep 2026 21:20:00 +0300
+
 wb-mqtt-homeui (2.255.0) stable; urgency=medium
 
   * Add slider editor for numeric config parameters with range format

--- a/frontend/src/components/cell/cell-datetime.tsx
+++ b/frontend/src/components/cell/cell-datetime.tsx
@@ -30,13 +30,13 @@ const dateToLocalTime = (date: Date): number =>
     date.getSeconds(),
   ) / 1000);
 
-export const CellDateTime = observer(({ cell, isReadOnly }: CellDateTimeProps) => {
+export const CellDateTime = observer(({ cell, isReadOnly, hideHistory }: CellDateTimeProps) => {
   const { t, i18n } = useTranslation();
   const dateFormat = i18n.language === 'ru' ? 'dd.MM.yyyy HH:mm' : 'dd/MM/yyyy HH:mm';
 
   return (
     <div className="deviceCell-textWrapper">
-      <CellHistory cell={cell} />
+      {!hideHistory && <CellHistory cell={cell} />}
 
       {cell.readOnly
         ? (

--- a/frontend/src/components/cell/cell-text.tsx
+++ b/frontend/src/components/cell/cell-text.tsx
@@ -20,7 +20,7 @@ export const CellText = observer(({ cell, isCompact, isReadOnly, hideHistory }: 
         'deviceCell-isEmpty': isCompact && !cell.value,
       })}
     >
-      {!isCompact && <CellHistory cell={cell} />}
+      {!isCompact && !hideHistory && <CellHistory cell={cell} />}
 
       {cell.value && cell.readOnly && (
         <Tooltip

--- a/frontend/src/components/cell/cell.tsx
+++ b/frontend/src/components/cell/cell.tsx
@@ -40,7 +40,7 @@ export const CellContent = observer((
       case CellComponent.Colorpicker:
         return <CellColorpicker cell={cell} isReadOnly={isReadOnly} hideHistory={hideHistory} />;
       case CellComponent.DateTime:
-        return <CellDateTime cell={cell} isReadOnly={isReadOnly} />;
+        return <CellDateTime cell={cell} isReadOnly={isReadOnly} hideHistory={hideHistory} />;
       case CellComponent.Value:
         return <CellValue cell={cell} isReadOnly={isReadOnly} hideHistory={hideHistory} />;
       default:

--- a/frontend/src/components/cell/types.ts
+++ b/frontend/src/components/cell/types.ts
@@ -59,6 +59,7 @@ export interface CellRangeProps {
 export interface CellDateTimeProps {
   cell: Cell;
   isReadOnly?: boolean;
+  hideHistory?: boolean;
 }
 
 export interface CellHistoryProps{


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

`CellText` рендерит ссылку на график, игнорируя `hideHistory`. Там, где роутера нет (WASM device editor), `<Link>` роняет приложение: `useLocation() may be used only in the context of a <Router>`.

___________________________________
**Что поменялось для пользователей:**

С `hideHistory` в текстовых ячейках больше нет иконки графика. Остальные ячейки не затронуты.

___________________________________
**Как проверял/а:**

`vitest run src/components/cell` — 28 тестов прошли; `cell.test.tsx` падает на `localStorage.getItem` и без правки. Мониторинг в WASM device editor открывается вместо белого экрана.