### PR TITLE
Add DALI on/off control editor for devices and groups

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-homeui (2.256.0) stable; urgency=medium
+
+  * Add DALI on/off control settings editor for devices and groups
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 11 Sep 2026 09:44:39 +0500
+
 wb-mqtt-homeui (2.255.1) stable; urgency=medium
 
   * Hide the chart link in text and date-time cells when history is disabled

--- a/frontend/src/components/json-schema-editor/README.md
+++ b/frontend/src/components/json-schema-editor/README.md
@@ -124,6 +124,7 @@ The schema subset the editor currently renders. Verified against `store-builder.
   - `dali-white` — a tunable-white slider.
   - `dali-tc` — a colour-temperature slider. The user edits Kelvin, the value is stored as
     mirek.
+- `dali-on-off` — an object-level editor for a DALI on/off block.
 - `wb-byte-array` — an editor for a byte-array value (`ByteArrayStore`).
 - `wb-serial-int`, `wb-int-address` — an integer / address kept as a string to simplify input.
   The builder converts a numeric value to a string and uses the `oneOf[0]` subschema.

--- a/frontend/src/components/json-schema-editor/dali-on-off-param-editor.test.tsx
+++ b/frontend/src/components/json-schema-editor/dali-on-off-param-editor.test.tsx
@@ -1,0 +1,399 @@
+// @vitest-environment happy-dom
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { loadJsonSchema, ObjectStore, StoreBuilder, Translator } from '@/stores/json-schema-editor';
+import { JsonSchemaEditor } from './json-schema-editor';
+
+vi.mock('@/components/dropdown', () => import('@/test/mocks/dropdown'));
+
+// Mirrors the live `on_off_editor_schema`, where `mode` is NOT marked required.
+const ON_ACTION_SCHEMA = {
+  type: 'object',
+  title: 'OnAction',
+  properties: {
+    mode: {
+      type: 'string',
+      title: 'OnMode',
+      enum: ['scene', 'last_active_level', 'level', 'dapc'],
+      options: { enum_titles: ['OnScene', 'OnLast', 'OnLevel', 'OnDapc'] },
+      propertyOrder: 1,
+    },
+    scene: { type: 'integer', title: 'OnSceneField', minimum: 0, maximum: 15, propertyOrder: 2 },
+    percent: { type: 'integer', title: 'OnPercentField', minimum: 1, maximum: 100, propertyOrder: 3 },
+    value: { type: 'integer', title: 'OnValueField', minimum: 1, maximum: 254, propertyOrder: 4 },
+    fade_time: {
+      type: 'integer',
+      title: 'OnFadeField',
+      // -1 is the "from device settings" sentinel; first, so it is the default.
+      enum: [-1, 0, 1, 2, 3],
+      options: { enum_titles: ['OnFadeDevice', 'OnFade0', 'OnFade1', 'OnFade2', 'OnFade3'] },
+      propertyOrder: 5,
+    },
+  },
+};
+
+const OFF_ACTION_SCHEMA = {
+  type: 'object',
+  title: 'OffAction',
+  properties: {
+    mode: {
+      type: 'string',
+      title: 'OffMode',
+      enum: ['off', 'dapc'],
+      options: { enum_titles: ['OffOff', 'OffDapc'] },
+      propertyOrder: 1,
+    },
+    fade_time: {
+      type: 'integer',
+      title: 'OffFadeField',
+      // -1 is the "from device settings" sentinel; first, so it is the default.
+      enum: [-1, 0, 1, 2, 3],
+      options: { enum_titles: ['OffFadeDevice', 'OffFade0', 'OffFade1', 'OffFade2', 'OffFade3'] },
+      propertyOrder: 2,
+    },
+  },
+};
+
+const BLOCK_SCHEMA = {
+  type: 'object',
+  format: 'dali-on-off',
+  required: ['enabled'],
+  properties: {
+    enabled: { type: 'boolean', title: 'EnableOnOff', propertyOrder: 1 },
+    on_action: { ...ON_ACTION_SCHEMA, propertyOrder: 2 },
+    off_action: { ...OFF_ACTION_SCHEMA, propertyOrder: 3 },
+  },
+};
+
+const FRESH_ENABLED_VALUE = {
+  enabled: true,
+  on_action: { mode: 'scene', scene: 0 },
+  off_action: { mode: 'off' },
+};
+
+const buildStore = (config: object = { enabled: false }) =>
+  new ObjectStore(loadJsonSchema(BLOCK_SCHEMA), config, false, new StoreBuilder());
+
+const renderEditor = (store: ObjectStore) =>
+  render(<JsonSchemaEditor store={store} translator={new Translator()} />);
+
+const enableBlock = async (store: ObjectStore) => {
+  const checkbox = await screen.findByRole('checkbox');
+  fireEvent.click(checkbox);
+  await waitFor(() => expect(store.value).toEqual(FRESH_ENABLED_VALUE));
+  return checkbox;
+};
+
+const onActionStore = (store: ObjectStore) => store.getParamByKey('on_action')!.store as ObjectStore;
+
+describe('DaliOnOffEditor', () => {
+  describe('enabled checkbox gating and visibility', () => {
+    test('a disabled block hides both actions, saves as { enabled: false }, and loads clean', async () => {
+      const store = buildStore();
+      renderEditor(store);
+
+      const checkbox = await screen.findByRole('checkbox') as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+      // actions are hidden while the block is off
+      expect(screen.queryByRole('button', { name: 'OnScene' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'OffOff' })).toBeNull();
+      // unconfigured block loads clean: exactly { enabled: false }, no errors, not dirty
+      expect(store.value).toEqual({ enabled: false });
+      expect(store.hasErrors).toBe(false);
+      expect(store.isDirty).toBe(false);
+    });
+
+    test('disabling the block clears action errors so Save is never blocked', async () => {
+      const store = buildStore();
+      renderEditor(store);
+      const checkbox = await enableBlock(store);
+
+      // an out-of-range field makes the enabled block invalid
+      onActionStore(store).getParamByKey('scene')!.store.setValue(20);
+      await waitFor(() => expect(store.hasErrors).toBe(true));
+
+      // turning the block off drops the actions from validation entirely
+      fireEvent.click(checkbox);
+      await waitFor(() => expect(store.value).toEqual({ enabled: false }));
+      expect(store.hasErrors).toBe(false);
+    });
+
+    test('enabling makes the actions editable with valid populated defaults', async () => {
+      const store = buildStore();
+      renderEditor(store);
+      await enableBlock(store);
+
+      expect(store.hasErrors).toBe(false);
+      // the on action's default mode (scene) now shows its field in place
+      expect(screen.getByText('OnSceneField')).toBeTruthy();
+    });
+
+    test('checking then unchecking returns to the loaded state (not dirty, Save stays off)', async () => {
+      const store = buildStore(); // loaded as { enabled: false }, so a clean baseline
+      renderEditor(store);
+      const checkbox = await enableBlock(store);
+      expect(store.isDirty).toBe(true); // enabling is a change
+
+      fireEvent.click(checkbox); // uncheck → back to the loaded { enabled: false }
+      await waitFor(() => expect(store.value).toEqual({ enabled: false }));
+      // the seeded action content must not linger as a change
+      expect(store.isDirty).toBe(false);
+    });
+
+    test('hydrates an already-configured block from its loaded value', async () => {
+      const store = buildStore({
+        enabled: true,
+        on_action: { mode: 'level', percent: 40, fade_time: 2 },
+        off_action: { mode: 'dapc', fade_time: 1 },
+      });
+      renderEditor(store);
+
+      const checkbox = await screen.findByRole('checkbox') as HTMLInputElement;
+      await waitFor(() => expect(checkbox.checked).toBe(true));
+      expect(store.value).toEqual({
+        enabled: true,
+        on_action: { mode: 'level', percent: 40, fade_time: 2 },
+        off_action: { mode: 'dapc', fade_time: 1 },
+      });
+      expect(store.hasErrors).toBe(false);
+    });
+
+    test('unchecking then rechecking keeps a configured block\'s saved actions', async () => {
+      // Regression guard: a toggle must not replace the device's settings with defaults.
+      const loaded = {
+        enabled: true,
+        on_action: { mode: 'scene', scene: 5 },
+        off_action: { mode: 'dapc', fade_time: 1 },
+      };
+      const store = buildStore(loaded);
+      renderEditor(store);
+
+      const checkbox = await screen.findByRole('checkbox') as HTMLInputElement;
+      await waitFor(() => expect(checkbox.checked).toBe(true));
+
+      fireEvent.click(checkbox);
+      await waitFor(() => expect(store.value).toEqual({ enabled: false }));
+
+      fireEvent.click(checkbox);
+      await waitFor(() => expect(store.value).toEqual(loaded));
+      expect(store.hasErrors).toBe(false);
+      expect(store.isDirty).toBe(false);
+      // the restored values must reach the inputs too, they render from editString
+      expect(screen.getByDisplayValue('5')).toBeTruthy();
+    });
+  });
+
+  describe('mode selector (schema does not mark mode required)', () => {
+    test('renders a selectable dropdown (not a disabled placeholder); picking a mode reveals fields', async () => {
+      const store = buildStore();
+      renderEditor(store);
+      const checkbox = await screen.findByRole('checkbox');
+
+      // actions are hidden until the block is enabled
+      expect(screen.queryByRole('button', { name: 'OnScene' })).toBeNull();
+
+      fireEvent.click(checkbox);
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'scene', scene: 0 }));
+      // mode is a real dropdown (its options render) even though the schema does not mark mode required
+      expect(screen.getByRole('button', { name: 'OnScene' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'OnDapc' })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: 'OnLevel' }));
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'level', percent: 1, fade_time: -1 }));
+      expect(screen.getByText('OnPercentField')).toBeTruthy();
+    });
+  });
+
+  describe('action mode-driven field visibility and value', () => {
+    test('switching the on action to dapc shows value and drops percent from the value', async () => {
+      const store = buildStore();
+      renderEditor(store);
+      await enableBlock(store);
+
+      fireEvent.click(screen.getByRole('button', { name: 'OnDapc' }));
+
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'dapc', value: 1, fade_time: -1 }));
+      expect(screen.getByText('OnValueField')).toBeTruthy();
+      expect(screen.queryByText('OnPercentField')).toBeNull();
+    });
+
+    test('the off action dapc mode carries only fade time (no level); toggling resets it to off', async () => {
+      const store = buildStore();
+      renderEditor(store);
+      const checkbox = await enableBlock(store);
+
+      fireEvent.click(screen.getByRole('button', { name: 'OffDapc' }));
+      await waitFor(() => expect((store.value as any).off_action).toEqual({ mode: 'dapc', fade_time: -1 }));
+      expect(screen.getByText('OffFadeField')).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: 'OffFade1' }));
+      await waitFor(() => expect((store.value as any).off_action).toEqual({ mode: 'dapc', fade_time: 1 }));
+
+      fireEvent.click(checkbox);
+      await waitFor(() => expect(store.value).toEqual({ enabled: false }));
+      fireEvent.click(checkbox);
+      await waitFor(() => expect((store.value as any).off_action).toEqual({ mode: 'off' }));
+    });
+  });
+
+  describe('fade time select', () => {
+    test('lists the from-device sentinel plus the codes; both are written as the value', async () => {
+      const store = buildStore();
+      renderEditor(store);
+      await enableBlock(store);
+
+      fireEvent.click(screen.getByRole('button', { name: 'OnLast' }));
+      // last_active_level seeds fade time to the "from device settings" sentinel (-1)
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'last_active_level', fade_time: -1 }));
+
+      expect(screen.getByRole('button', { name: 'OnFadeDevice' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'OnFade2' })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: 'OnFade2' }));
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'last_active_level', fade_time: 2 }));
+
+      fireEvent.click(screen.getByRole('button', { name: 'OnFadeDevice' }));
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'last_active_level', fade_time: -1 }));
+    });
+  });
+
+  describe('schema ranges gate saving when enabled', () => {
+    // The `scene` range is covered by "disabling the block clears action errors" above.
+    test.each([
+      ['OnLevel', 'percent', 200, { mode: 'level', percent: 1, fade_time: -1 }],
+      ['OnDapc', 'value', 300, { mode: 'dapc', value: 1, fade_time: -1 }],
+      ['OnLast', 'fade_time', 99, { mode: 'last_active_level', fade_time: -1 }],
+    ])('in %s mode a %s outside the schema range blocks the block', async (mode, field, value, seeded) => {
+      const store = buildStore();
+      renderEditor(store);
+      await enableBlock(store);
+      fireEvent.click(screen.getByRole('button', { name: mode as string }));
+      await waitFor(() => expect((store.value as any).on_action).toEqual(seeded));
+
+      onActionStore(store).getParamByKey(field as string)!.store.setValue(value);
+      await waitFor(() => expect(store.hasErrors).toBe(true));
+    });
+  });
+
+  describe('mode description', () => {
+    // A description on the mode field is rendered under the selector once shown.
+    test('renders the mode schema description under the selector', async () => {
+      const schemaWithHint = {
+        ...BLOCK_SCHEMA,
+        properties: {
+          ...BLOCK_SCHEMA.properties,
+          on_action: {
+            ...ON_ACTION_SCHEMA,
+            propertyOrder: 2,
+            properties: {
+              ...ON_ACTION_SCHEMA.properties,
+              mode: { ...ON_ACTION_SCHEMA.properties.mode, description: 'OnModeHint' },
+            },
+          },
+        },
+      };
+      const store = new ObjectStore(
+        loadJsonSchema(schemaWithHint), { enabled: false }, false, new StoreBuilder(),
+      );
+      render(<JsonSchemaEditor store={store} translator={new Translator()} />);
+      const checkbox = await screen.findByRole('checkbox');
+      // hidden while the block is off, shown once enabled
+      expect(screen.queryByText('OnModeHint')).toBeNull();
+
+      fireEvent.click(checkbox);
+      await waitFor(() => expect(screen.getByText('OnModeHint')).toBeTruthy());
+    });
+  });
+
+  describe('required mode does not pre-activate fields while the block is off', () => {
+    // Here `mode` is required and defaults to `level`, so the store sets it immediately;
+    // the level field must still stay out of the value while the block is off.
+    const REQUIRED_MODE_SCHEMA = {
+      ...BLOCK_SCHEMA,
+      properties: {
+        ...BLOCK_SCHEMA.properties,
+        on_action: {
+          ...ON_ACTION_SCHEMA,
+          required: ['mode'],
+          propertyOrder: 2,
+          properties: {
+            ...ON_ACTION_SCHEMA.properties,
+            mode: { ...ON_ACTION_SCHEMA.properties.mode, default: 'level' },
+          },
+        },
+      },
+    };
+
+    test('block off keeps percent excluded; enabling seeds its default', async () => {
+      const store = new ObjectStore(
+        loadJsonSchema(REQUIRED_MODE_SCHEMA), { enabled: false }, false, new StoreBuilder(),
+      );
+      renderEditor(store);
+      await screen.findByRole('checkbox');
+
+      // block off: the level field is not pre-activated and nothing leaks into the value
+      const percent = onActionStore(store).getParamByKey('percent')!;
+      expect(percent.disabled).toBe(true);
+      expect(store.value).toEqual({ enabled: false });
+
+      // enabling activates the level field and seeds its default (minimum = 1)
+      fireEvent.click(screen.getByRole('checkbox'));
+      await waitFor(() => expect(percent.disabled).toBe(false));
+      expect((store.value as any).on_action).toEqual({ mode: 'level', percent: 1, fade_time: -1 });
+    });
+
+    test('re-enabling re-seeds the level field instead of leaving it blank', async () => {
+      const store = new ObjectStore(
+        loadJsonSchema(REQUIRED_MODE_SCHEMA), { enabled: false }, false, new StoreBuilder(),
+      );
+      renderEditor(store);
+      const checkbox = await screen.findByRole('checkbox');
+
+      fireEvent.click(checkbox);
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'level', percent: 1, fade_time: -1 }));
+
+      // off, then on again: the action's setDefault blanks percent, it must be re-seeded
+      fireEvent.click(checkbox);
+      await waitFor(() => expect(store.value).toEqual({ enabled: false }));
+      fireEvent.click(checkbox);
+      await waitFor(() => expect((store.value as any).on_action).toEqual({ mode: 'level', percent: 1, fade_time: -1 }));
+    });
+  });
+
+  describe('reveal on enable scrolls the block into view', () => {
+    const flushTwoFrames = async () => {
+      // the effect defers past two rAF ticks so the revealed actions are laid out
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null))));
+      });
+    };
+
+    test('scrolls when the user turns the block on, not when it loads already on', async () => {
+      const scrollIntoView = vi.fn();
+      const original = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = scrollIntoView;
+      try {
+        const alreadyOn = buildStore({
+          enabled: true,
+          on_action: { mode: 'scene', scene: 5 },
+          off_action: { mode: 'off' },
+        });
+        const { unmount } = renderEditor(alreadyOn);
+        await screen.findByRole('checkbox');
+        await flushTwoFrames();
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        unmount();
+
+        const store = buildStore();
+        renderEditor(store);
+        const checkbox = await screen.findByRole('checkbox');
+        fireEvent.click(checkbox);
+        await waitFor(() => expect(store.value).toEqual(FRESH_ENABLED_VALUE));
+        await flushTwoFrames();
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+      } finally {
+        Element.prototype.scrollIntoView = original;
+      }
+    });
+  });
+});

--- a/frontend/src/components/json-schema-editor/dali-on-off-param-editor.tsx
+++ b/frontend/src/components/json-schema-editor/dali-on-off-param-editor.tsx
@@ -1,0 +1,131 @@
+import { runInAction } from 'mobx';
+import { observer } from 'mobx-react-lite';
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { type ObjectParamStore, type ObjectStore } from '@/stores/json-schema-editor';
+import ObjectEditor from './object-param-editor';
+import { DaliOnOffActionMode, type DaliOnOffEditorProps } from './types';
+
+const ENABLED_KEY = 'enabled';
+const ACTION_KEYS = ['on_action', 'off_action'];
+const MODE_KEY = 'mode';
+const FADE_TIME_KEY = 'fade_time';
+
+// Fields each mode puts into the value; an action that has no such param is skipped.
+const MODE_FIELDS: Record<DaliOnOffActionMode, string[]> = {
+  [DaliOnOffActionMode.Scene]: ['scene'],
+  [DaliOnOffActionMode.LastActiveLevel]: [FADE_TIME_KEY],
+  [DaliOnOffActionMode.Level]: ['percent', FADE_TIME_KEY],
+  [DaliOnOffActionMode.Dapc]: ['value', FADE_TIME_KEY],
+  [DaliOnOffActionMode.Off]: [],
+};
+
+// A mode from a newer wb-mqtt-dali is unknown here, so none of its fields apply.
+const isActionMode = (value: unknown): value is DaliOnOffActionMode =>
+  typeof value === 'string' && Object.hasOwn(MODE_FIELDS, value);
+
+const readMode = (action: ObjectStore): DaliOnOffActionMode | undefined => {
+  const value = action.getParamByKey(MODE_KEY)?.store.value;
+  return isActionMode(value) ? value : undefined;
+};
+
+const reconcileAction = (param: ObjectParamStore) => {
+  const action = param.store as ObjectStore;
+  param.enable();
+  // Mode first: it decides which of the other fields belong to the value. The schema
+  // does not mark it required, so it is enabled here.
+  action.getParamByKey(MODE_KEY)?.enable();
+  const mode = readMode(action);
+  const applicable = new Set<string>(mode === undefined ? [] : MODE_FIELDS[mode]);
+  action.params.forEach((field) => {
+    if (field.key === MODE_KEY) {
+      return;
+    }
+    if (applicable.has(field.key)) {
+      field.enable();
+    } else {
+      field.disable();
+    }
+  });
+};
+
+// The checkbox gates the actions and each `mode` gates its fields, both through
+// enable/disable, so the value, the errors and what ObjectEditor shows follow from it.
+const reconcileOnOffBlock = (store: ObjectStore, enabled: boolean) => {
+  ACTION_KEYS.forEach((key) => {
+    const param = store.getParamByKey(key);
+    if (!param) {
+      return;
+    }
+    if (enabled) {
+      reconcileAction(param);
+      return;
+    }
+    param.disable();
+    // Drop the seeded defaults so a check then uncheck doesn't leave the form dirty.
+    (param.store as ObjectStore).reset();
+  });
+};
+
+// Thin wrapper over ObjectEditor: it only drives the rules above and scrolls the
+// block into view when it is switched on, everything is rendered by ObjectEditor.
+const DaliOnOffEditor = observer(({
+  store,
+  rootStore,
+  translator,
+  editorBuilder,
+  isTopLevel,
+}: DaliOnOffEditorProps) => {
+  const enabledParam = store.getParamByKey(ENABLED_KEY);
+  const enabled = enabledParam?.store.value === true;
+  const [onAction, offAction] = ACTION_KEYS.map(
+    (key) => store.getParamByKey(key)?.store as ObjectStore | undefined,
+  );
+  // Read the modes so the effect re-runs (and fields re-reconcile) when they change.
+  const onMode = onAction && readMode(onAction);
+  const offMode = offAction && readMode(offAction);
+
+  useLayoutEffect(() => {
+    runInAction(() => reconcileOnOffBlock(store, enabled));
+  }, [store, enabled, onMode, offMode]);
+
+  // The block sits at the bottom of a long form, so show what enabling it revealed.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const wasEnabled = useRef(enabled);
+  useEffect(() => {
+    const revealed = enabled && !wasEnabled.current;
+    wasEnabled.current = enabled;
+    if (!revealed) {
+      return undefined;
+    }
+    // The actions appear in a MobX-driven re-render after this effect, so the scroll
+    // waits for it; `start` because only the already visible header would be `nearest`.
+    let innerRaf = 0;
+    const outerRaf = requestAnimationFrame(() => {
+      innerRaf = requestAnimationFrame(() => {
+        containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    });
+    return () => {
+      cancelAnimationFrame(outerRaf);
+      cancelAnimationFrame(innerRaf);
+    };
+  }, [enabled]);
+
+  if (!enabledParam) {
+    return null;
+  }
+
+  return (
+    <div ref={containerRef}>
+      <ObjectEditor
+        store={store}
+        rootStore={rootStore}
+        translator={translator}
+        editorBuilder={editorBuilder}
+        isTopLevel={isTopLevel}
+      />
+    </div>
+  );
+});
+
+export default DaliOnOffEditor;

--- a/frontend/src/components/json-schema-editor/json-schema-editor.tsx
+++ b/frontend/src/components/json-schema-editor/json-schema-editor.tsx
@@ -26,9 +26,23 @@ const RangeSliderEditor = lazy(() => import('./range-slider-param-editor'));
 const DaliColorTemperatureSliderEditor = lazy(() => import('./dali-color-temperature-slider-param-editor'));
 const DaliRGBEditor = lazy(() => import('./dali-rgb-param-editor'));
 const DaliWhiteEditor = lazy(() => import('./dali-white-param-editor'));
+const DaliOnOffEditor = lazy(() => import('./dali-on-off-param-editor'));
 
 const DefaultEditorBuilder = (props: EditorBuilderFunctionProps) => {
   if (props.store.storeType === 'object') {
+    if (props.store.schema.format === 'dali-on-off') {
+      return (
+        <Suspense>
+          <DaliOnOffEditor
+            store={props.store as ObjectStore}
+            rootStore={props.rootStore}
+            translator={props.translator}
+            editorBuilder={DefaultEditorBuilder}
+            isTopLevel={props.isTopLevel}
+          />
+        </Suspense>
+      );
+    }
     return (
       <Suspense>
         <ObjectEditor

--- a/frontend/src/components/json-schema-editor/types.ts
+++ b/frontend/src/components/json-schema-editor/types.ts
@@ -77,6 +77,22 @@ export interface DaliWhiteEditorProps {
   inputId?: string;
 }
 
+export enum DaliOnOffActionMode {
+  Scene = 'scene',
+  LastActiveLevel = 'last_active_level',
+  Level = 'level',
+  Dapc = 'dapc',
+  Off = 'off',
+}
+
+export interface DaliOnOffEditorProps {
+  store: ObjectStore;
+  rootStore: PropertyStore;
+  translator: Translator;
+  editorBuilder: EditorBuilderFunction;
+  isTopLevel?: boolean;
+}
+
 export interface StringEditorProps {
   store: StringStore;
   inputId?: string;

--- a/frontend/src/pages/settings/configs/dali/components/device-tab-content/device-tab-content.tsx
+++ b/frontend/src/pages/settings/configs/dali/components/device-tab-content/device-tab-content.tsx
@@ -11,13 +11,7 @@ import { useAsyncAction } from '@/utils/async-action';
 import { ResetConfirm } from './reset-confirm';
 import type { ResetMode } from './types';
 
-export const DeviceTabContent = observer(({
-  store,
-  onDeviceRemoved,
-}: {
-  store: DeviceStore;
-  onDeviceRemoved: (device: DeviceStore) => void;
-}) => {
+export const DeviceTabContent = observer(({ store }: { store: DeviceStore }) => {
   const { t } = useTranslation();
   const [identify, isIdentifying] = useAsyncAction(async () => {
     await store.identify();
@@ -32,7 +26,6 @@ export const DeviceTabContent = observer(({
     } else {
       await store.reset();
       setIsResetDialogOpen(false);
-      onDeviceRemoved(store);
     }
   });
 

--- a/frontend/src/pages/settings/configs/dali/dali.tsx
+++ b/frontend/src/pages/settings/configs/dali/dali.tsx
@@ -1,6 +1,6 @@
 import { type TFunction } from 'i18next';
 import { observer } from 'mobx-react-lite';
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useMediaQuery } from 'react-responsive';
 import { Link } from 'react-router-dom';
@@ -25,13 +25,7 @@ import { GatewayTabContent } from './components/gateway-tab-content';
 import { GroupTabContent } from './components/group-tab-content';
 import './styles.css';
 
-const TabContent = ({
-  store,
-  onDeviceRemoved,
-}: {
-  store: ItemStore;
-  onDeviceRemoved: (device: DeviceStore) => void;
-}) => {
+const TabContent = ({ store }: { store: ItemStore }) => {
   if (store?.type === 'bus') {
     return <BusTabContent store={store as BusStore} />;
   }
@@ -39,12 +33,7 @@ const TabContent = ({
     return <GroupTabContent store={store as GroupStore} />;
   }
   if (store?.type === 'device') {
-    return (
-      <DeviceTabContent
-        store={store as DeviceStore}
-        onDeviceRemoved={onDeviceRemoved}
-      />
-    );
+    return <DeviceTabContent store={store as DeviceStore} />;
   }
   if (store?.type === 'gateway') {
     return <GatewayTabContent store={store} />;
@@ -79,7 +68,7 @@ const DaliPage = observer(() => {
   const store = useStore(() => new DaliPageStore(daliGlobalStore));
   const { t, i18n } = useTranslation();
   const isMobile = useMediaQuery({ maxWidth: 991 });
-  const [selectedItem, setSelectedItem] = useState<ItemStore | null>(null);
+  const selectedItem = store.selectedItem;
 
   const itemStoreMap = new Map<string, ItemStore>();
   const data = buildTreeItems(store.gateways, itemStoreMap, t);
@@ -88,11 +77,7 @@ const DaliPage = observer(() => {
     const fetchData = async () => {
       await store.load();
       if (!isMobile) {
-        const firstGateway = store.gateways.at(0);
-        if (firstGateway) {
-          setSelectedItem(firstGateway);
-          firstGateway.load();
-        }
+        store.selectItem(store.gateways.at(0) ?? null);
       }
     };
     fetchData();
@@ -100,19 +85,7 @@ const DaliPage = observer(() => {
   }, []);
 
   const onItemClick = (treeItem: TreeItem) => {
-    const item = itemStoreMap.get(treeItem.id) ?? null;
-    setSelectedItem(item);
-    item?.load();
-  };
-
-  const onDeviceRemoved = (device: DeviceStore) => {
-    const parentBus = device.parent;
-    if (parentBus) {
-      setSelectedItem(parentBus);
-      parentBus.load();
-    } else {
-      setSelectedItem(null);
-    }
+    store.selectItem(itemStoreMap.get(treeItem.id) ?? null);
   };
 
   return (
@@ -125,7 +98,7 @@ const DaliPage = observer(() => {
       actions={
         <>
           {isMobile && selectedItem && (
-            <Button label={t('dali.buttons.return')} variant="secondary" onClick={() => setSelectedItem(null)} />
+            <Button label={t('dali.buttons.return')} variant="secondary" onClick={() => store.selectItem(null)} />
           )}
         </>
       }
@@ -155,10 +128,7 @@ const DaliPage = observer(() => {
               {!selectedItem?.isLoading && selectedItem?.error && (
                 <Alert variant="danger">{selectedItem.error}</Alert>
               )}
-              <TabContent
-                store={selectedItem}
-                onDeviceRemoved={onDeviceRemoved}
-              />
+              <TabContent store={selectedItem} />
             </section>
           )}
         </div>

--- a/frontend/src/pages/settings/configs/dali/styles.css
+++ b/frontend/src/pages/settings/configs/dali/styles.css
@@ -1,7 +1,14 @@
+/* The shared wrapper is a flex item with min-height: auto, so it grows to its content
+   and the inner scroll containers never engage. Scoped to leave other pages alone. */
+.page-contentWrapper:has(.dali) {
+    min-height: 0;
+}
+
 .dali {
     display: flex;
     gap: 12px;
     height: 100%;
+    min-height: 0;
     overflow: auto;
     flex-grow: 1;
 }
@@ -13,6 +20,7 @@
 
 .dali-list {
     width: 100%;
+    min-height: 0;
     overflow-y: auto;
 
     @media (min-width: 991px) {
@@ -24,6 +32,7 @@
     border: 1px solid var(--border-color);
     padding: 12px;
     width: 100%;
+    min-height: 0;
     border-radius: var(--container-border-radius);
     background: var(--background-accent-color-hover);
     display: flex;

--- a/frontend/src/stores/dali/bus-store.test.ts
+++ b/frontend/src/stores/dali/bus-store.test.ts
@@ -14,7 +14,7 @@ describe('BusStore', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    store = new BusStore('bus1', 'Bus 1', 1, 'GW');
+    store = new BusStore({ id: 'bus1', name: 'Bus 1', devices: [] }, 1, 'GW');
   });
 
   describe('constructor', () => {
@@ -30,7 +30,7 @@ describe('BusStore', () => {
 
     test('accepts initial commissioning state', () => {
       const state = { status: 'binary_search' as const, progress: 50, error: null, device_count: 0, devices: null, finished_at: null };
-      const s = new BusStore('bus2', 'Bus 2', 2, 'GW', state);
+      const s = new BusStore({ id: 'bus2', name: 'Bus 2', devices: [], commissioning: state }, 2, 'GW');
       expect(s.commissioningState.status).toBe('binary_search');
     });
   });
@@ -298,6 +298,18 @@ describe('BusStore', () => {
       expect(groupIndexes).toEqual([1]);
     });
 
+    test('keeps a group the backend reported even when no device belongs to it', () => {
+      const bus = new BusStore(
+        { id: 'bus1', name: 'Bus 1', devices: [{ id: 'd1', name: 'D1', groups: [1] }], groups: [{ id: 'bus1_g5', number: 5 }] },
+        1,
+        'GW',
+      );
+
+      const groups = bus.children.filter((c): c is GroupStore => c.type === ItemType.Group);
+      expect(groups.map((g) => g.index)).toEqual([1, 5]);
+      expect(groups.map((g) => g.id)).toEqual(['bus1_g1', 'bus1_g5']);
+    });
+
     test('sorts devices before groups, groups by index', () => {
       store.children = [
         new DeviceStore('d1', 'D1', [2, 0], store),
@@ -308,6 +320,22 @@ describe('BusStore', () => {
       const types = store.children.map((c) => c.type);
       expect(types[0]).toBe(ItemType.Device);
       expect(types.slice(1).every((t) => t === 'group')).toBe(true);
+    });
+  });
+
+  describe('removeGroup', () => {
+    test('drops the group and keeps the reported list from bringing it back', () => {
+      const bus = new BusStore(
+        { id: 'bus1', name: 'Bus 1', devices: [], groups: [{ id: 'bus1_g5', number: 5 }] },
+        1,
+        'GW',
+      );
+      const group = bus.children.find((c): c is GroupStore => c.type === ItemType.Group);
+
+      bus.removeGroup(group!);
+      bus.syncGroupChildren();
+
+      expect(bus.children.filter((c) => c.type === ItemType.Group)).toEqual([]);
     });
   });
 

--- a/frontend/src/stores/dali/bus-store.ts
+++ b/frontend/src/stores/dali/bus-store.ts
@@ -6,7 +6,7 @@ import { BusCommandsStore } from './bus-commands-store';
 import { DeviceStore } from './device-store';
 import { GroupStore } from './group-store';
 import { relativizeTcLimitPaths } from './tc-limit-paths';
-import type { CommissioningState } from './types';
+import type { Bus, CommissioningState, Device } from './types';
 
 const IDLE_COMMISSIONING_STATE: CommissioningState = {
   status: 'idle',
@@ -34,21 +34,18 @@ export class BusStore extends BaseItemStore {
   public scanStopRequested: boolean = false;
 
   private isFirstLoad: boolean = true;
+  /** Groups GetList reported. Empty on an older backend, then only device membership counts. */
+  #reportedGroupIds: Map<number, string>;
   #commissioningTopic: string;
   #commissioningHandler: ((msg: { topic: string; payload: string }) => void) | null = null;
 
-  constructor(
-    id: string,
-    name: string,
-    index: number,
-    gatewayName: string,
-    commissioning?: CommissioningState,
-  ) {
-    super(id, name);
+  constructor(bus: Bus, index: number, gatewayName: string) {
+    super(bus.id, bus.name);
     this.index = index;
     this.gatewayName = gatewayName;
-    this.commands = new BusCommandsStore(id);
-    this.#commissioningTopic = `/wb-dali/${id}/commissioning`;
+    this.commands = new BusCommandsStore(bus.id);
+    this.#commissioningTopic = `/wb-dali/${bus.id}/commissioning`;
+    this.#reportedGroupIds = new Map((bus.groups ?? []).map((group) => [group.number, group.id]));
     makeObservable(this, {
       load: action,
       scan: action,
@@ -57,6 +54,7 @@ export class BusStore extends BaseItemStore {
       setBusMonitorSyslogEnabled: action,
       applyCommissioningState: action,
       syncGroupChildren: action,
+      removeGroup: action,
       setError: action,
       isLoading: observable,
       isParametersSchemaLoading: observable,
@@ -72,7 +70,8 @@ export class BusStore extends BaseItemStore {
       broadcastSettingsVisible: observable,
     });
 
-    this.commissioningState = commissioning ?? IDLE_COMMISSIONING_STATE;
+    this.commissioningState = bus.commissioning ?? IDLE_COMMISSIONING_STATE;
+    this.setDevices(bus.devices);
     this.subscribeToCommissioning();
   }
 
@@ -197,12 +196,18 @@ export class BusStore extends BaseItemStore {
     this.unsubscribeFromCommissioning();
   }
 
+  removeGroup(group: GroupStore) {
+    this.#reportedGroupIds.delete(group.index);
+    this.children = this.children.filter((child) => child !== group);
+  }
+
   syncGroupChildren() {
-    const activeGroupNums = new Set<number>(
-      this.children
+    const activeGroupNums = new Set<number>([
+      ...this.#reportedGroupIds.keys(),
+      ...this.children
         .filter((c): c is DeviceStore => c.type === ItemType.Device)
         .flatMap((d) => d.groups),
-    );
+    ]);
     this.children = this.children.filter((c) => {
       if (c.type !== ItemType.Group) {
         return true;
@@ -217,7 +222,7 @@ export class BusStore extends BaseItemStore {
     const groupIndexesToAdd: number[] = Array.from(activeGroupNums.keys())
       .filter((index) => !existingGroupIndexes.has(index));
     groupIndexesToAdd.forEach((index) => {
-      this.children.push(new GroupStore(this.makeGroupId(index), index, this));
+      this.children.push(new GroupStore(this.#reportedGroupIds.get(index) ?? this.makeGroupId(index), index, this));
     });
     this.children.sort((a, b) => {
       if (a.type !== ItemType.Group || b.type !== ItemType.Group) {
@@ -237,14 +242,18 @@ export class BusStore extends BaseItemStore {
     this.scanStartRequested = false;
     this.scanStopRequested = false;
     if ('completed' === newState.status && wasScanning) {
-      this.children = newState.devices.map((device: { id: string; name: string; groups: number[] }) =>
-        new DeviceStore(device.id, device.name, device.groups, this),
-      );
-      this.syncGroupChildren();
+      this.setDevices(newState.devices);
       this.setError(null);
       this.objectStore = null;
       await this.load();
     }
+  }
+
+  private setDevices(devices: Device[]) {
+    this.children = devices.map(
+      (device) => new DeviceStore(device.id, device.name, device.groups ?? [], this),
+    );
+    this.syncGroupChildren();
   }
 
   private subscribeToCommissioning() {

--- a/frontend/src/stores/dali/dali-page-store.test.ts
+++ b/frontend/src/stores/dali/dali-page-store.test.ts
@@ -1,0 +1,90 @@
+import { observable, runInAction } from 'mobx';
+import { DaliPageStore } from './dali-page-store';
+
+vi.mock('@/services', () => import('@/test/mocks/services'));
+vi.mock('@/stores/json-schema-editor', () => import('@/test/mocks/json-schema-editor'));
+vi.mock('@/utils/format-error', () => import('@/test/mocks/format-error'));
+
+// The selection only needs the tree shape. `deep: false` mirrors BusStore's
+// observable.shallow, so the children keep their identity instead of becoming proxies.
+const buildBus = () => ({
+  type: 'bus',
+  id: 'bus1',
+  load: vi.fn(),
+  children: observable.array<any>([], { deep: false }),
+});
+
+const buildChild = (bus: any, type: 'device' | 'group') => {
+  const child = { type, id: `${type}1`, load: vi.fn(), parent: bus };
+  runInAction(() => bus.children.push(child));
+  return child;
+};
+
+describe('DaliPageStore', () => {
+  let store: DaliPageStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new DaliPageStore({ refresh: vi.fn() } as any);
+  });
+
+  afterEach(() => store.destroy());
+
+  describe('selectItem', () => {
+    test('remembers the item and loads it', () => {
+      const bus = buildBus();
+
+      store.selectItem(bus as any);
+
+      expect(store.selectedItem).toBe(bus);
+      expect(bus.load).toHaveBeenCalled();
+    });
+
+    test('clears the selection without loading anything', () => {
+      store.selectItem(buildBus() as any);
+
+      store.selectItem(null);
+
+      expect(store.selectedItem).toBeNull();
+    });
+  });
+
+  describe('selection of an item that leaves the tree', () => {
+    test.each(['device', 'group'] as const)(
+      'falls back to the bus when the selected %s is removed from it',
+      (type) => {
+        const bus = buildBus();
+        const child = buildChild(bus, type);
+        store.selectItem(child as any);
+
+        runInAction(() => bus.children.remove(child));
+
+        expect(store.selectedItem).toBe(bus);
+        expect(bus.load).toHaveBeenCalled();
+      },
+    );
+
+    test('keeps the selection while the item is still in the tree', () => {
+      const bus = buildBus();
+      const device = buildChild(bus, 'device');
+      const other = buildChild(bus, 'group');
+      store.selectItem(device as any);
+
+      runInAction(() => bus.children.remove(other));
+
+      expect(store.selectedItem).toBe(device);
+      expect(bus.load).not.toHaveBeenCalled();
+    });
+
+    test('stops watching the selection once the page store is destroyed', () => {
+      const bus = buildBus();
+      const device = buildChild(bus, 'device');
+      store.selectItem(device as any);
+
+      store.destroy();
+      runInAction(() => bus.children.remove(device));
+
+      expect(store.selectedItem).toBe(device);
+    });
+  });
+});

--- a/frontend/src/stores/dali/dali-page-store.ts
+++ b/frontend/src/stores/dali/dali-page-store.ts
@@ -1,17 +1,29 @@
-import { runInAction, makeObservable, observable } from 'mobx';
+import { runInAction, makeObservable, observable, action, reaction, type IReactionDisposer } from 'mobx';
 import { type ErrorInfo } from '@/layouts/page';
 import { formatError } from '@/utils/format-error';
 import { BusStore } from './bus-store';
 import type { DaliGlobalStore } from './dali-global-store';
-import { DeviceStore } from './device-store';
 import { GatewayStore } from './gateway-store';
+import type { ItemStore } from './types';
+
+// The bus of a selected device or group it no longer holds: a factory reset, a group
+// switched off or a rescan can leave the selection on a node that is out of the tree.
+const detachedParentBus = (item: ItemStore | null): BusStore | null => {
+  if (!item || !('parent' in item)) {
+    return null;
+  }
+  const parent = item.parent;
+  return parent && !parent.children.includes(item) ? parent : null;
+};
 
 export class DaliPageStore {
   public gateways: GatewayStore[] = [];
+  public selectedItem: ItemStore | null = null;
   public isLoading = true;
   public errors: ErrorInfo[];
 
   private daliGlobalStore: DaliGlobalStore;
+  private selectionDisposer: IReactionDisposer;
 
   constructor(daliGlobalStore: DaliGlobalStore) {
     this.daliGlobalStore = daliGlobalStore;
@@ -19,7 +31,22 @@ export class DaliPageStore {
       isLoading: observable,
       errors: observable,
       gateways: observable.shallow,
+      selectedItem: observable.ref,
+      selectItem: action,
     });
+    this.selectionDisposer = reaction(
+      () => detachedParentBus(this.selectedItem),
+      (parentBus) => {
+        if (parentBus) {
+          this.selectItem(parentBus);
+        }
+      },
+    );
+  }
+
+  selectItem(item: ItemStore | null) {
+    this.selectedItem = item;
+    item?.load();
   }
 
   async load() {
@@ -28,20 +55,9 @@ export class DaliPageStore {
       runInAction(() => {
         this.gateways = gateways.map((gateway) => {
           const gatewayStore = new GatewayStore(gateway.id, gateway.name);
-          gatewayStore.children = gateway.buses.map((bus, idx) => {
-            const busStore = new BusStore(
-              bus.id,
-              bus.name,
-              idx + 1,
-              gateway.name,
-              bus.commissioning,
-            );
-            busStore.children = bus.devices.map(
-              (device) => new DeviceStore(device.id, device.name, device.groups ?? [], busStore),
-            );
-            busStore.syncGroupChildren();
-            return busStore;
-          });
+          gatewayStore.children = gateway.buses.map(
+            (bus, idx) => new BusStore(bus, idx + 1, gateway.name),
+          );
           return gatewayStore;
         });
       });
@@ -55,6 +71,7 @@ export class DaliPageStore {
   }
 
   destroy() {
+    this.selectionDisposer();
     this.gateways.forEach((gateway) => {
       gateway.children.forEach((bus) => {
         bus.destroy();

--- a/frontend/src/stores/dali/device-store.test.ts
+++ b/frontend/src/stores/dali/device-store.test.ts
@@ -106,6 +106,33 @@ describe('DeviceStore', () => {
       expect(store.isLoading).toBe(false);
     });
 
+    test('save sends the block as part of the config and feeds the reply back', async () => {
+      // ObjectStore is mocked here, so this covers the wiring, not the block's value.
+      daliProxyMock.GetDevice.mockResolvedValue({
+        config: { on_off: { enabled: false }, groups: [] },
+        schema: {},
+        name: 'Lamp',
+      });
+      await store.load();
+
+      const response = {
+        name: 'Lamp 2',
+        groups: [true],
+        config: { on_off: { enabled: true, on_action: { mode: 'scene', scene: 3 } } },
+      };
+      daliProxyMock.SetDevice.mockResolvedValue(response);
+
+      await store.save();
+
+      const sent = daliProxyMock.SetDevice.mock.calls[0][0];
+      expect(sent.deviceId).toBe('dev1');
+      expect(sent.config).toBe(store.objectStore!.value);
+      expect(store.objectStore!.setValue).toHaveBeenCalledWith(response);
+      expect(store.objectStore!.commit).toHaveBeenCalled();
+      expect(store.label).toBe('Lamp 2');
+      expect(store.groups).toEqual([0]);
+    });
+
     test('does nothing without objectStore', async () => {
       await store.save();
       expect(daliProxyMock.SetDevice).not.toHaveBeenCalled();

--- a/frontend/src/stores/dali/group-store.test.ts
+++ b/frontend/src/stores/dali/group-store.test.ts
@@ -1,3 +1,4 @@
+import { loadJsonSchema } from '@/stores/json-schema-editor';
 import { daliProxyMock } from '@/test/mocks/services';
 import { GroupStore } from './group-store';
 
@@ -7,10 +8,11 @@ vi.mock('@/utils/format-error', () => import('@/test/mocks/format-error'));
 
 describe('GroupStore', () => {
   let store: GroupStore;
-  const parentMock = { dropDeviceCaches: vi.fn() } as any;
+  let parentMock: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    parentMock = { dropDeviceCaches: vi.fn(), removeGroup: vi.fn() };
     store = new GroupStore('bus1_g5', 5, parentMock);
   });
 
@@ -34,6 +36,15 @@ describe('GroupStore', () => {
       expect(store.error).toBeNull();
     });
 
+    test('seeds the objectStore from the {config, schema} response', async () => {
+      const config = { on_off: { enabled: false } };
+      daliProxyMock.GetGroup.mockResolvedValue({ config, schema: { title: 'Group' } });
+
+      await store.load();
+
+      expect(store.objectStore!.value).toEqual(config);
+    });
+
     test('skips if already loaded', async () => {
       daliProxyMock.GetGroup.mockResolvedValue({ config: {}, schema: {} });
       await store.load();
@@ -50,6 +61,45 @@ describe('GroupStore', () => {
       await store.load();
 
       expect(store.error).toBe('fail');
+      expect(store.isLoading).toBe(false);
+    });
+
+    test('accepts the older bare-schema reply and seeds the schema defaults', async () => {
+      // wb-mqtt-dali updates independently, so a controller can still answer with
+      // the schema itself rather than {config, schema}.
+      const bareSchema = { type: 'object', title: 'Group', properties: { brightness: {} } };
+      daliProxyMock.GetGroup.mockResolvedValue(bareSchema);
+
+      await store.load();
+
+      expect(loadJsonSchema).toHaveBeenCalledWith(bareSchema);
+      expect(store.objectStore).not.toBeNull();
+      expect(store.objectStore!.setDefault).toHaveBeenCalled();
+      expect(store.error).toBeNull();
+    });
+
+    test('still builds the editor when the reply carries a schema but no config', async () => {
+      // An unconfigured group can come back without a config; the tab must still
+      // render its params instead of going blank. setDefault() is deliberately no
+      // longer called here, so absent params stay absent rather than being seeded.
+      daliProxyMock.GetGroup.mockResolvedValue({ schema: { title: 'Group' } });
+
+      await store.load();
+
+      expect(store.objectStore).not.toBeNull();
+      expect(store.objectStore!.setDefault).not.toHaveBeenCalled();
+      expect(store.error).toBeNull();
+      expect(store.isLoading).toBe(false);
+    });
+
+    test('does not create an objectStore when the response has no usable schema', async () => {
+      daliProxyMock.GetGroup.mockResolvedValue({ config: {}, schema: undefined });
+      vi.mocked(loadJsonSchema).mockReturnValueOnce(undefined);
+
+      await store.load();
+
+      expect(store.objectStore).toBeNull();
+      expect(store.error).toBeNull();
       expect(store.isLoading).toBe(false);
     });
   });
@@ -96,6 +146,52 @@ describe('GroupStore', () => {
       await store.saveParam('key');
 
       expect(store.error).toBe('fail');
+    });
+
+    test('drops the group from the bus when switching on_off off takes it away', async () => {
+      daliProxyMock.GetGroup.mockResolvedValue({ config: {}, schema: { title: 'Group' } });
+      await store.load();
+      const paramMock = { store: { value: { enabled: false }, commit: vi.fn() } };
+      (vi.mocked(store.objectStore!.getParamByKey).mockReturnValue as any)(paramMock);
+      daliProxyMock.SetGroup.mockResolvedValue({ config: {}, schema: {} });
+
+      await store.saveParam('on_off');
+
+      expect(parentMock.removeGroup).toHaveBeenCalledWith(store);
+      expect(parentMock.dropDeviceCaches).not.toHaveBeenCalled();
+      expect(paramMock.store.commit).not.toHaveBeenCalled();
+      expect(store.error).toBeNull();
+    });
+
+    test('keeps the group when the reply still carries its config and schema', async () => {
+      daliProxyMock.GetGroup.mockResolvedValue({ config: {}, schema: { title: 'Group' } });
+      await store.load();
+      (vi.mocked(store.objectStore!.getParamByKey).mockReturnValue as any)({
+        store: { value: { enabled: false }, commit: vi.fn() },
+      });
+      daliProxyMock.SetGroup.mockResolvedValue({
+        config: { on_off: { enabled: false } },
+        schema: { properties: { on_off: {} } },
+      });
+
+      await store.saveParam('on_off');
+
+      expect(parentMock.removeGroup).not.toHaveBeenCalled();
+      expect(parentMock.dropDeviceCaches).toHaveBeenCalledWith(5);
+    });
+
+    test('keeps the group when an older backend answers the write with nothing', async () => {
+      daliProxyMock.GetGroup.mockResolvedValue({ config: {}, schema: { title: 'Group' } });
+      await store.load();
+      (vi.mocked(store.objectStore!.getParamByKey).mockReturnValue as any)({
+        store: { value: 1, commit: vi.fn() },
+      });
+      daliProxyMock.SetGroup.mockResolvedValue({});
+
+      await store.saveParam('brightness');
+
+      expect(parentMock.removeGroup).not.toHaveBeenCalled();
+      expect(parentMock.dropDeviceCaches).toHaveBeenCalledWith(5);
     });
   });
 });

--- a/frontend/src/stores/dali/group-store.ts
+++ b/frontend/src/stores/dali/group-store.ts
@@ -4,6 +4,22 @@ import { ObjectStore, StoreBuilder, Translator, loadJsonSchema } from '@/stores/
 import { BaseItemStore } from './base-item-store';
 import type { BusStore } from './bus-store';
 import { relativizeTcLimitPaths } from './tc-limit-paths';
+import type { GroupDetailed, GroupReply } from './types';
+
+const isEmptyObject = (value: unknown) => (
+  typeof value === 'object' && value !== null && !Object.keys(value).length
+);
+
+/** SetGroup answers with an empty config and schema when the write took the group away. */
+const isGroupGone = (data: GroupDetailed) => (
+  isEmptyObject(data?.config) && isEmptyObject(data?.schema)
+);
+
+/** Both GetGroup shapes are in the field: the older bare schema, the newer {config, schema}. */
+const isWrapped = (reply: GroupReply): reply is GroupDetailed => {
+  const schema = (reply as GroupDetailed)?.schema;
+  return typeof schema === 'object' && schema !== null;
+};
 
 export class GroupStore extends BaseItemStore {
   readonly type = 'group' as const;
@@ -23,19 +39,29 @@ export class GroupStore extends BaseItemStore {
     });
   }
 
+  get parent(): BusStore | null {
+    return this.#parent;
+  }
+
   async load() {
     if (this.objectStore) {
       return;
     }
     this.isLoading = true;
     try {
-      const data = await daliProxy.GetGroup({ groupId: this.id });
+      const reply = await daliProxy.GetGroup({ groupId: this.id });
       this.translator = new Translator();
-      const schema = loadJsonSchema(data);
-      relativizeTcLimitPaths(schema);
-      this.translator.addTranslations(schema.translations);
-      this.objectStore = new ObjectStore(schema, {}, false, new StoreBuilder());
-      this.objectStore.setDefault();
+      const wrapped = isWrapped(reply);
+      const schema = loadJsonSchema(wrapped ? reply.schema : reply);
+      if (schema) {
+        relativizeTcLimitPaths(schema);
+        this.translator.addTranslations(schema.translations);
+        this.objectStore = new ObjectStore(schema, wrapped ? reply.config : {}, false, new StoreBuilder());
+        if (!wrapped) {
+          // the bare-schema reply carries no config, so seed the schema defaults
+          this.objectStore.setDefault();
+        }
+      }
       this.setError(null);
     } catch (error) {
       this.setError(error);
@@ -55,7 +81,15 @@ export class GroupStore extends BaseItemStore {
       return;
     }
     try {
-      await daliProxy.SetGroup({ groupId: this.id, config: { [key]: param.store.value } });
+      const data = await daliProxy.SetGroup({ groupId: this.id, config: { [key]: param.store.value } });
+      if (isGroupGone(data)) {
+        // Dropping it from the bus also moves the page's selection off it (see DaliPageStore).
+        runInAction(() => {
+          this.setError(null);
+          this.#parent?.removeGroup(this);
+        });
+        return;
+      }
       runInAction(() => {
         param.store.commit();
         this.setError(null);

--- a/frontend/src/stores/dali/index.ts
+++ b/frontend/src/stores/dali/index.ts
@@ -8,7 +8,7 @@ export { BusCommandsStore } from './bus-commands-store';
 export { DaliPageStore } from './dali-page-store';
 export { MonitorStore } from './monitor-store';
 
-export type ItemStore = GatewayStore | BusStore | DeviceStore | GroupStore;
+export type { ItemStore } from './types';
 
 export const daliGlobalStore = new DaliGlobalStore();
 

--- a/frontend/src/stores/dali/types.ts
+++ b/frontend/src/stores/dali/types.ts
@@ -1,7 +1,14 @@
 import {
   type JsonSchema,
 } from '@/stores/json-schema-editor';
+import type { BusStore } from './bus-store';
+import type { DeviceStore } from './device-store';
+import type { GatewayStore } from './gateway-store';
+import type { GroupStore } from './group-store';
 import type { MonitorStore } from './monitor-store';
+
+/** A node of the DALI tree: what the page can select and show a tab for. */
+export type ItemStore = GatewayStore | BusStore | DeviceStore | GroupStore;
 
 export type CommissioningStatus =
   | 'idle'
@@ -40,14 +47,14 @@ export interface Bus {
   id: string;
   name: string;
   devices: Device[];
-  groups: Group[];
+  groups?: Group[];
   commissioning?: CommissioningState;
   bus_monitor_enabled?: boolean;
 }
 
 export interface Group {
   id: string;
-  index: number;
+  number: number;
 }
 
 export interface Device {
@@ -132,10 +139,14 @@ export interface StopScanBusResponse {
   status: 'stopped' | 'not_running';
 }
 
+/** Both keys are optional: an empty pair means the write removed the group. */
 export interface GroupDetailed {
-  config: object;
-  schema: JsonSchema;
+  config?: object;
+  schema?: JsonSchema;
 }
+
+/** `GetGroup` on an older backend answers with the bare schema instead of the pair. */
+export type GroupReply = GroupDetailed | JsonSchema;
 
 export interface DaliProxy {
   GetGateway(params: GetGatewayParams): Promise<GatewayDetailed>;
@@ -144,7 +155,7 @@ export interface DaliProxy {
   SetBus(params: SetBusParams): Promise<void>;
   GetDevice(params: GetDeviceParams): Promise<DeviceDetailed>;
   SetDevice(params: SetDeviceParams): Promise<DeviceDetailed>;
-  GetGroup(params: GetGroupParams): Promise<GroupDetailed>;
+  GetGroup(params: GetGroupParams): Promise<GroupReply>;
   SetGroup(params: SetGroupParams): Promise<GroupDetailed>;
   GetList(): Promise<Gateway[]>;
   ScanBus(params: ScanBusParams): Promise<ScanBusResponse>;

--- a/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.ts
+++ b/frontend/src/stores/device-manager/device-tab/device-settings-editor/device-settings-store.ts
@@ -272,8 +272,11 @@ export class DeviceSettingsObjectStore {
   }
 
   setSlaveId(id: string | undefined) {
-    const store = this.commonParams.getParamByKey('slave_id').store as StringStore;
-    store?.setValue(id);
+    const param = this.commonParams.getParamByKey('slave_id');
+    if (id !== undefined) {
+      param?.enable();
+    }
+    (param?.store as StringStore)?.setValue(id);
   }
 
   // When switching to another template the params store is rebuilt from scratch, so the

--- a/frontend/src/stores/json-schema-editor/number-store.ts
+++ b/frontend/src/stores/json-schema-editor/number-store.ts
@@ -216,6 +216,8 @@ export class NumberStore implements PropertyStore {
 
   reset(): void {
     this.value = this._initialValue;
+    // The editors render from editString, so it has to follow the restored value.
+    this.editString = typeof this.value === 'number' ? formatEditString(this.schema, this.value) : '';
     this.isDirty = false;
     this._checkConstraints();
     if (this._doNotShowInvalidValue && this.hasErrors) {

--- a/frontend/src/stores/json-schema-editor/object-store.ts
+++ b/frontend/src/stores/json-schema-editor/object-store.ts
@@ -43,9 +43,12 @@ export class ObjectParamStore {
 
   enable() {
     if (this.disabled) {
-      this.store.setDefault();
+      this.store.reset();
       this.disabled = false;
       this.store.setForbidUndefined(true);
+    }
+    if (this.store.value === undefined) {
+      this.store.setDefault();
     }
   }
 
@@ -78,6 +81,7 @@ export class ObjectStore implements PropertyStore {
   readonly defaultText = '';
 
   private _paramByKey: Record<string, ObjectParamStore> = {};
+  private _initialIsUndefined: boolean = false;
 
   constructor(schema: JsonSchema, initialValue: unknown, required: boolean, builder: StoreBuilder) {
     this.schema = schema;
@@ -105,6 +109,7 @@ export class ObjectStore implements PropertyStore {
         this.isUndefined = true;
       }
     }
+    this._initialIsUndefined = this.isUndefined;
 
     makeObservable(this, {
       isUndefined: observable,
@@ -136,7 +141,8 @@ export class ObjectStore implements PropertyStore {
       return undefined;
     }
     return this.params.reduce((acc, param) => {
-      if (param.store.value === undefined || param.store.value instanceof MistypedValue) {
+      // reset() restores a nested object whether or not its param is disabled.
+      if (param.disabled || param.store.value === undefined || param.store.value instanceof MistypedValue) {
         return acc;
       }
       if (!param.store.required &&
@@ -190,12 +196,14 @@ export class ObjectStore implements PropertyStore {
     this.params.forEach((param) => {
       param.store.commit();
     });
+    this._initialIsUndefined = this.isUndefined;
   }
 
   reset() {
     this.params.forEach((param) => {
       param.store.reset();
     });
+    this.isUndefined = this._initialIsUndefined;
   }
 
   setForbidUndefined() {}


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В конфиге DALI-устройства и группы появился блок `on_off`: два действия (`on_action`, `off_action`), у каждого свой режим, и набор полей зависит от режима. Схема этого не выражает (ни `oneOf`, ни `if-then`), поэтому нужен свой редактор блока.

___________________________________
**Что поменялось для пользователей:**

- В форме устройства и группы появился блок on/off с чекбоксом включения. Пока чекбокс снят, действия скрыты, блок сохраняется как `{enabled: false}` и не блокирует «Сохранить» своими ошибками.
- В каждом действии показываются только поля выбранного режима, остальные не попадают в конфиг.
- Снятие и повторная установка чекбокса возвращает настройки, загруженные с устройства, а не дефолты схемы. Это же теперь верно для любого опционального параметра с галкой, в том числе в настройках устройств Modbus.
- Группа, от которой остался только блок on/off, не пропадает из дерева. Когда запись убирает группу, она исчезает и открывается вкладка шины.
- При включении блок подскроллен в видимую область: он находится в конце длинной формы.

___________________________________
**Как проверял/а:**

`npm run check:types`, `npm run lint`, `npm test` чисто, 200 файлов и 2556 тестов.

Новый `dali-on-off-param-editor.test.tsx`, 17 тестов через `JsonSchemaEditor` с реальными сторами: гейтинг чекбоксом, видимость полей по режиму, круговой обход выключить-включить, диапазоны из схемы, `fade_time` со значением «из настроек устройства», подскролл. Логика включения и сброса параметров покрыта тестами `object-store` и `device-tab-store`, дерево и выбор узла - `dali-page-store.test.ts`, обе формы ответа `GetGroup` - `group-store.test.ts`.
